### PR TITLE
Improve README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,27 @@
-# BluEye MVP📱🌀
+# BluEye
 
-**BluEye** is a cross-platform mobile app for hurricane prevention and response.  
-It leverages real-time geolocation, official weather APIs, and on-device LLaMA-powered AI to deliver personalized alerts, safe-route guidance, and shelter information before, during, and after a storm.
+BluEye es una aplicación móvil multiplataforma enfocada en la prevención y respuesta ante huracanes. Utiliza geolocalización en tiempo real, datos de OpenWeather y un asistente de IA disponible en [ai-blueye](https://github.com/DiegoCM1/ai-blueye) para ofrecer alertas personalizadas y recomendaciones seguras.
 
----
+## Características principales
+- **Alertas en tiempo real** con información meteorológica oficial.
+- **Guía asistida por IA** para preguntas de emergencia.
+- **Mapeo de rutas seguras y refugios públicos**.
+- **Funcionamiento sin conexión** usando los últimos datos guardados.
 
-## 🚀 Features
+## Estructura del repositorio
+- **frontend/** - Aplicación React Native con Expo. Contiene pantallas, componentes y la conexión con la IA.
+- **backend/** - Servidor Express que calcula el riesgo meteorológico y almacena retroalimentación.
+- **README.md** - Este documento.
 
-- **Real-time Alerts**  
-  - Watches official weather feeds for hurricane watches/warnings  
-  - Pushes urgent notifications based on user location  
+## Cómo empezar
+1. Clona este repositorio y el proyecto [ai-blueye](https://github.com/DiegoCM1/ai-blueye).
+2. Instala dependencias en cada carpeta con `npm install`.
+3. En `frontend/` ejecuta `npx expo start` para arrancar la app.
+4. En `backend/` ejecuta `npm start` para iniciar la API.
 
-- **AI-Driven Guidance**  
-  - Uses a fine-tuned LLaMA model to answer “what to do” questions  
-  - Crafts personalized checklists and safety tips  
+## Contribución
+1. Haz un *fork* del repositorio y crea una rama para tus cambios.
+2. Envía un *pull request* describiendo la mejora o corrección.
+3. Si encuentras problemas, abre un *issue* para poder revisarlo.
 
-- **Safe-Route & Shelter Finder**  
-  - Maps nearest public shelters and evacuation routes  
-  - Updates dynamically as conditions evolve  
-
-- **Offline Fallback**  
-  - Caches last known weather data and safety advice  
-  - Continues to serve critical guidance when connectivity is lost  
-
----
-
-## 🧱 Tech Stack
-
-| Layer                   | Technology                                         |
-|-------------------------|----------------------------------------------------|
-| **Mobile App**          | React Native, JavaScript, Expo                     |
-| **Styling**             | React Native Stylesheets, NativeWindCSS   |
-| **AI Inference**        | Open Router LLaMA model  |
-| **Weather & Geo APIs**  | OpenWeatherMap, Google Maps Geocoding              |
-| **Backend Scripts**     | Python 3.9+, `httpx`, `python-dotenv`              |
-| **Data Processing**     | Custom Python modules: `apiOpenWeather.py`, etc.   |
-
----
-
-## 📂 Repository Structure
-
-```
-/
-├── react-native-blueye/         # React Native Expo app
-│   ├── App.js
-│   ├── package.json
-│   ├── assets/
-│   └── src/
-│       ├── screens/
-│       ├── components/
-│       └── llama/               # Native LLaMA integration
-│
-├── CubaOpenWeather/              # (Optional) sample region configs
-├── apiOpenWeather.py             # Python helper for weather API calls
-├── adivinanzaUpi.py              # Demo/chatbot script
-├── open.py                       # Early PoC scripts
-├── open1.py
-├── open3.py
-├── open6.py
-│
-├── .gitignore
-└── README.md                     # ← you are here
-```
-
-“Prepared today, secure tomorrow.” 🌀
+“Preparados hoy, seguros mañana”. 🌀

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,26 +1,27 @@
-# BlueEye Backend
+# Backend de BluEye
 
-Simple Express backend serving hurricane risk data, alert history and feedback collection.
+Este backend está construido con Node.js y Express. Calcula el riesgo meteorológico usando datos de OpenWeather, guarda alertas y recibe comentarios de los usuarios. El asistente de IA se encuentra en el proyecto [ai-blueye](https://github.com/DiegoCM1/ai-blueye).
 
-## Setup
+## Instalación rápida
+1. Copia `.env.example` a `.env` y agrega tu `OPENWEATHER_API_KEY`.
+2. Ejecuta `npm install` para instalar las dependencias.
+3. Inicia el servidor con `npm start` (o `npm run dev` si prefieres usar nodemon).
 
-1. Copy `.env.example` to `.env` and fill in your OpenWeather `OPENWEATHER_API_KEY`.
-2. Install dependencies:
-   ```bash
-   npm install
-   ```
-3. Start the server:
-   ```bash
-   npm start
-   ```
+El servidor escucha en el puerto definido por `PORT` (3002 por defecto) y utiliza una base de datos SQLite definida por `DB_PATH`.
 
-The server listens on the port defined in `.env` (`PORT`, default `3002`).
+## Estructura de carpetas
+- `src/index.js` — punto de entrada de la aplicación.
+- `src/routes/` — define los endpoints `/risk`, `/alerts` y `/feedback`.
+- `src/controllers/` — lógica de cada ruta.
+- `src/services/` — integración con OpenWeather y utilidades de análisis.
+- `data/` — archivos de base de datos.
 
-## Endpoints
+## Endpoints principales
+- **POST `/risk`**: evalúa el riesgo meteorológico para las coordenadas proporcionadas.
+- **GET `/alerts`** y **GET `/alerts/:id`**: consulta de alertas guardadas.
+- **POST `/feedback`**: almacena la opinión del usuario.
 
-- `POST /risk` — Analyze meteorological risk for given `lat`/`lon` using OpenWeather data. Returns alerts, banner and recommendations.
-- `GET /alerts` — List stored alerts.
-- `GET /alerts/:id` — Get a single alert.
-- `POST /feedback` — Submit user feedback (rating, email, message). Returns `201` with `{ success, id }`.
-
-Feedback entries are stored in an SQLite database (path defined by `DB_PATH`, default `data.db`).
+## Contribuir
+1. Haz *fork* y crea una rama con tu propuesta.
+2. Envía un *pull request* descriptivo.
+3. Reporta errores mediante *issues*.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,11 +1,19 @@
-## Start:
-npx expo start
+# Frontend de BluEye
 
-## Libraries:
-- Material Community Icons
-- Material Icons
-- Tamagui
-- NativeWindCSS
+Esta es la aplicación móvil creada con React Native y Expo. Desde aquí se consume la API del backend y se envían preguntas al asistente de IA mediante el archivo `api/sendMessage.jsx`.
 
-## React
-- React Navigation
+## Uso rápido
+1. Ejecuta `npm install` para instalar dependencias.
+2. Inicia la aplicación con `npx expo start` y sigue las instrucciones para abrirla en tu dispositivo o simulador.
+
+## Carpetas destacadas
+- `app/` — pantallas y navegación principal de la app.
+- `components/` — componentes reutilizables e indicadores de categoría de huracán.
+- `context/` — proveedores de tema y modo daltónico.
+- `api/sendMessage.jsx` — helper que se conecta al servicio de IA alojado en [ai-blueye](https://github.com/DiegoCM1/ai-blueye).
+- `assets/` — iconos e imágenes.
+
+## Contribuir
+1. Crea una rama desde tu *fork* con los cambios que desees proponer.
+2. Abre un *pull request* y describe tu aportación.
+3. Para reportar errores usa los *issues* del repositorio.


### PR DESCRIPTION
## Summary
- rewrite root README in Spanish with clearer instructions and mention to ai-blueye repo
- update backend README with folder descriptions and quick setup
- expand frontend README with start guide, folder structure and contribution notes

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm start` in backend *(works)*

------
https://chatgpt.com/codex/tasks/task_e_687150e262948331b564c7ba955ac26c