### PR TITLE
Use env var for OpenWeather key

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -41,7 +41,8 @@
       },
       "eas": {
         "projectId": "ed07ab1d-33c0-4d51-bec1-7d6c9d0e5fe9"
-      }
+      },
+      "EXPO_PUBLIC_OPENWEATHER_API_KEY": "73d3f6f15ce8ce7055f93bb64dde8486"
     },
     "runtimeVersion": {
       "policy": "appVersion"

--- a/frontend/components/Main.native.jsx
+++ b/frontend/components/Main.native.jsx
@@ -3,7 +3,7 @@ import { View, Pressable, Text, ActivityIndicator, StyleSheet } from 'react-nati
 import MapView, { UrlTile, PROVIDER_GOOGLE } from 'react-native-maps';
 import * as Location from 'expo-location';
 
-const OWM_API_KEY = 'YOUR_OPENWEATHERMAP_KEY';
+const OWM_API_KEY = process.env.EXPO_PUBLIC_OPENWEATHER_API_KEY;
 
 export default function WeatherMapNativewind() {
   const [region, setRegion] = useState(null);

--- a/frontend/components/Main.web.jsx
+++ b/frontend/components/Main.web.jsx
@@ -11,6 +11,8 @@ import L from "leaflet";
 import axios from "axios";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 
+const OWM_API_KEY = process.env.EXPO_PUBLIC_OPENWEATHER_API_KEY;
+
 // Configuración de íconos para Leaflet
 delete L.Icon.Default.prototype._getIconUrl;
 
@@ -42,16 +44,16 @@ const MapViewWeb = () => {
 
   const weatherTileURLs = {
     temperature:
-      "https://tile.openweathermap.org/map/temp_new/{z}/{x}/{y}.png?appid=73d3f6f15ce8ce7055f93bb64dde8486",
+      `https://tile.openweathermap.org/map/temp_new/{z}/{x}/{y}.png?appid=${OWM_API_KEY}`,
     precipitation:
-      "https://tile.openweathermap.org/map/precipitation_new/{z}/{x}/{y}.png?appid=73d3f6f15ce8ce7055f93bb64dde8486",
+      `https://tile.openweathermap.org/map/precipitation_new/{z}/{x}/{y}.png?appid=${OWM_API_KEY}`,
     humidity:
-      "https://tile.openweathermap.org/map/humidity_new/{z}/{x}/{y}.png?appid=73d3f6f15ce8ce7055f93bb64dde8486",
-    wind: "https://tile.openweathermap.org/map/wind_new/{z}/{x}/{y}.png?appid=73d3f6f15ce8ce7055f93bb64dde8486",
+      `https://tile.openweathermap.org/map/humidity_new/{z}/{x}/{y}.png?appid=${OWM_API_KEY}`,
+    wind: `https://tile.openweathermap.org/map/wind_new/{z}/{x}/{y}.png?appid=${OWM_API_KEY}`,
     pressure:
-      "https://tile.openweathermap.org/map/pressure_new/{z}/{x}/{y}.png?appid=73d3f6f15ce8ce7055f93bb64dde8486",
+      `https://tile.openweathermap.org/map/pressure_new/{z}/{x}/{y}.png?appid=${OWM_API_KEY}`,
     hurricaneRadar:
-      "https://tile.openweathermap.org/map/wind_new/{z}/{x}/{y}.png?appid=73d3f6f15ce8ce7055f93bb64dde8486", // Usando la capa de viento para huracanes
+      `https://tile.openweathermap.org/map/wind_new/{z}/{x}/{y}.png?appid=${OWM_API_KEY}`,
   };
 
   const HurricaneMap = () => {
@@ -76,7 +78,7 @@ const MapViewWeb = () => {
   };
 
   const obtenerClima = async (lat, lon) => {
-    const API_KEY = "73d3f6f15ce8ce7055f93bb64dde8486";
+    const API_KEY = OWM_API_KEY;
     const BASE_URL = "https://api.openweathermap.org/data/2.5/weather";
 
     try {
@@ -102,7 +104,7 @@ const MapViewWeb = () => {
   };
 
   const obtenerPronostico = async (lat, lon) => {
-    const API_KEY = "73d3f6f15ce8ce7055f93bb64dde8486";
+    const API_KEY = OWM_API_KEY;
     const BASE_URL = "https://api.openweathermap.org/data/2.5/forecast";
 
     try {


### PR DESCRIPTION
## Summary
- pull OpenWeather API key from environment instead of hardcoding
- store the key in `app.json` under `expo.extra`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6872c7df72608331b7655cbb2d93ff1d