### PR TITLE
Fix npm integrity for EAS build

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16667,7 +16667,7 @@
     "node_modules/react-dom": {
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
-      "integrity": "sha512-MU232nkbZpXOPUB6ehrm+GJBBmJrx9LKyz+LhFJ9RtqBreEWZ9iG4OerwaTnvMspULprUS0kkIgvV+nb1IrDUA==",
+      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {


### PR DESCRIPTION
## Summary
- correct `react-dom` tarball hash in `package-lock.json`
- add `.npmrc` to allow `npm ci` to succeed during EAS build

## Testing
- `npm ci`

------
https://chatgpt.com/codex/tasks/task_e_68787d991a308331b4172030a5068101