### PR TITLE
Fix unmatched route on startup

### DIFF
--- a/frontend/app/index.jsx
+++ b/frontend/app/index.jsx
@@ -1,0 +1,5 @@
+import { Redirect } from "expo-router";
+
+export default function Index() {
+  return <Redirect href="/(tabs)" />;
+}


### PR DESCRIPTION
## Summary
- add a root index route that redirects to the tab layout

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6878a667b1cc8331b2d5f6462a439dce