### PR TITLE
Fix safe area for headers

### DIFF
--- a/frontend/app/_layout.jsx
+++ b/frontend/app/_layout.jsx
@@ -1,6 +1,6 @@
 import { Stack } from "expo-router";
 // import { Drawer } from "expo-router/drawer";
-import { SafeAreaProvider } from "react-native-safe-area-context";
+import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
 import { TamaguiProvider } from "@tamagui/core";
 import config from "../tamagui.config";
 import { ThemeProvider } from "../context/ThemeContext";
@@ -15,37 +15,39 @@ export default function Layout() {
         <ThemeProvider>
           <SafeAreaProvider>
             <TamaguiProvider config={config} defaultTheme="light">
-              <Stack screenOptions={{ headerShown: true }}>
-                <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-                <Stack.Screen
-                  name="SettingsScreen"
-                  options={{ title: "Ajustes" }}
-                />
-                <Stack.Screen
-                  name="AlarmScreen"
-                  options={{ title: "Alarma" }}
-                />
-                <Stack.Screen
-                  name="FeedbackScreen"
-                  options={{ title: "Feedback" }}
-                />
-                <Stack.Screen
-                  name="AlertDetailsScreen"
-                  options={{ title: "Detalles de Alerta" }}
-                />
-                <Stack.Screen
-                  name="ChatAIScreen"
-                  options={{ title: "Chat-AI" }}
-                />
-                <Stack.Screen
-                  name="AlertsHistoryScreen"
-                  options={{ title: "Alertas" }}
-                />
-                <Stack.Screen
-                  name="AboutScreen"
-                  options={{ title: "Acerca de nosotros" }}
-                />
-              </Stack>
+              <SafeAreaView style={{ flex: 1 }} edges={['top']}>
+                <Stack screenOptions={{ headerShown: true }}>
+                  <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+                  <Stack.Screen
+                    name="SettingsScreen"
+                    options={{ title: "Ajustes" }}
+                  />
+                  <Stack.Screen
+                    name="AlarmScreen"
+                    options={{ title: "Alarma" }}
+                  />
+                  <Stack.Screen
+                    name="FeedbackScreen"
+                    options={{ title: "Feedback" }}
+                  />
+                  <Stack.Screen
+                    name="AlertDetailsScreen"
+                    options={{ title: "Detalles de Alerta" }}
+                  />
+                  <Stack.Screen
+                    name="ChatAIScreen"
+                    options={{ title: "Chat-AI" }}
+                  />
+                  <Stack.Screen
+                    name="AlertsHistoryScreen"
+                    options={{ title: "Alertas" }}
+                  />
+                  <Stack.Screen
+                    name="AboutScreen"
+                    options={{ title: "Acerca de nosotros" }}
+                  />
+                </Stack>
+              </SafeAreaView>
             </TamaguiProvider>
           </SafeAreaProvider>
         </ThemeProvider>


### PR DESCRIPTION
## Summary
- wrap main navigator with SafeAreaView so header and back icon do not overlap the system notch

## Testing
- `npm run lint` *(fails: could not find eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_6878c6b693e88331a20349d48270081f