### PR TITLE
Add precipitation, sea level, clouds layers in mobile map

### DIFF
--- a/frontend/components/Main.native.jsx
+++ b/frontend/components/Main.native.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { View, Pressable, Text, ActivityIndicator, StyleSheet } from 'react-native';
+import { View, Pressable, Text, ActivityIndicator, StyleSheet, Switch, Modal } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 import MapView, { UrlTile, PROVIDER_GOOGLE } from 'react-native-maps';
 import * as Location from 'expo-location';
 
@@ -9,6 +10,10 @@ export default function WeatherMapNativewind() {
   const [region, setRegion] = useState(null);
   const [showWind, setShowWind] = useState(true);
   const [showTemp, setShowTemp] = useState(true);
+  const [showPrecip, setShowPrecip] = useState(false);
+  const [showSea, setShowSea] = useState(false);
+  const [showClouds, setShowClouds] = useState(false);
+  const [layerModalVisible, setLayerModalVisible] = useState(false);
   const [loading, setLoading] = useState(true);
   const mapRef = useRef(null);
 
@@ -67,27 +72,76 @@ export default function WeatherMapNativewind() {
             opacity={0.5}
           />
         )}
+        {showPrecip && (
+          <UrlTile
+            urlTemplate={`https://tile.openweathermap.org/map/precipitation_new/{z}/{x}/{y}.png?appid=${OWM_API_KEY}`}
+            maximumZ={12}
+            tileSize={256}
+            zIndex={3}
+            opacity={0.5}
+          />
+        )}
+        {showSea && (
+          <UrlTile
+            urlTemplate={`https://tile.openweathermap.org/map/pressure_new/{z}/{x}/{y}.png?appid=${OWM_API_KEY}`}
+            maximumZ={12}
+            tileSize={256}
+            zIndex={4}
+            opacity={0.5}
+          />
+        )}
+        {showClouds && (
+          <UrlTile
+            urlTemplate={`https://tile.openweathermap.org/map/clouds_new/{z}/{x}/{y}.png?appid=${OWM_API_KEY}`}
+            maximumZ={12}
+            tileSize={256}
+            zIndex={5}
+            opacity={0.5}
+          />
+        )}
       </MapView>
 
-      {/* Layer toggles */}
-      <View className="absolute top-12 left-4 flex-row space-x-3">
-        <Pressable
-          onPress={() => setShowWind(w => !w)}
-          className="bg-white bg-opacity-90 px-4 py-2 rounded-full shadow-md"
-        >
-          <Text className="text-sm font-medium">
-            {showWind ? 'Hide Wind' : 'Show Wind'}
-          </Text>
-        </Pressable>
-        <Pressable
-          onPress={() => setShowTemp(t => !t)}
-          className="bg-white bg-opacity-90 px-4 py-2 rounded-full shadow-md"
-        >
-          <Text className="text-sm font-medium">
-            {showTemp ? 'Hide Temp' : 'Show Temp'}
-          </Text>
-        </Pressable>
-      </View>
+      {/* Layer selector */}
+      <Pressable
+        onPress={() => setLayerModalVisible(true)}
+        className="absolute top-12 right-4 bg-white bg-opacity-90 p-3 rounded-full shadow-md"
+      >
+        <MaterialCommunityIcons name="layers-outline" size={24} color="#333" />
+      </Pressable>
+
+      <Modal
+        animationType="slide"
+        transparent
+        visible={layerModalVisible}
+        onRequestClose={() => setLayerModalVisible(false)}
+      >
+        <View className="flex-1 justify-end bg-black/40">
+          <View className="bg-white p-6 rounded-t-2xl">
+            <Text className="text-lg font-bold mb-4 text-center">Map Layers</Text>
+            {[
+              { label: 'Wind', state: showWind, setter: setShowWind, icon: 'weather-windy' },
+              { label: 'Temperature', state: showTemp, setter: setShowTemp, icon: 'thermometer' },
+              { label: 'Precipitation', state: showPrecip, setter: setShowPrecip, icon: 'weather-rainy' },
+              { label: 'Sea Level', state: showSea, setter: setShowSea, icon: 'waves' },
+              { label: 'Clouds', state: showClouds, setter: setShowClouds, icon: 'weather-cloudy' },
+            ].map(({ label, state, setter, icon }) => (
+              <View key={label} className="flex-row justify-between items-center mb-3">
+                <View className="flex-row items-center">
+                  <MaterialCommunityIcons name={icon} size={20} color="#333" />
+                  <Text className="ml-2 text-base">{label}</Text>
+                </View>
+                <Switch value={state} onValueChange={setter} />
+              </View>
+            ))}
+            <Pressable
+              onPress={() => setLayerModalVisible(false)}
+              className="mt-2 bg-blue-600 py-3 rounded-full items-center"
+            >
+              <Text className="text-white font-semibold">Close</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
 
       {/* Recenter */}
       <Pressable


### PR DESCRIPTION
## Summary
- extend `Main.native.jsx` with precipitation, sea level and cloud layers
- add a modal layer selector with icons for a better UX

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_6878cd6d37f08331b508bf532d46204e