### PR TITLE
Add dynamic dark mode colors for layouts

### DIFF
--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -1,14 +1,23 @@
 import { Tabs } from "expo-router";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { useColorScheme } from "nativewind";
 
 export default function TabsLayout() {
+  const { colorScheme } = useColorScheme();
+  const barBg =
+    colorScheme === "dark" ? "rgb(40, 60, 80)" : "rgb(60, 200, 220)";
+  const activeTint =
+    colorScheme === "dark" ? "rgb(230, 230, 250)" : "rgb(255, 255, 255)";
+  const inactiveTint =
+    colorScheme === "dark" ? "rgb(180, 180, 200)" : "rgb(220, 220, 220)";
+
   return (
     <Tabs
       screenOptions={{
         headerShown: false,
-        tabBarActiveTintColor: "rgb(255, 255, 255)", // tailwind `phase2Buttons`
-        tabBarInactiveTintColor: "rgb(220, 220, 220)", // tailwind `phase2Buttons`
-        tabBarStyle: { backgroundColor: "rgb(60, 200, 220)" }, // tailwind `phase2bg`
+        tabBarActiveTintColor: activeTint,
+        tabBarInactiveTintColor: inactiveTint,
+        tabBarStyle: { backgroundColor: barBg },
         tabBarHideOnKeyboard: true, // Hide the tab bar when the keyboard is open so it doesn't overlap the text input on Android builds
       }}
     >
@@ -47,16 +56,12 @@ export default function TabsLayout() {
           ),
         }}
       />
-       <Tabs.Screen
+      <Tabs.Screen
         name="MoreScreen"
         options={{
           title: "Más",
           tabBarIcon: ({ color, size }) => (
-            <MaterialCommunityIcons
-              name="menu"
-              color={color}
-              size={size}
-            />
+            <MaterialCommunityIcons name="menu" color={color} size={size} />
           ),
         }}
       />

--- a/frontend/app/_layout.jsx
+++ b/frontend/app/_layout.jsx
@@ -6,20 +6,29 @@ import config from "../tamagui.config";
 import { ThemeProvider } from "../context/ThemeContext";
 import { DaltonicModeProvider } from "../context/DaltonicModeContext";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { useColorScheme } from "nativewind";
 
 /* ---------- Layout raíz ---------- */
 export default function Layout() {
+  const { colorScheme } = useColorScheme();
+  const headerBg =
+    colorScheme === "dark" ? "rgb(40, 60, 80)" : "rgb(60, 200, 220)";
+  const headerTint = colorScheme === "dark" ? "rgb(230, 230, 250)" : "#fff";
+
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <DaltonicModeProvider>
         <ThemeProvider>
           <SafeAreaProvider>
             <TamaguiProvider config={config} defaultTheme="light">
-              <SafeAreaView style={{ flex: 1 }} edges={["top"]} className="bg-phase2ButtonsDark dark:bg-phase2bgDark">
+              <SafeAreaView
+                style={{ flex: 1, backgroundColor: headerBg }}
+                edges={["top"]}
+              >
                 <Stack
                   screenOptions={{
-                    headerStyle: { backgroundColor: "rgb(60, 200, 220)" },
-                    headerTintColor: "#fff",
+                    headerStyle: { backgroundColor: headerBg },
+                    headerTintColor: headerTint,
                     headerTitleStyle: { fontWeight: "bold" },
                   }}
                 >


### PR DESCRIPTION
## Summary
- adjust root layout to style header and safe area with current color scheme
- update tabs layout with matching dark mode styles

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` in frontend *(fails: missing script)*
- `npm test` in backend *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687994383bac8331aa970bed46b29554