### PR TITLE
Fix text input hidden under tab bar on Android

### DIFF
--- a/frontend/app/(tabs)/ChatAIScreen.jsx
+++ b/frontend/app/(tabs)/ChatAIScreen.jsx
@@ -17,6 +17,7 @@ import {
   SafeAreaView,
   useSafeAreaInsets,
 } from "react-native-safe-area-context";
+import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 // import * as ImagePicker from "expo-image-picker";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 // import { Camera } from "expo-camera";
@@ -34,6 +35,7 @@ export default function ChatAIScreen() {
   const [messages, setMessages] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const insets = useSafeAreaInsets(); // ← gives you { top, bottom, left, right }
+  const tabBarHeight = useBottomTabBarHeight();
 
   /* Camera permission and open handler disabled 
 
@@ -230,8 +232,9 @@ export default function ChatAIScreen() {
       </TouchableOpacity>
       <KeyboardAvoidingView
         style={{ flex: 1 }}
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
-        keyboardVerticalOffset={insets.bottom + insets.bottom + 5}      >
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        keyboardVerticalOffset={tabBarHeight + insets.bottom + 5}
+      >
         <View className="flex-1 px-4 pt-2">
           {/* Messages List */}
           <FlatList


### PR DESCRIPTION
## Summary
- ensure ChatAIScreen accounts for tab bar height
- use `useBottomTabBarHeight` and adjust KeyboardAvoidingView props

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: no test script found)*

------
https://chatgpt.com/codex/tasks/task_e_68799550c0088331bcbc3d20ba49ca17