### PR TITLE
Fix Android text input visibility

### DIFF
--- a/frontend/app/(tabs)/ChatAIScreen.jsx
+++ b/frontend/app/(tabs)/ChatAIScreen.jsx
@@ -17,6 +17,7 @@ import {
   SafeAreaView,
   useSafeAreaInsets,
 } from "react-native-safe-area-context";
+import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 // import * as ImagePicker from "expo-image-picker";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 // import { Camera } from "expo-camera";
@@ -34,6 +35,7 @@ export default function ChatAIScreen() {
   const [messages, setMessages] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const insets = useSafeAreaInsets(); // ← gives you { top, bottom, left, right }
+  const tabBarHeight = useBottomTabBarHeight();
 
   /* Camera permission and open handler disabled 
 
@@ -231,7 +233,7 @@ export default function ChatAIScreen() {
       <KeyboardAvoidingView
         style={{ flex: 1 }}
         behavior={Platform.OS === "ios" ? "padding" : "height"}
-        keyboardVerticalOffset={insets.bottom + insets.bottom + 5}
+        keyboardVerticalOffset={insets.bottom + tabBarHeight + 5}
       >
         <View className="flex-1 px-4 pt-2">
           {/* Messages List */}


### PR DESCRIPTION
## Summary
- adjust `ChatAIScreen` keyboard offset to account for tab bar height

## Testing
- `npm run lint` *(fails: ESLint couldn't find config file)*
- `npm test` in `backend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68799cc17bb8833198895edd42312c9c