### PR TITLE
Add Expo notifications and alert fetching

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,2 @@
 REACT_APP_OPENWEATHER_API_KEY=YOUR_KEY_HERE
+EXPO_PUBLIC_ALERTS_URL=https://your-alerts-api.example.com

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -5,7 +5,8 @@ Este paquete contiene la app realizada con React Native y Expo. Utiliza **Expo R
 ## Uso rápido
 1. Ejecuta `npm install` para instalar las dependencias.
 2. Copia `.env.example` a `.env` y coloca tu clave de OpenWeather en `REACT_APP_OPENWEATHER_API_KEY`.
-3. Inicia la aplicación con `npx expo start` y sigue las instrucciones para abrirla en tu dispositivo, emulador o navegador.
+3. Define `EXPO_PUBLIC_ALERTS_URL` con la URL de la base de datos de alertas.
+4. Inicia la aplicación con `npx expo start` y sigue las instrucciones para abrirla en tu dispositivo, emulador o navegador.
 
 ## Estructura relevante
 - `app/` – pantallas de la aplicación y la definición de rutas.

--- a/frontend/api/alerts.js
+++ b/frontend/api/alerts.js
@@ -1,0 +1,24 @@
+import axios from "axios";
+
+const BASE_URL = process.env.EXPO_PUBLIC_ALERTS_URL || "https://alerts.example.com";
+
+export const getAlertSummary = async (id) => {
+  try {
+    const res = await axios.get(`${BASE_URL}/alerts/${id}`, { params: { summary: true } });
+    return res.data;
+  } catch (err) {
+    console.error("getAlertSummary error", err.response?.data || err.message);
+    throw err;
+  }
+};
+
+export const getAlertDetails = async (id) => {
+  try {
+    const res = await axios.get(`${BASE_URL}/alerts/${id}`);
+    return res.data;
+  } catch (err) {
+    console.error("getAlertDetails error", err.response?.data || err.message);
+    throw err;
+  }
+};
+

--- a/frontend/app/AlarmScreen.jsx
+++ b/frontend/app/AlarmScreen.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { Modal, View, Text, TouchableOpacity } from "react-native";
-import { Link, useRouter } from "expo-router";
+import { Link, useRouter, useLocalSearchParams } from "expo-router";
+import { getAlertSummary } from "../api/alerts";
 
 const CATEGORY_BG = {
   3: "bg-phase3bg dark:bg-phase2CardsDark",
@@ -8,26 +9,31 @@ const CATEGORY_BG = {
   5: "bg-phase5bg dark:bg-phase2CardsDark",
 };
 
-const distanceKm = 100
-const etaHours = 14
-
-const MOCK_ALERT = {
-  category: 3,
-  title: "Huracán Otis · Categoría 3",
-  message: "Otis está cada vez más cerca: solo " + distanceKm + "km y se estima que llegará en " + etaHours + " horas. Prepárate para evacuar y sigue las indicaciones oficiales.",
-};
-
 export default function AlarmScreen() {
+  const params = useLocalSearchParams();
+  const alertId = params.id;
+  const [alert, setAlert] = useState(null);
   const [visible, setVisible] = useState(false);
+  const router = useRouter();
+
   useEffect(() => {
+    const fetchData = async () => {
+      if (alertId) {
+        try {
+          const data = await getAlertSummary(alertId);
+          setAlert(data);
+        } catch (e) {
+          console.error("Failed to fetch alert", e);
+        }
+      }
+    };
+    fetchData();
     const t = setTimeout(() => setVisible(true), 250);
     return () => clearTimeout(t);
-  }, []);
-
-  const router = useRouter();
+  }, [alertId]);
   const handleMap = () => {
     setVisible(false);
-    router.push("/MapScreen");       // Ruta del mapa
+    router.push("/MapScreen");
   };
   const handleClose = () => setVisible(false);
 
@@ -36,29 +42,20 @@ export default function AlarmScreen() {
       <View className="flex-1 justify-center items-center bg-black/70">
         <View
           className={`w-11/12 max-w-md rounded-2xl p-6 shadow-xl ${
-            CATEGORY_BG[MOCK_ALERT.category]
+            CATEGORY_BG[alert?.category || 3]
           }`}
         >
           {/* Título */}
           <Text className="text-2xl font-extrabold text-phase2Titles dark:text-phase2TitlesDark text-center mb-4">
-            {MOCK_ALERT.title}
+            {alert?.title}
           </Text>
 
           {/* Mensaje breve */}
           <Text className="text-base text-phase2Titles dark:text-phase2TitlesDark text-center mb-6">
-            {MOCK_ALERT.message}
+            {alert?.message}
           </Text>
 
-          {/* Datos clave */}
-          {/* <View className="space-y-1 mb-8">
-            <Stat label="Distancia" value={`${MOCK_ALERT.distanceKm} km`} />
-            <Stat label="ETA" value={`${MOCK_ALERT.etaHours} h`} />
-            <Stat label="Viento" value={`${MOCK_ALERT.windKmh} km/h`} />
-            <Stat label="Ráfagas" value={`${MOCK_ALERT.gustKmh} km/h`} />
-            <Stat label="Presión" value={`${MOCK_ALERT.pressureMb} mb`} />
-            <Stat label="Lluvia 1 h" value={`${MOCK_ALERT.rain1h} mm`} />
-            <Stat label="Prob. lluvia" value={`${Math.round(MOCK_ALERT.pop * 100)} %`} />
-          </View> */}
+
 
           {/* Botones */}
           <View className="flex-row justify-between mb-6">
@@ -69,10 +66,13 @@ export default function AlarmScreen() {
               <Text className="font-bold text-white">Ver en el mapa</Text>
               </TouchableOpacity>
 
-            <Link href="/AlertDetailsScreen" asChild>
-                <TouchableOpacity className="flex-1 ml-2 py-3 rounded-lg bg-phase2Buttons dark:bg-phase2ButtonsDark items-center">
-                  <Text className="font-bold text-white">Más información</Text>
-                </TouchableOpacity>
+            <Link
+              href={{ pathname: "/AlertDetailsScreen", params: { id: alertId } }}
+              asChild
+            >
+              <TouchableOpacity className="flex-1 ml-2 py-3 rounded-lg bg-phase2Buttons dark:bg-phase2ButtonsDark items-center">
+                <Text className="font-bold text-white">Más información</Text>
+              </TouchableOpacity>
             </Link>
           </View>
 
@@ -86,11 +86,3 @@ export default function AlarmScreen() {
   );
 }
 
-function Stat({ label, value }) {
-  return (
-    <Text className="text-phase2Titles dark:text-phase2TitlesDark">
-      <Text className="font-bold">{label}: </Text>
-      {value}
-    </Text>
-  );
-}

--- a/frontend/app/AlertDetailsScreen.jsx
+++ b/frontend/app/AlertDetailsScreen.jsx
@@ -1,10 +1,14 @@
 import { View, Text, ScrollView } from "react-native";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { useEffect, useState } from "react";
+import { useLocalSearchParams } from "expo-router";
+import { getAlertDetails } from "../api/alerts";
 
 // ────────────────── componente principal ──────────────────
 export default function AlertDetailsScreen({ data }) {
-  // Mock por defecto
-  const info =
+  const params = useLocalSearchParams();
+  const alertId = params.id;
+  const [info, setInfo] = useState(
     data || {
       name: "Idalia",
       category: 3,
@@ -16,7 +20,22 @@ export default function AlertDetailsScreen({ data }) {
       pressureMb: 960,
       forwardSpeedKmh: 18,
       localRisk: { extremeWind: 80, waveHeight: 5.4, rainfall24h: 180 },
+    }
+  );
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (alertId) {
+        try {
+          const res = await getAlertDetails(alertId);
+          setInfo(res);
+        } catch (e) {
+          console.error("Failed to load alert details", e);
+        }
+      }
     };
+    fetchData();
+  }, [alertId]);
 
   // Colores según categoría
   const catColors = {

--- a/frontend/app/_layout.jsx
+++ b/frontend/app/_layout.jsx
@@ -5,6 +5,7 @@ import { TamaguiProvider } from "@tamagui/core";
 import config from "../tamagui.config";
 import { ThemeProvider } from "../context/ThemeContext";
 import { DaltonicModeProvider } from "../context/DaltonicModeContext";
+import { NotificationsProvider } from "../context/NotificationsContext";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useColorScheme } from "nativewind";
 
@@ -19,12 +20,13 @@ export default function Layout() {
     <GestureHandlerRootView style={{ flex: 1 }}>
       <DaltonicModeProvider>
         <ThemeProvider>
-          <SafeAreaProvider>
-            <TamaguiProvider config={config} defaultTheme="light">
-              <SafeAreaView
-                style={{ flex: 1, backgroundColor: headerBg }}
-                edges={["top"]}
-              >
+          <NotificationsProvider>
+            <SafeAreaProvider>
+              <TamaguiProvider config={config} defaultTheme="light">
+                <SafeAreaView
+                  style={{ flex: 1, backgroundColor: headerBg }}
+                  edges={["top"]}
+                >
                 <Stack
                   screenOptions={{
                     headerStyle: { backgroundColor: headerBg },
@@ -67,7 +69,8 @@ export default function Layout() {
                 </Stack>
               </SafeAreaView>
             </TamaguiProvider>
-          </SafeAreaProvider>
+            </SafeAreaProvider>
+          </NotificationsProvider>
         </ThemeProvider>
       </DaltonicModeProvider>
     </GestureHandlerRootView>

--- a/frontend/context/NotificationsContext.jsx
+++ b/frontend/context/NotificationsContext.jsx
@@ -1,0 +1,65 @@
+import React, { createContext, useContext, useEffect, useRef, useState } from "react";
+import * as Notifications from "expo-notifications";
+import { Platform } from "react-native";
+import { useRouter } from "expo-router";
+
+const NotificationsContext = createContext();
+
+export const NotificationsProvider = ({ children }) => {
+  const [expoPushToken, setExpoPushToken] = useState(null);
+  const router = useRouter();
+  const responseListener = useRef();
+
+  useEffect(() => {
+    registerForPushNotificationsAsync().then(token => setExpoPushToken(token));
+
+    responseListener.current = Notifications.addNotificationResponseReceivedListener(response => {
+      const data = response.notification.request.content.data || {};
+      const alertId = data.alertId;
+      const level = data.level;
+      if (level === "high" || level === "emergency") {
+        router.push({ pathname: "/AlarmScreen", params: { id: alertId } });
+      } else {
+        router.push("/(tabs)/MapScreen");
+      }
+    });
+
+    return () => {
+      if (responseListener.current) {
+        Notifications.removeNotificationSubscription(responseListener.current);
+      }
+    };
+  }, []);
+
+  return (
+    <NotificationsContext.Provider value={{ expoPushToken }}>
+      {children}
+    </NotificationsContext.Provider>
+  );
+};
+
+export const useNotifications = () => useContext(NotificationsContext);
+
+async function registerForPushNotificationsAsync() {
+  let token;
+  const { status: existingStatus } = await Notifications.getPermissionsAsync();
+  let finalStatus = existingStatus;
+  if (existingStatus !== "granted") {
+    const { status } = await Notifications.requestPermissionsAsync();
+    finalStatus = status;
+  }
+  if (finalStatus !== "granted") {
+    return null;
+  }
+  token = (await Notifications.getExpoPushTokenAsync()).data;
+
+  if (Platform.OS === "android") {
+    Notifications.setNotificationChannelAsync("default", {
+      name: "default",
+      importance: Notifications.AndroidImportance.DEFAULT,
+    });
+  }
+
+  return token;
+}
+

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "expo-image-picker": "~16.1.4",
         "expo-linking": "~7.1.7",
         "expo-location": "~18.1.5",
+        "expo-notifications": "^0.31.4",
         "expo-router": "^5.1.3",
         "expo-status-bar": "~2.2.3",
         "leaflet": "1.9.4",
@@ -3246,6 +3247,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@ide/backoff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
+      "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -8920,6 +8927,19 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -8955,7 +8975,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -9229,6 +9248,12 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -9432,7 +9457,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -9464,7 +9488,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -10218,7 +10241,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -10245,7 +10267,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -11579,6 +11600,15 @@
         }
       }
     },
+    "node_modules/expo-application": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-6.1.5.tgz",
+      "integrity": "sha512-ToImFmzw8luY043pWFJhh2ZMm4IwxXoHXxNoGdlhD4Ym6+CCmkAvCglg0FK8dMLzAb+/XabmOE7Rbm8KZb6NZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-asset": {
       "version": "11.1.7",
       "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-11.1.7.tgz",
@@ -11793,6 +11823,26 @@
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-notifications": {
+      "version": "0.31.4",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-0.31.4.tgz",
+      "integrity": "sha512-NnGKIFGpgZU66qfiFUyjEBYsS77VahURpSSeWEOLt+P1zOaUFlgx2XqS+dxH3/Bn1Vm7TMj04qKsK5KvzR/8Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.7.6",
+        "@ide/backoff": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "assert": "^2.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~6.1.5",
+        "expo-constants": "~17.1.7"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-router": {
@@ -12172,7 +12222,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -12635,7 +12684,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -12924,6 +12972,22 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -13040,7 +13104,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13161,7 +13224,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
       "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -13194,6 +13256,22 @@
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -13284,7 +13362,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -13367,7 +13444,6 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -15560,11 +15636,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15574,7 +15665,6 @@
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -16158,7 +16248,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -17473,7 +17562,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -17708,7 +17796,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -19257,6 +19344,19 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -19466,7 +19566,6 @@
       "version": "1.1.19",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
       "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "expo-image-picker": "~16.1.4",
     "expo-linking": "~7.1.7",
     "expo-location": "~18.1.5",
+    "expo-notifications": "^0.31.4",
     "expo-router": "^5.1.3",
     "expo-status-bar": "~2.2.3",
     "leaflet": "1.9.4",


### PR DESCRIPTION
## Summary
- enable expo-notifications in frontend
- add NotificationsProvider context
- fetch alert info from API in AlarmScreen and AlertDetailsScreen
- route notification taps to AlarmScreen or MapScreen
- document new EXPO_PUBLIC_ALERTS_URL env variable

## Testing
- `npm run lint` *(fails: prettier issues)*

------
https://chatgpt.com/codex/tasks/task_e_687bf869ec7c8331a648a43e6ba27a74