### PR TITLE
Fix import issues in backend

### DIFF
--- a/backend/src/controllers/alertsController.js
+++ b/backend/src/controllers/alertsController.js
@@ -1,6 +1,7 @@
 // backend/src/controllers/alerts.controller.js
 
-import alertsStore from '../data/alertsStore.js';
+// Import the alert store functions directly as there is no default export
+import * as alertsStore from '../data/alertsStore.js';
 
 export function listAlerts(req, res) {
   res.json(alertsStore.getAll());

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -10,9 +10,8 @@ import feedbackRoutes from './routes/feedback.js';
 import pushTokenRoutes from './routes/pushToken.routes.js';
 
 // Inicializa la conexión a la base de datos (puede que exportes el pool ahí)
-import './services/db.js';
-// o, si tu db.js exporta directamente el pool:
-// import pool from './services/db.js';
+// Import the database pool to use it in health checks
+import pool from './services/db.js';
 
 dotenv.config();
 

--- a/backend/src/routes/feedback.js
+++ b/backend/src/routes/feedback.js
@@ -1,14 +1,15 @@
 // backend/src/routes/feedback.js
 
 import { Router } from 'express';
-import { createFeedback, getAllFeedback } from '../controllers/feedbackController.js';
+// Use the handler names exported by the controller
+import { createFeedbackHandler, getAllFeedbackHandler } from '../controllers/feedbackController.js';
 
 const router = Router();
 
 // POST /feedback → crea un nuevo feedback
-router.post('/', createFeedback);
+router.post('/', createFeedbackHandler);
 
 // GET  /feedback → lista todos los feedbacks
-router.get('/', getAllFeedback);
+router.get('/', getAllFeedbackHandler);
 
 export default router;


### PR DESCRIPTION
## Summary
- fix alerts controller import style
- update feedback routes to use correct handler names
- import the db pool directly in `index.js`

## Testing
- `npm start`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6885b5cd20cc83318ec8a9b73dc8f1c3