### PR TITLE
Implement alerts history and details screens

### DIFF
--- a/frontend/app/AlertDetailsScreen.jsx
+++ b/frontend/app/AlertDetailsScreen.jsx
@@ -1,136 +1,95 @@
-import { View, Text, ScrollView } from "react-native";
-import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { useEffect, useState } from 'react';
+import { View, Text, ActivityIndicator, ScrollView } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+import { colorForLevel } from '../components/AlertCard';
 
-// ────────────────── componente principal ──────────────────
-export default function AlertDetailsScreen({ data }) {
-  // Mock por defecto
-  const info =
-    data || {
-      name: "Idalia",
-      category: 3,
-      updatedAt: "Hace 1 h",
-      distanceKm: 185,
-      etaHours: 14,
-      windKmh: 195,
-      gustsKmh: 230,
-      pressureMb: 960,
-      forwardSpeedKmh: 18,
-      localRisk: { extremeWind: 80, waveHeight: 5.4, rainfall24h: 180 },
+const API_URL = 'https://metaquetzal-production.up.railway.app';
+
+export default function AlertDetailsScreen() {
+  const { id } = useLocalSearchParams();
+  const [alert, setAlert] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    setLoading(true);
+    fetch(`${API_URL}/alerts/${id}`)
+      .then(async (res) => {
+        if (!res.ok) {
+          const err = new Error('Error');
+          err.status = res.status;
+          throw err;
+        }
+        return res.json();
+      })
+      .then((data) => {
+        if (isMounted) setAlert(data);
+      })
+      .catch((e) => {
+        if (isMounted) setError(e);
+      })
+      .finally(() => {
+        if (isMounted) setLoading(false);
+      });
+    return () => {
+      isMounted = false;
     };
+  }, [id]);
 
-  // Colores según categoría
-  const catColors = {
-    1: "bg-yellow-500",
-    2: "bg-orange-500",
-    3: "bg-red-600",
-    4: "bg-red-700",
-    5: "bg-purple-700",
-  };
+  if (loading) {
+    return (
+      <View className="flex-1 justify-center items-center">
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  if (error) {
+    if (error.status === 404) {
+      return (
+        <View className="flex-1 justify-center items-center">
+          <Text>Alerta no encontrada</Text>
+        </View>
+      );
+    }
+    return (
+      <View className="flex-1 justify-center items-center">
+        <Text>Error al cargar alerta</Text>
+      </View>
+    );
+  }
+
+  if (!alert) {
+    return null;
+  }
 
   return (
-    <ScrollView className="flex-1 bg-phase2bg dark:bg-phase2bgDark">
-      {/* Encabezado */}
+    <ScrollView className="flex-1">
       <View
-        className={`rounded-2xl p-5 shadow-lg ${catColors[info.category]} flex-row justify-between items-center mx-4 mt-4`}
+        style={{ backgroundColor: colorForLevel(alert.level), height: 80 }}
+        className="justify-center items-center"
       >
-        <View>
-          <Text className="text-2xl font-extrabold text-white">
-            {info.name} • Cat {info.category}
-          </Text>
-          <Text className="text-white/80 mt-1">
-            Actualizado {info.updatedAt}
-          </Text>
-        </View>
-        <MaterialCommunityIcons
-          name="weather-hurricane"
-          size={36}
-          color="white"
-        />
+        <Text className="text-white font-bold text-lg text-center">
+          {alert.title}
+        </Text>
       </View>
 
-      {/* RIESGOS LOCALES */}
-      <Card title="Riesgos locales">
-        <Stat
-          label="Prob. viento extremo"
-          value={`${info.localRisk.extremeWind}%`}
-        />
-        <Stat label="Altura de oleaje" value={`${info.localRisk.waveHeight} m`} />
-        <Stat label="Lluvia 24 h" value={`${info.localRisk.rainfall24h} mm`} />
-      </Card>
+      <View className="p-4">
+        <Text className="text-base font-bold mb-2">Recomendaciones</Text>
+        {alert.recommendations?.map((rec, idx) => (
+          <Text key={idx} className="mb-1">
+            • {rec}
+          </Text>
+        ))}
 
-      {/* Trayectoria */}
-      <Card title="Trayectoria">
-        <Text className="text-phase2Titles dark:text-white">
-          A <Text className="font-semibold">{info.distanceKm} km</Text> de tu
-          ubicación. ETA aproximada en{" "}
-          <Text className="font-semibold">{info.etaHours} h</Text>. Ruta
-          proyectada mostrada en el mapa principal.
-        </Text>
-      </Card>
-
-      {/* Datos técnicos */}
-      <Card title="Datos técnicos">
-        <View className="grid grid-cols-2 gap-2">
-          <Stat label="Viento sostenido" value={`${info.windKmh} km/h`} />
-          <Stat label="Rachas máx." value={`${info.gustsKmh} km/h`} />
-          <Stat label="Presión" value={`${info.pressureMb} mb`} />
-          <Stat
-            label="Vel. traslación"
-            value={`${info.forwardSpeedKmh} km/h`}
-          />
-        </View>
-      </Card>
-
-      {/* Plan de acción */}
-      <Card title="Plan de acción">
-        <ChecklistItem text="Revisar rutas de evacuación" />
-        <ChecklistItem text="Asegurar ventanas y puertas" />
-        <ChecklistItem text="Preparar kit de emergencia" />
-      </Card>
-
-      {/* Avisos oficiales */}
-      <Card title="Avisos oficiales">
-        <Text className="text-phase2Titles dark:text-white">
-          Último boletín de Conagua ★ NHC indica posible intensificación en las
-          próximas 12 h.
-        </Text>
-      </Card>
+        <Text className="text-base font-bold mt-4 mb-2">Factores</Text>
+        {alert.factors?.map((fac, idx) => (
+          <Text key={idx} className="mb-1">
+            • {fac}
+          </Text>
+        ))}
+      </View>
     </ScrollView>
-  );
-}
-
-// ────────────────── helpers ──────────────────
-function Card({ title, children }) {
-  return (
-    <View className="rounded-2xl bg-phase2Cards dark:bg-phase2CardsDark p-5 shadow-md border border-phase2Borders dark:border-phase2BordersDark mx-4 mt-6">
-      <Text className="text-xl font-bold text-phase2Titles dark:text-white mb-2">
-        {title}
-      </Text>
-      {children}
-    </View>
-  );
-}
-
-function Stat({ label, value }) {
-  return (
-    <View className="flex-row justify-between mb-2">
-      <Text className="text-phase2Titles dark:text-white/80">{label}</Text>
-      <Text className="font-semibold text-phase2Titles dark:text-white">
-        {value}
-      </Text>
-    </View>
-  );
-}
-
-function ChecklistItem({ text }) {
-  return (
-    <View className="flex-row items-start space-x-2 mb-2">
-      <MaterialCommunityIcons
-        name="checkbox-blank-circle-outline"
-        size={18}
-        color="rgb(115,115,115)"
-      />
-      <Text className="text-phase2Titles dark:text-white">{text}</Text>
-    </View>
   );
 }

--- a/frontend/app/AlertsHistoryScreen.jsx
+++ b/frontend/app/AlertsHistoryScreen.jsx
@@ -1,0 +1,52 @@
+import { View, Text, FlatList, ActivityIndicator } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import useAlerts from '../hooks/useAlerts';
+import AlertCard from '../components/AlertCard';
+
+export default function AlertsHistoryScreen() {
+  const router = useRouter();
+  const { data, error, isLoading } = useAlerts();
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 justify-center items-center">
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View className="flex-1 justify-center items-center">
+        <Text>Error al cargar alertas</Text>
+      </View>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <View className="flex-1 justify-center items-center">
+        <Text>No hay alertas</Text>
+      </View>
+    );
+  }
+
+  return (
+    <SafeAreaView className="flex-1 bg-white dark:bg-neutral-900" edges={['left','right','bottom']}>
+      <FlatList
+        contentContainerStyle={{ padding: 16 }}
+        data={data}
+        keyExtractor={(item) => item.id.toString()}
+        renderItem={({ item }) => (
+          <AlertCard
+            alert={item}
+            onPress={() =>
+              router.push({ pathname: 'AlertDetailsScreen', params: { id: item.id } })
+            }
+          />
+        )}
+      />
+    </SafeAreaView>
+  );
+}

--- a/frontend/components/AlertCard.jsx
+++ b/frontend/components/AlertCard.jsx
@@ -1,0 +1,39 @@
+import { Pressable, Text } from 'react-native';
+import dayjs from '../utils/date';
+
+export const colorForLevel = (l) => ({
+  1: '#4ade80',
+  2: '#4ade80',
+  3: '#facc15',
+  4: '#f87171',
+  5: '#ef4444',
+}[l]);
+
+export const bgForLevel = (l) => ({
+  1: 'rgba(74,222,128,.15)',
+  2: 'rgba(74,222,128,.15)',
+  3: 'rgba(250,204,21,.15)',
+  4: 'rgba(248,113,113,.15)',
+  5: 'rgba(239,68,68,.15)',
+}[l]);
+
+export default function AlertCard({ alert, onPress }) {
+  return (
+    <Pressable
+      className="p-4 mb-3 rounded-lg border"
+      style={{
+        borderColor: colorForLevel(alert.level),
+        backgroundColor: bgForLevel(alert.level),
+      }}
+      onPress={onPress}
+    >
+      <Text className="font-bold text-base mb-1">{alert.title}</Text>
+      <Text className="text-xs text-gray-700 dark:text-gray-300 mb-1">
+        {alert.short}
+      </Text>
+      <Text className="text-[10px] text-gray-500 dark:text-gray-400">
+        {dayjs(alert.timestamp).fromNow()}
+      </Text>
+    </Pressable>
+  );
+}

--- a/frontend/hooks/useAlerts.js
+++ b/frontend/hooks/useAlerts.js
@@ -1,0 +1,17 @@
+import useSWR from 'swr';
+
+const API_URL = 'https://metaquetzal-production.up.railway.app';
+
+const fetcher = async () => {
+  const res = await fetch(`${API_URL}/alerts?limit=50`);
+  if (!res.ok) throw new Error('Error fetching alerts');
+  return res.json();
+};
+
+export default function useAlerts() {
+  const { data, error, isLoading, mutate } = useSWR('alerts', fetcher, {
+    refreshInterval: 60000,
+  });
+
+  return { data, error, isLoading, mutate };
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@tamagui/themes": "^1.116.15",
         "@tamagui/web": "1.116.15",
         "axios": "^1.9.0",
+        "dayjs": "^1.11.10",
         "expo": "~53.0.0",
         "expo-audio": "^0.4.6",
         "expo-camera": "~16.1.7",
@@ -41,6 +42,7 @@
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
         "react-native-toast-message": "^2.3.3",
+        "swr": "^2.2.4",
         "tailwindcss": "^3.4.15",
         "tamagui": "^1.116.15"
       },
@@ -10178,6 +10180,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -10300,6 +10308,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -18701,6 +18718,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/synckit": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,9 @@
     "react-native-screens": "~4.11.1",
     "react-native-toast-message": "^2.3.3",
     "tailwindcss": "^3.4.15",
-    "tamagui": "^1.116.15"
+    "tamagui": "^1.116.15",
+    "swr": "^2.2.4",
+    "dayjs": "^1.11.10"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/frontend/utils/date.js
+++ b/frontend/utils/date.js
@@ -1,0 +1,7 @@
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+
+dayjs.extend(relativeTime);
+dayjs.locale('es');
+
+export default dayjs;


### PR DESCRIPTION
## Summary
- add custom `useAlerts` hook using SWR
- implement `AlertCard` component with color helpers
- add `AlertsHistoryScreen` using hook and FlatList
- refactor `AlertDetailsScreen` to fetch data from backend
- setup dayjs with relative time plugin
- include `swr` and `dayjs` dependencies

## Testing
- `npm install`
- `npm run lint` *(fails: many prettier errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_688d22d45ab8833196ad93bbe1310b96