### PR TITLE
style: improve alert details dark mode

### DIFF
--- a/frontend/app/AlertDetailsScreen.jsx
+++ b/frontend/app/AlertDetailsScreen.jsx
@@ -14,14 +14,11 @@ import dayjs from "../utils/date";
 const API_URL = "https://metaquetzal-production.up.railway.app";
 
 // helpers
-const colorForLevel = {
-  1: "#4ade80",
-  2: "#4ade80",
-  3: "#facc15",
-  4: "#f87171",
-  5: "#ef4444",
+const colorForScore = (s) => {
+  if (s <= 33) return "#4ade80"; // green
+  if (s <= 66) return "#facc15"; // yellow
+  return "#ef4444"; // red
 };
-const bgSoft = (l) => colorForLevel[l] + "1A"; // 10 % opacity
 
 export default function AlertDetailsScreen() {
   const { id } = useLocalSearchParams();
@@ -72,13 +69,13 @@ export default function AlertDetailsScreen() {
     );
 
   /* UI */
-  const levelColor = colorForLevel[alert.level] ?? "#60a5fa";
+  const bannerColor = colorForScore(alert.score ?? 0);
 
   return (
     <View className="flex-1 bg-white dark:bg-neutral-900">
       {/* banner */}
       <View
-        style={{ backgroundColor: levelColor }}
+        style={{ backgroundColor: bannerColor }}
         className="pt-10 pb-6 px-5 items-center"
       >
         <MaterialCommunityIcons
@@ -109,12 +106,20 @@ export default function AlertDetailsScreen() {
         {/* métricas */}
         <View className="flex-row justify-around bg-neutral-100 dark:bg-neutral-800 rounded-xl p-4">
           <View className="items-center">
-            <Text className="font-bold text-lg">{alert.level}</Text>
-            <Text className="text-xs">Nivel</Text>
+            <Text className="font-bold text-lg text-phase2Titles dark:text-phase2TitlesDark">
+              {alert.level}
+            </Text>
+            <Text className="text-xs text-phase2SecondaryTxt dark:text-phase2SecondaryTxtDark">
+              Nivel
+            </Text>
           </View>
           <View className="items-center">
-            <Text className="font-bold text-lg">{alert.score}</Text>
-            <Text className="text-xs">Score</Text>
+            <Text className="font-bold text-lg text-phase2Titles dark:text-phase2TitlesDark">
+              {alert.score}
+            </Text>
+            <Text className="text-xs text-phase2SecondaryTxt dark:text-phase2SecondaryTxtDark">
+              Score
+            </Text>
           </View>
         </View>
 
@@ -125,7 +130,10 @@ export default function AlertDetailsScreen() {
               Recomendaciones
             </Text>
             {alert.recommendations.map((r, i) => (
-              <Text key={i} className="mb-1">
+              <Text
+                key={i}
+                className="mb-1 text-phase2SecondaryTxt dark:text-phase2SecondaryTxtDark"
+              >
                 • {r}
               </Text>
             ))}
@@ -139,34 +147,51 @@ export default function AlertDetailsScreen() {
               Factores
             </Text>
             {alert.factors.map((f, i) => (
-              <Text key={i} className="mb-1">
+              <Text
+                key={i}
+                className="mb-1 text-phase2SecondaryTxt dark:text-phase2SecondaryTxtDark"
+              >
                 • {f}
               </Text>
             ))}
-            <Text className="mb-1">• Latitud</Text>
-            <Text className="mb-1">• Altitud</Text>
-            <Text className="mb-1">• Radio</Text>
-            <Text className="mb-1">• Vientos</Text>
+            <Text className="mb-1 text-phase2SecondaryTxt dark:text-phase2SecondaryTxtDark">
+              • Latitud
+            </Text>
+            <Text className="mb-1 text-phase2SecondaryTxt dark:text-phase2SecondaryTxtDark">
+              • Altitud
+            </Text>
+            <Text className="mb-1 text-phase2SecondaryTxt dark:text-phase2SecondaryTxtDark">
+              • Radio
+            </Text>
+            <Text className="mb-1 text-phase2SecondaryTxt dark:text-phase2SecondaryTxtDark">
+              • Vientos
+            </Text>
           </View>
         )}
 
         {/* id */}
-        <Text className="text-xs text-neutral-500 mt-4">ID: {alert.id}</Text>
+        <Text className="text-xs text-neutral-500 dark:text-phase2SecondaryTxtDark mt-4">
+          ID: {alert.id}
+        </Text>
       </ScrollView>
 
       {/* acciones */}
       <View className="px-4 pb-6 flex-row justify-between gap-3">
         <TouchableOpacity
           className="flex-1 bg-phase2Buttons dark:bg-phase2ButtonsDark rounded-2xl py-3 items-center"
-          onPress={() => console.log("TODO: abrir mapa", id)}
+          onPress={() => router.push("/MapScreen")}
         >
-          <Text className="text-white font-bold">Ver en mapa</Text>
+          <Text className="text-white dark:text-phase2TitlesDark font-bold">
+            Ver en mapa
+          </Text>
         </TouchableOpacity>
         <TouchableOpacity
           className="flex-1 bg-phase2Buttons dark:bg-phase2ButtonsDark rounded-2xl py-3 items-center"
           onPress={() => console.log("TODO: Boletín oficial", id)}
         >
-          <Text className="text-white font-bold">Ver Boletín oficial</Text>
+          <Text className="text-white dark:text-phase2TitlesDark font-bold">
+            Ver Boletín oficial
+          </Text>
         </TouchableOpacity>
       </View>
     </View>


### PR DESCRIPTION
## Summary
- style alert details screen for dark mode coherence
- color banner based on alert score (green/yellow/red)
- hook map button to navigate to the map screen

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prettier errors across project)*

------
https://chatgpt.com/codex/tasks/task_e_688fbf6c5bec833196ac75668ffbcfb4