### PR TITLE
feat: color alerts by level

### DIFF
--- a/frontend/app/AlertDetailsScreen.jsx
+++ b/frontend/app/AlertDetailsScreen.jsx
@@ -10,15 +10,9 @@ import {
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import dayjs from "../utils/date";
+import { colorForLevel } from "../components/AlertCard";
 
 const API_URL = "https://metaquetzal-production.up.railway.app";
-
-// helpers
-const colorForScore = (s) => {
-  if (s <= 33) return "#4ade8080";
-  if (s <= 66) return "#facc1580";
-  return "#ef444480";
-};
 
 export default function AlertDetailsScreen() {
   const { id } = useLocalSearchParams();
@@ -69,10 +63,14 @@ export default function AlertDetailsScreen() {
     );
 
   /* UI */
-  const bannerColor = colorForScore(alert.score ?? 0);
+  const baseColor = colorForLevel(alert.level);
+  const bannerColor = `${baseColor}80`;
 
   return (
-    <View className="flex-1 bg-white dark:bg-neutral-900">
+    <View
+      className="flex-1 bg-white dark:bg-neutral-900"
+      style={{ borderColor: baseColor, borderWidth: 2 }}
+    >
       {/* banner */}
       <View
         style={{ backgroundColor: bannerColor }}
@@ -179,6 +177,7 @@ export default function AlertDetailsScreen() {
       <View className="px-4 pb-6 flex-row justify-between gap-3">
         <TouchableOpacity
           className="flex-1 bg-phase2Buttons dark:bg-phase2ButtonsDark rounded-2xl py-3 items-center"
+          android_ripple={{ color: "#ffffff33" }}
           onPress={() => router.push("/MapScreen")}
         >
           <Text className="text-white dark:text-phase2TitlesDark font-bold">
@@ -187,6 +186,7 @@ export default function AlertDetailsScreen() {
         </TouchableOpacity>
         <TouchableOpacity
           className="flex-1 bg-phase2Buttons dark:bg-phase2ButtonsDark rounded-2xl py-3 items-center"
+          android_ripple={{ color: "#ffffff33" }}
           onPress={() => console.log("TODO: Boletín oficial", id)}
         >
           <Text className="text-white dark:text-phase2TitlesDark font-bold">

--- a/frontend/components/AlertCard.jsx
+++ b/frontend/components/AlertCard.jsx
@@ -3,11 +3,14 @@ import { MaterialCommunityIcons } from "@expo/vector-icons";
 import dayjs from "../utils/date";
 import { useLocalSearchParams, useRouter } from "expo-router";
 
-const colorForScore = (s) => {
-  if (s <= 33) return "#4ade8033";
-  if (s <= 66) return "#facc1533";
-  return "#ef444433";
-};
+export const colorForLevel = (l) =>
+  ({
+    1: "#3B82F6", // azul
+    2: "#22C55E", // verde
+    3: "#FACC15", // amarillo
+    4: "#FB923C", // naranja
+    5: "#EF4444", // rojo
+  }[l]);
 
 export default function AlertCard({ alert, onPress }) {
   const { id, level, title, short: description, timestamp } = alert;
@@ -15,7 +18,7 @@ export default function AlertCard({ alert, onPress }) {
   const router = useRouter();
   const { id: paramId } = useLocalSearchParams();
 
-  const bannerColor = colorForScore(alert.score ?? 0);
+  const bannerColor = `${colorForLevel(level)}33`;
 
   return (
     <Pressable
@@ -47,6 +50,7 @@ export default function AlertCard({ alert, onPress }) {
         <View className="space-y-2 w-2/6 h-24">
           <TouchableOpacity
             className="bg-phase2Buttons dark:bg-phase2ButtonsDark rounded-lg justify-center items-center h-10 ml-auto mb-2"
+            android_ripple={{ color: "#ffffff33" }}
             onPress={() => router.push("/MapScreen")}
           >
             <Text className="text-white dark:text-phase2TitlesDark font-bold px-2">
@@ -55,6 +59,7 @@ export default function AlertCard({ alert, onPress }) {
           </TouchableOpacity>
           <TouchableOpacity
             className="bg-phase2Buttons dark:bg-phase2ButtonsDark rounded-lg justify-center items-center h-10 ml-auto"
+            android_ripple={{ color: "#ffffff33" }}
             onPress={onPress}
           >
             <Text className="text-white dark:text-phase2TitlesDark font-bold px-2">


### PR DESCRIPTION
## Summary
- color alert cards and details by level using five unique colors
- add ripple feedback to alert action buttons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prettier errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6893e624eb3483319aeb2a1868dd4af8