### PR TITLE
Initialize analytics before tracking events

### DIFF
--- a/frontend/app/_layout.jsx
+++ b/frontend/app/_layout.jsx
@@ -25,6 +25,10 @@ export default function Layout() {
 
   const { colorScheme } = useColorScheme();
 
+  useEffect(() => {
+    initAnalytics().catch(console.error);
+  }, []);
+
   // ⚡ Solicitar token FCM al montar
   useEffect(() => {
     registerForPushNotificationsAsync()
@@ -39,8 +43,9 @@ export default function Layout() {
     setForegroundNotificationHandler();
 
     // 👇 Cuando el usuario pulse la notificación
-    const sub = addNotificationResponseListener((data) => {
+    const sub = addNotificationResponseListener(async (data) => {
       if (data?.alertId) {
+        await initAnalytics();
         track("push_open", {
           alertId: String(data.alertId),
           alertLevel: data.alertLevel ? Number(data.alertLevel) : undefined,
@@ -64,6 +69,7 @@ export default function Layout() {
       const alertLevel =
         initial?.notification?.request?.content?.data?.alertLevel;
       if (alertId) {
+        await initAnalytics();
         track("push_open", {
           alertId: String(alertId),
           alertLevel: alertLevel ? Number(alertLevel) : undefined,
@@ -80,7 +86,12 @@ export default function Layout() {
   // Registra la pantalla actual en Mixpanel
   const pathname = usePathname();
   useEffect(() => {
-    if (pathname) track("screen_view", { screen: pathname });
+    if (pathname) {
+      (async () => {
+        await initAnalytics();
+        track("screen_view", { screen: pathname });
+      })();
+    }
   }, [pathname]);
 
   const headerBg =


### PR DESCRIPTION
## Summary
- initialize analytics when the layout mounts
- await analytics init before tracking notification opens and screen views

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 117 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68953d2f3da08331a86cb5e77729b2dc