### PR TITLE
Add Mixpanel tracking for alerts, pushes, and user actions

### DIFF
--- a/frontend/app/AlertDetailsScreen.jsx
+++ b/frontend/app/AlertDetailsScreen.jsx
@@ -11,6 +11,7 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import dayjs from "../utils/date";
 import { colorForLevel } from "../components/AlertCard";
+import { track } from "../utils/analytics";
 
 const API_URL = "https://metaquetzal-production.up.railway.app";
 
@@ -42,6 +43,16 @@ export default function AlertDetailsScreen() {
       live = false;
     };
   }, [id]);
+
+  useEffect(() => {
+    if (alert) {
+      track("alert_details_view", {
+        alertId: String(alert.id),
+        level: Number(alert.level),
+        score: Number(alert.score ?? 0),
+      });
+    }
+  }, [alert]);
 
   /* estados */
   if (loading)
@@ -178,7 +189,14 @@ export default function AlertDetailsScreen() {
         <TouchableOpacity
           className="flex-1 bg-phase2Buttons dark:bg-phase2ButtonsDark rounded-2xl py-3 items-center"
           android_ripple={{ color: "#ffffff33" }}
-          onPress={() => router.push("/MapScreen")}
+          onPress={() => {
+            track("details_map_tap", {
+              alertId: String(alert.id),
+              level: Number(alert.level),
+              score: Number(alert.score ?? 0),
+            });
+            router.push("/MapScreen");
+          }}
         >
           <Text className="text-white dark:text-phase2TitlesDark font-bold">
             Ver en mapa
@@ -187,7 +205,14 @@ export default function AlertDetailsScreen() {
         <TouchableOpacity
           className="flex-1 bg-phase2Buttons dark:bg-phase2ButtonsDark rounded-2xl py-3 items-center"
           android_ripple={{ color: "#ffffff33" }}
-          onPress={() => console.log("TODO: Boletín oficial", id)}
+          onPress={() => {
+            track("details_boletin_tap", {
+              alertId: String(alert.id),
+              level: Number(alert.level),
+              score: Number(alert.score ?? 0),
+            });
+            console.log("TODO: Boletín oficial", id);
+          }}
         >
           <Text className="text-white dark:text-phase2TitlesDark font-bold">
             Ver Boletín oficial

--- a/frontend/app/FeedbackScreen.jsx
+++ b/frontend/app/FeedbackScreen.jsx
@@ -12,6 +12,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useColorScheme } from "nativewind";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { submitFeedback } from "../services/feedbackService";
+import { track } from "../utils/analytics";
 
 export default function FeedbackScreen() {
   const { colorScheme } = useColorScheme();
@@ -22,7 +23,7 @@ export default function FeedbackScreen() {
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
 
-  // Validation 
+  // Validation
   const validate = () => {
     const newErrors = {};
     if (rating === 0)
@@ -42,6 +43,11 @@ export default function FeedbackScreen() {
     setLoading(true);
     try {
       await submitFeedback({ rating, email, message }); // ⬅︎ nuevo
+      track("feedback_submit", {
+        hasText: message.trim().length > 0,
+        length: message.trim().length,
+        screen: "FeedbackScreen",
+      });
 
       setSuccess(true);
       setRating(0);

--- a/frontend/app/SettingsScreen.jsx
+++ b/frontend/app/SettingsScreen.jsx
@@ -6,6 +6,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { Link } from "expo-router";
 import { Ionicons, MaterialCommunityIcons } from "@expo/vector-icons";
 import { useColorScheme } from "nativewind";
+import { track } from "../utils/analytics";
 
 export default function SettingsScreen() {
   const [isNotificationsEnabled, setNotificationsEnabled] = useState(false);
@@ -23,7 +24,11 @@ export default function SettingsScreen() {
   const handleDaltonicToggle = () =>
     Alert.alert("¡Próximamente!", "Esta función estará disponible muy pronto.");
 
-  const handleDarkModeToggle = () => toggleColorScheme();
+  const handleDarkModeToggle = () => {
+    const newTheme = colorScheme === "dark" ? "light" : "dark";
+    toggleColorScheme();
+    track("theme_change", { theme: newTheme });
+  };
 
   /** shared row styling */
   const row =

--- a/frontend/app/_layout.jsx
+++ b/frontend/app/_layout.jsx
@@ -8,6 +8,7 @@ import { DaltonicModeProvider } from "../context/DaltonicModeContext";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useColorScheme } from "nativewind";
 import { useEffect } from "react";
+import { AppState } from "react-native";
 import { useRouter } from "expo-router";
 import {
   registerForPushNotificationsAsync,
@@ -93,6 +94,15 @@ export default function Layout() {
       })();
     }
   }, [pathname]);
+
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (state) => {
+      if (state === "background") {
+        track("app_background");
+      }
+    });
+    return () => sub.remove();
+  }, []);
 
   const headerBg =
     colorScheme === "dark" ? "rgb(40, 60, 80)" : "rgb(60, 200, 220)";

--- a/frontend/hooks/useAlerts.js
+++ b/frontend/hooks/useAlerts.js
@@ -1,15 +1,31 @@
-import useSWR from 'swr';
+import useSWR from "swr";
+import { track } from "../utils/analytics";
 
-const API_URL = 'https://metaquetzal-production.up.railway.app';
+const API_URL = "https://metaquetzal-production.up.railway.app";
 
 const fetcher = async () => {
-  const res = await fetch(`${API_URL}/alerts?limit=50`);
-  if (!res.ok) throw new Error('Error fetching alerts');
-  return res.json();
+  const start = Date.now();
+  track("alerts_fetch_start");
+  try {
+    const res = await fetch(`${API_URL}/alerts?limit=50`);
+    if (!res.ok) throw new Error("Error fetching alerts");
+    const data = await res.json();
+    track("alerts_fetch_success", {
+      duration_ms: Date.now() - start,
+      list_count: Array.isArray(data) ? data.length : 0,
+    });
+    return data;
+  } catch (e) {
+    track("alerts_fetch_error", {
+      duration_ms: Date.now() - start,
+      error: String(e?.message || e),
+    });
+    throw e;
+  }
 };
 
 export default function useAlerts() {
-  const { data, error, isLoading, mutate } = useSWR('alerts', fetcher, {
+  const { data, error, isLoading, mutate } = useSWR("alerts", fetcher, {
     refreshInterval: 60000,
   });
 


### PR DESCRIPTION
## Summary
- track alert fetch lifecycle with duration and count
- log alert detail views and detail screen actions
- capture push permission, foreground receipt, theme changes, feedback, and app background events

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Prettier errors in untouched files)*
- `npx eslint hooks/useAlerts.js app/AlertDetailsScreen.jsx app/SettingsScreen.jsx app/FeedbackScreen.jsx app/_layout.jsx utils/pushNotifications.js`


------
https://chatgpt.com/codex/tasks/task_e_68954ec56f0c8331bdd81538b46b09ba