### PR TITLE
feat: add analytics to AI chat

### DIFF
--- a/frontend/app/(tabs)/ChatAIScreen.jsx
+++ b/frontend/app/(tabs)/ChatAIScreen.jsx
@@ -24,6 +24,7 @@ import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { sendMessage } from "../../api/sendMessage";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import PageTitle from "../../components/PageTitle";
+import { track } from "../../utils/analytics";
 
 export default function ChatAIScreen() {
   const [input, setInput] = useState("");
@@ -38,6 +39,11 @@ export default function ChatAIScreen() {
       fontSize: 18,
     },
   };
+
+  // Track screen view
+  React.useEffect(() => {
+    track("ai_screen_view");
+  }, []);
 
   // Persistent storage functions
   const loadMessages = async () => {
@@ -74,6 +80,7 @@ export default function ChatAIScreen() {
         {
           text: "Reiniciar",
           onPress: () => {
+            track("ai_restart_conversation");
             setMessages([]);
             saveMessages([]);
           },
@@ -104,6 +111,7 @@ export default function ChatAIScreen() {
     setMessages((prev) => [...prev, userMessage]);
     setInput("");
     setIsLoading(true);
+    track("ai_message_send", { length: userMessage.text.length });
 
     try {
       const aiResponse = await sendMessage(userMessage.text);
@@ -113,7 +121,9 @@ export default function ChatAIScreen() {
         timestamp: new Date().toISOString(),
       };
       setMessages((prev) => [...prev, botMessage]);
+      track("ai_response_received", { length: aiResponse.length });
     } catch (error) {
+      track("ai_response_error");
       Alert.alert("Error", "No se pudo enviar el mensaje. Intente nuevamente.");
     } finally {
       setIsLoading(false);


### PR DESCRIPTION
## Summary
- track AI chat screen open, message send, responses, and conversation resets

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 94 problems)


------
https://chatgpt.com/codex/tasks/task_e_6895525a55e08331b675f4c72d1b13d4