### PR TITLE
Flush analytics events on app background

### DIFF
--- a/frontend/app/_layout.jsx
+++ b/frontend/app/_layout.jsx
@@ -17,7 +17,7 @@ import {
 } from "../utils/pushNotifications";
 import * as Notifications from "expo-notifications";
 import Toast from "react-native-toast-message";
-import { initAnalytics, track } from "../utils/analytics";
+import { initAnalytics, track, flush } from "../utils/analytics";
 import { usePathname } from "expo-router";
 
 /* ---------- Layout raíz ---------- */
@@ -99,6 +99,7 @@ export default function Layout() {
     const sub = AppState.addEventListener("change", (state) => {
       if (state === "background") {
         track("app_background");
+        flush();
       }
     });
     return () => sub.remove();


### PR DESCRIPTION
## Summary
- import `flush` from analytics helper
- flush queued events when app transitions to background

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 97 problems)*
- `npx eslint app/_layout.jsx` *(warnings: React Hook useEffect has a missing dependency: 'router')*

------
https://chatgpt.com/codex/tasks/task_e_6895643d23c88331a480388ff735bc69