### PR TITLE
feat: align alert colors with Saffir–Simpson categories

### DIFF
--- a/backend/src/services/riskAnalysis.js
+++ b/backend/src/services/riskAnalysis.js
@@ -223,15 +223,15 @@ export function generateAlerts(riskAnalysis, currentWeather) {
 export function generateBanner(riskAnalysis) {
   const banners = {
     1: {
-      color: '#3B82F6',
-      backgroundColor: '#DBEAFE',
+      color: '#22C55E',
+      backgroundColor: '#DCFCE7',
       text: '🌀 CATEGORÍA 1',
       description: 'Vientos 119–153 km/h',
       icon: '🌀',
     },
     2: {
-      color: '#22C55E',
-      backgroundColor: '#DCFCE7',
+      color: '#15803D',
+      backgroundColor: '#BBF7D0',
       text: '🌀 CATEGORÍA 2',
       description: '154–177 km/h',
       icon: '🌀',
@@ -244,15 +244,15 @@ export function generateBanner(riskAnalysis) {
       icon: '🌀',
     },
     4: {
-      color: '#FB923C',
-      backgroundColor: '#FFEDD5',
+      color: '#EF4444',
+      backgroundColor: '#FEE2E2',
       text: '🌀 CATEGORÍA 4',
       description: '209–251 km/h',
       icon: '🌀',
     },
     5: {
-      color: '#EF4444',
-      backgroundColor: '#FEE2E2',
+      color: '#C026D3',
+      backgroundColor: '#FAE8FF',
       text: '🌀 CATEGORÍA 5',
       description: '≥ 252 km/h',
       icon: '🌀',

--- a/frontend/components/AlertCard.jsx
+++ b/frontend/components/AlertCard.jsx
@@ -2,16 +2,16 @@ import { View, Text, Pressable, TouchableOpacity } from "react-native";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import dayjs from "../utils/date";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { track } from '../utils/analytics';
+import { track } from "../utils/analytics";
 
 export const colorForLevel = (l) =>
   ({
-    1: "#3B82F6", // azul
-    2: "#22C55E", // verde
+    1: "#22C55E", // verde
+    2: "#15803D", // verde oscuro
     3: "#FACC15", // amarillo
-    4: "#FB923C", // naranja
-    5: "#EF4444", // rojo
-  }[l]);
+    4: "#EF4444", // rojo
+    5: "#C026D3", // morado
+  })[l];
 
 export default function AlertCard({ alert, onPress }) {
   const { id, level, title, short: description, timestamp } = alert;
@@ -26,14 +26,14 @@ export default function AlertCard({ alert, onPress }) {
       className="w-full border-b border-b-gray-200 dark:border-b-gray-700 rounded-lg mb-2"
       style={{ backgroundColor: bannerColor }}
       android_ripple={{ color: "#ccc" }}
-        onPress={() => {
-         track('alert_card_tap', {
-           alertId: String(alert.id),
-           level: Number(alert.level),
-           score: Number(alert.score ?? 0),
-         });
-          onPress?.();
-        }}
+      onPress={() => {
+        track("alert_card_tap", {
+          alertId: String(alert.id),
+          level: Number(alert.level),
+          score: Number(alert.score ?? 0),
+        });
+        onPress?.();
+      }}
     >
       {/* fila título + icono + tiempo */}
       <View className="flex-row items-center justify-between p-4">


### PR DESCRIPTION
## Summary
- map hurricane categories to new color palette
- adjust alert banner colors for Saffir–Simpson categories

## Testing
- `cd backend && npm test`
- `cd frontend && npx eslint components/AlertCard.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68957fe81dfc83319c07fc7df0a49b69