### PR TITLE
feat: persist theme selection

### DIFF
--- a/frontend/context/ThemeContext.jsx
+++ b/frontend/context/ThemeContext.jsx
@@ -1,12 +1,35 @@
-import React, { createContext, useContext } from "react";
+import React, { createContext, useContext, useEffect, useState } from "react";
 import { useColorScheme } from "nativewind";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 // Crea el contexto
 const ThemeContext = createContext();
 
 // Proveedor del tema
 export const ThemeProvider = ({ children }) => {
-  const { colorScheme, toggleColorScheme } = useColorScheme();
+  const { colorScheme, setColorScheme, toggleColorScheme } = useColorScheme();
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  // Load saved theme on mount
+  useEffect(() => {
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem("theme");
+        if (stored) {
+          setColorScheme(stored);
+        }
+      } finally {
+        setIsLoaded(true);
+      }
+    })();
+  }, [setColorScheme]);
+
+  // Persist theme whenever it changes
+  useEffect(() => {
+    if (isLoaded) {
+      AsyncStorage.setItem("theme", colorScheme);
+    }
+  }, [colorScheme, isLoaded]);
 
   return (
     <ThemeContext.Provider value={{ colorScheme, toggleColorScheme }}>


### PR DESCRIPTION
## Summary
- store user's selected theme in AsyncStorage
- restore theme on load so dark/light mode persists

## Testing
- `npm run lint` *(fails: 77 errors, 12 warnings — existing issues)*


------
https://chatgpt.com/codex/tasks/task_e_689d28c5247c83319c1a191c52213545