### PR TITLE
Refine chat UI spacing and error handling

### DIFF
--- a/frontend/api/sendMessage.jsx
+++ b/frontend/api/sendMessage.jsx
@@ -8,6 +8,9 @@ export const sendMessage = async (question) => {
     return response.data.response;
   } catch (error) {
     console.error("AI Request Error:", error.response?.data || error.message);
-    return "Lo siento, ocurrió un error al contactar al asistente.";
+    if (!error.response) {
+      throw new Error("NO_CONNECTION");
+    }
+    throw new Error(error.response?.data?.message || "SERVER_ERROR");
   }
 };


### PR DESCRIPTION
## Summary
- Reduce vertical spacing between chat messages and thinking indicator
- Standardize message font sizes across user, bot, and error text
- Add detailed AI error handling with red chat messages for failures

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d2b273e648331b118c360dc6027e1