### PR TITLE
Fix infinite dark mode toggle

### DIFF
--- a/frontend/app/SettingsScreen.jsx
+++ b/frontend/app/SettingsScreen.jsx
@@ -10,7 +10,7 @@ import { track } from "../utils/analytics";
 
 export default function SettingsScreen() {
   const [isNotificationsEnabled, setNotificationsEnabled] = useState(false);
-  const { colorScheme, toggleColorScheme } = useColorScheme(); // "light" | "dark"
+  const { colorScheme, setColorScheme } = useColorScheme(); // "light" | "dark"
 
   /* ──────────────── colour palette (matches MoreScreen) ──────────────── */
   const iconColor = colorScheme === "dark" ? "rgb(60, 200, 220)" : "#1F2937"; // blue‑ish / gray‑800
@@ -24,9 +24,9 @@ export default function SettingsScreen() {
   const handleDaltonicToggle = () =>
     Alert.alert("¡Próximamente!", "Esta función estará disponible muy pronto.");
 
-  const handleDarkModeToggle = () => {
-    const newTheme = colorScheme === "dark" ? "light" : "dark";
-    toggleColorScheme();
+  const handleDarkModeToggle = (value) => {
+    const newTheme = value ? "dark" : "light";
+    setColorScheme(newTheme);
     track("theme_change", { theme: newTheme });
   };
 


### PR DESCRIPTION
## Summary
- prevent Settings screen dark mode switch from endlessly flipping between themes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple Prettier errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689d2d5522b88331a394847f6840b345