### PR TITLE
feat: add affected users siat endpoint

### DIFF
--- a/backend/app/features/siat/router.py
+++ b/backend/app/features/siat/router.py
@@ -1,9 +1,9 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
-from app.features.siat.schemas import RunCycleResponse, UserSiatStatus
-from app.features.siat.service import get_user_siat_status, run_cycle
+from app.features.siat.schemas import AffectedUsersResponse, RunCycleResponse, UserSiatStatus
+from app.features.siat.service import get_affected_users, get_user_siat_status, run_cycle
 from app.middleware.api_key_auth import verify_api_key
 
 router = APIRouter()
@@ -21,6 +21,22 @@ async def siat_run_cycle(db: AsyncSession = Depends(get_db)):
     Protected by X-API-Key header.
     """
     return await run_cycle(db)
+
+
+@router.get(
+    "/api/v1/siat/affected-users",
+    response_model=AffectedUsersResponse,
+    dependencies=[Depends(verify_api_key)],
+)
+async def siat_affected_users(
+    lat: float,
+    lon: float,
+    radius_km: float = Query(default=500.0, gt=0),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return users within radius_km of (lat, lon). Protected by X-API-Key header."""
+    users = await get_affected_users(db, lat, lon, radius_km)
+    return {"total": len(users), "users": users}
 
 
 @router.get(

--- a/backend/app/features/siat/schemas.py
+++ b/backend/app/features/siat/schemas.py
@@ -26,3 +26,13 @@ class RunCycleResponse(BaseModel):
     users_evaluated: int
     notifications_sent: int
     assessments: list[AssessmentResult]
+
+
+class AffectedUser(BaseModel):
+    user_id: int
+    distance_km: float
+
+
+class AffectedUsersResponse(BaseModel):
+    total: int
+    users: list[AffectedUser]

--- a/backend/app/features/siat/service.py
+++ b/backend/app/features/siat/service.py
@@ -23,7 +23,7 @@ from firebase_admin import messaging
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
-from app.features.siat.evaluator import evaluate_user
+from app.features.siat.evaluator import evaluate_user, haversine_km
 from app.features.siat.providers.nhc import fetch_active_cyclones
 from app.features.notifications.service import get_tokens_for_users
 
@@ -154,6 +154,20 @@ async def _get_users_with_location(db: AsyncSession) -> list:
         text("SELECT id, lat, lon FROM users WHERE lat IS NOT NULL AND lon IS NOT NULL")
     )
     return result.mappings().all()
+
+
+async def get_affected_users(
+    db: AsyncSession, lat: float, lon: float, radius_km: float = 500.0
+) -> list[dict]:
+    """Return users within radius_km of (lat, lon), sorted by distance ascending."""
+    users = await _get_users_with_location(db)
+    within = []
+    for user in users:
+        dist = haversine_km(lat, lon, user["lat"], user["lon"])
+        if dist <= radius_km:
+            within.append({"user_id": user["id"], "distance_km": round(dist, 2)})
+    within.sort(key=lambda x: x["distance_km"])
+    return within
 
 
 async def _get_user_state(db: AsyncSession, user_id: int) -> dict | None:

--- a/backend/app/features/siat/tests/test_router.py
+++ b/backend/app/features/siat/tests/test_router.py
@@ -177,3 +177,61 @@ def test_evaluate_user_distant_slow_cyclone_is_azul():
 
     assert result["out_of_range"] is False
     assert result["siat_level"] <= 2  # AZUL or VERDE
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/siat/affected-users
+# ---------------------------------------------------------------------------
+
+_FAKE_AFFECTED = [
+    {"user_id": 1, "distance_km": 120.5},
+    {"user_id": 4, "distance_km": 340.2},
+]
+
+
+def test_affected_users_happy_path():
+    with patch(f"{_ROUTER}.get_affected_users", new_callable=AsyncMock, return_value=_FAKE_AFFECTED):
+        r = client.get(
+            "/api/v1/siat/affected-users",
+            params={"lat": 20.5, "lon": -98.0},
+            headers=API_KEY_HEADERS,
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 2
+    assert body["users"][0]["user_id"] == 1
+    assert body["users"][0]["distance_km"] == 120.5
+
+
+def test_affected_users_empty_radius():
+    with patch(f"{_ROUTER}.get_affected_users", new_callable=AsyncMock, return_value=[]):
+        r = client.get(
+            "/api/v1/siat/affected-users",
+            params={"lat": 20.5, "lon": -98.0, "radius_km": 10},
+            headers=API_KEY_HEADERS,
+        )
+    assert r.status_code == 200
+    assert r.json() == {"total": 0, "users": []}
+
+
+def test_affected_users_requires_api_key():
+    r = client.get("/api/v1/siat/affected-users", params={"lat": 20.5, "lon": -98.0})
+    assert r.status_code == 422
+
+
+def test_affected_users_wrong_api_key():
+    r = client.get(
+        "/api/v1/siat/affected-users",
+        params={"lat": 20.5, "lon": -98.0},
+        headers={"X-Api-Key": "wrong"},
+    )
+    assert r.status_code == 401
+
+
+def test_affected_users_invalid_radius():
+    r = client.get(
+        "/api/v1/siat/affected-users",
+        params={"lat": 20.5, "lon": -98.0, "radius_km": 0},
+        headers=API_KEY_HEADERS,
+    )
+    assert r.status_code == 422


### PR DESCRIPTION
## Qué incluye
- GET `/api/v1/siat/affected-users`
- Auth por `X-Api-Key`
- Reutilización de `_get_users_with_location()` y `haversine_km()`
- Validación de `radius_km > 0`
- Tests de integración y edge cases

## Tests
- `python3 -m pytest app/features/siat/tests/ -v`
- Resultado: 16 passed

## Fuera de alcance
- Notification preferences
- SMN push automático
- Frontend
- AI summary