### PR TITLE
feat: add SMN automatic alert notifications

### DIFF
--- a/backend/app/features/siat/service.py
+++ b/backend/app/features/siat/service.py
@@ -26,6 +26,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from app.features.siat.evaluator import evaluate_user, haversine_km
 from app.features.siat.providers.nhc import fetch_active_cyclones
 from app.features.notifications.service import get_tokens_for_users
+from app.features.notification_preferences.service import get_preferences
 
 logger = logging.getLogger(__name__)
 
@@ -354,12 +355,19 @@ async def run_cycle(db: AsyncSession) -> dict:
                 await _upsert_user_state(db, user["id"], new_level, assessment["siat_color"], cyclone_id)
 
                 if new_level >= _NOTIFY_MIN_LEVEL and (old_level is None or new_level > old_level):
-                    prev = escalations.get(user["id"])
-                    if prev is None or new_level > prev["siat_level"]:
-                        escalations[user["id"]] = assessment
-                        logger.info(
-                            "Escalation queued: user_id=%d %s→%s (%s)",
-                            user["id"], old_level, new_level, assessment["siat_color"],
+                    prefs = await get_preferences(db, user["id"])
+                    if prefs["siat_enabled"] and new_level >= prefs["min_siat_level"]:
+                        prev = escalations.get(user["id"])
+                        if prev is None or new_level > prev["siat_level"]:
+                            escalations[user["id"]] = assessment
+                            logger.info(
+                                "Escalation queued: user_id=%d %s→%s (%s)",
+                                user["id"], old_level, new_level, assessment["siat_color"],
+                            )
+                    else:
+                        logger.debug(
+                            "user_id=%d: push filtered by prefs (siat_enabled=%s, min_siat_level=%d, got=%d)",
+                            user["id"], prefs["siat_enabled"], prefs["min_siat_level"], new_level,
                         )
 
                 all_assessments.append({**assessment, "user_id": user["id"]})

--- a/backend/app/features/siat/service.py
+++ b/backend/app/features/siat/service.py
@@ -93,6 +93,9 @@ async def ensure_siat_tables(engine: AsyncEngine) -> None:
                 updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
             )
         """))
+        await conn.execute(text(
+            "ALTER TABLE alerts ADD COLUMN IF NOT EXISTS notified_at TIMESTAMPTZ"
+        ))
     logger.info("SIAT tables verified/created")
 
 
@@ -289,38 +292,122 @@ async def _push_per_user(
 
 
 # ---------------------------------------------------------------------------
+# SMN/CONAGUA alerts → geocercado push
+# ---------------------------------------------------------------------------
+
+_SMN_RADIUS_KM = 500.0
+
+
+async def _get_pending_smn_alerts(db: AsyncSession) -> list:
+    result = await db.execute(text("""
+        SELECT id, title, short, level, lat, lon
+        FROM alerts
+        WHERE lat IS NOT NULL
+          AND lon IS NOT NULL
+          AND notified_at IS NULL
+          AND timestamp > NOW() - INTERVAL '35 minutes'
+        ORDER BY timestamp DESC
+    """))
+    return result.mappings().all()
+
+
+async def _mark_alert_notified(db: AsyncSession, alert_id) -> None:
+    await db.execute(
+        text("UPDATE alerts SET notified_at = NOW() WHERE id = :id"),
+        {"id": alert_id},
+    )
+
+
+async def _push_smn_for_alert(
+    db: AsyncSession, alert: dict, users: list
+) -> int:
+    affected_user_ids = []
+    for user in users:
+        dist = haversine_km(alert["lat"], alert["lon"], user["lat"], user["lon"])
+        if dist > _SMN_RADIUS_KM:
+            continue
+        prefs = await get_preferences(db, user["id"])
+        if prefs["siat_enabled"] and alert["level"] >= prefs["min_siat_level"]:
+            affected_user_ids.append(user["id"])
+
+    if not affected_user_ids:
+        return 0
+
+    token_map = await get_tokens_for_users(db, affected_user_ids)
+    all_tokens = [t for tokens in token_map.values() for t in tokens]
+    if not all_tokens:
+        return 0
+
+    msg = messaging.MulticastMessage(
+        notification=messaging.Notification(
+            title=f"Nueva alerta — {alert['title']}",
+            body=alert["short"],
+        ),
+        data={
+            "alert_id": str(alert["id"]),
+            "level": str(alert["level"]),
+            "siat_level": str(alert["level"]),
+        },
+        android=messaging.AndroidConfig(priority="high"),
+        apns=messaging.APNSConfig(
+            headers={"apns-priority": "10"},
+        ),
+        tokens=all_tokens,
+    )
+
+    total_sent = 0
+    try:
+        response = await asyncio.to_thread(messaging.send_each_for_multicast, msg)
+        total_sent = response.success_count
+        logger.info(
+            "SMN push alert_id=%s level=%d users=%d success=%d failure=%d",
+            alert["id"], alert["level"], len(affected_user_ids),
+            response.success_count, response.failure_count,
+        )
+        if response.failure_count:
+            failed = [all_tokens[i] for i, r in enumerate(response.responses) if not r.success]
+            logger.warning("SMN push failures alert_id=%s: %s", alert["id"], failed[:5])
+    except Exception as exc:
+        logger.error("SMN push failed for alert_id=%s: %s", alert["id"], exc, exc_info=True)
+
+    if total_sent > 0:
+        await _mark_alert_notified(db, alert["id"])
+
+    return total_sent
+
+
+async def _notify_smn_alerts(db: AsyncSession, users: list) -> int:
+    if not users:
+        return 0
+
+    alerts = await _get_pending_smn_alerts(db)
+    if not alerts:
+        logger.debug("SMN: no pending alerts")
+        return 0
+
+    total_sent = 0
+    for alert in alerts:
+        total_sent += await _push_smn_for_alert(db, alert, users)
+
+    return total_sent
+
+
+# ---------------------------------------------------------------------------
 # Main orchestrator
 # ---------------------------------------------------------------------------
 
 async def run_cycle(db: AsyncSession) -> dict:
     logger.info("SIAT run-cycle started")
 
-    cyclones = await fetch_active_cyclones()
-    if not cyclones:
-        logger.info("SIAT run-cycle: no active cyclones, nothing to do")
-        return {
-            "cyclones_found": 0,
-            "users_evaluated": 0,
-            "notifications_sent": 0,
-            "assessments": [],
-        }
-
     users = await _get_users_with_location(db)
-    if not users:
-        logger.warning("SIAT run-cycle: %d cyclone(s) found but no users with location", len(cyclones))
-        return {
-            "cyclones_found": len(cyclones),
-            "users_evaluated": 0,
-            "notifications_sent": 0,
-            "assessments": [],
-        }
+    cyclones = await fetch_active_cyclones()
 
     logger.info("SIAT run-cycle: %d cyclone(s), %d user(s) with location", len(cyclones), len(users))
 
     all_assessments: list[dict] = []
     escalations: dict[int, dict] = {}  # user_id → highest assessment this cycle
 
-    for cyclone in cyclones:
+    for cyclone in (cyclones if users else []):
         try:
             cyclone_id = await _save_cyclone(db, cyclone)
             logger.info("Cyclone saved: id=%d name=%s status=%s", cyclone_id, cyclone["name"], cyclone["status"])
@@ -387,6 +474,8 @@ async def run_cycle(db: AsyncSession) -> dict:
             await _mark_notified(db, user_id, assessment["siat_level"])
     else:
         logger.info("SIAT run-cycle: no escalations, no push sent")
+
+    notifications_sent += await _notify_smn_alerts(db, users)
 
     await db.commit()
 

--- a/backend/app/features/siat/tests/test_router.py
+++ b/backend/app/features/siat/tests/test_router.py
@@ -1,4 +1,5 @@
-from unittest.mock import AsyncMock, patch
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
 from starlette.testclient import TestClient
 from app.main import app
 from datetime import datetime, timezone
@@ -235,3 +236,107 @@ def test_affected_users_invalid_radius():
         headers=API_KEY_HEADERS,
     )
     assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# run_cycle() respects notification_preferences — service-level tests
+# ---------------------------------------------------------------------------
+
+_SVC = "app.features.siat.service"
+
+_FAKE_CYCLONE = {
+    "name": "ALBERTO",
+    "status": "HU",
+    "lat": 22.0,
+    "lon": -97.0,
+    "wind_kmh": 150.0,
+    "movement_speed_kmh": 20.0,
+}
+
+_FAKE_USER = {"id": 1, "lat": 20.5, "lon": -98.0}
+
+_ASSESSMENT_LEVEL_2 = {
+    "siat_level": 2,
+    "siat_color": "VERDE",
+    "distance_km": 200.0,
+    "eta_hours": 10.0,
+    "reason": "test",
+    "out_of_range": False,
+}
+
+_ASSESSMENT_LEVEL_3 = {
+    "siat_level": 3,
+    "siat_color": "AMARILLO",
+    "distance_km": 200.0,
+    "eta_hours": 5.0,
+    "reason": "test",
+    "out_of_range": False,
+}
+
+
+def _base_run_cycle_patches(assessment, prefs, push_return=0):
+    """Return a list of (target, kwargs) patch specs for run_cycle service tests."""
+    return [
+        patch(f"{_SVC}.fetch_active_cyclones", new_callable=AsyncMock, return_value=[_FAKE_CYCLONE]),
+        patch(f"{_SVC}._get_users_with_location", new_callable=AsyncMock, return_value=[_FAKE_USER]),
+        patch(f"{_SVC}._save_cyclone", new_callable=AsyncMock, return_value=99),
+        patch(f"{_SVC}.evaluate_user", return_value=assessment),
+        patch(f"{_SVC}._get_user_state", new_callable=AsyncMock, return_value={"current_level": 1}),
+        patch(f"{_SVC}._save_assessment", new_callable=AsyncMock, return_value=None),
+        patch(f"{_SVC}._upsert_user_state", new_callable=AsyncMock, return_value=None),
+        patch(f"{_SVC}.get_preferences", new_callable=AsyncMock, return_value=prefs),
+        patch(f"{_SVC}.get_tokens_for_users", new_callable=AsyncMock, return_value={1: ["token-abc"]}),
+        patch(f"{_SVC}._push_per_user", new_callable=AsyncMock, return_value=push_return),
+        patch(f"{_SVC}._mark_notified", new_callable=AsyncMock, return_value=None),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_cycle_respects_siat_disabled():
+    """User with siat_enabled=False must not receive push even on valid escalation."""
+    from app.features.siat.service import run_cycle
+
+    prefs = {"siat_enabled": False, "min_siat_level": 2, "map_events_enabled": True}
+    db = MagicMock()
+    db.commit = AsyncMock()
+
+    patches = _base_run_cycle_patches(_ASSESSMENT_LEVEL_3, prefs, push_return=0)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10]:
+        result = await run_cycle(db)
+
+    assert result["notifications_sent"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_cycle_respects_min_siat_level():
+    """User with min_siat_level=3 must not receive push when new_level=2 (Verde)."""
+    from app.features.siat.service import run_cycle
+
+    prefs = {"siat_enabled": True, "min_siat_level": 3, "map_events_enabled": True}
+    db = MagicMock()
+    db.commit = AsyncMock()
+
+    patches = _base_run_cycle_patches(_ASSESSMENT_LEVEL_2, prefs, push_return=0)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10]:
+        result = await run_cycle(db)
+
+    assert result["notifications_sent"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_cycle_sends_push_when_prefs_allow():
+    """User with defaults (siat_enabled=True, min_siat_level=2) must receive push on level-2 escalation."""
+    from app.features.siat.service import run_cycle
+
+    prefs = {"siat_enabled": True, "min_siat_level": 2, "map_events_enabled": True}
+    db = MagicMock()
+    db.commit = AsyncMock()
+
+    patches = _base_run_cycle_patches(_ASSESSMENT_LEVEL_2, prefs, push_return=1)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10]:
+        result = await run_cycle(db)
+
+    assert result["notifications_sent"] == 1

--- a/backend/app/features/siat/tests/test_router.py
+++ b/backend/app/features/siat/tests/test_router.py
@@ -288,6 +288,7 @@ def _base_run_cycle_patches(assessment, prefs, push_return=0):
         patch(f"{_SVC}.get_tokens_for_users", new_callable=AsyncMock, return_value={1: ["token-abc"]}),
         patch(f"{_SVC}._push_per_user", new_callable=AsyncMock, return_value=push_return),
         patch(f"{_SVC}._mark_notified", new_callable=AsyncMock, return_value=None),
+        patch(f"{_SVC}._notify_smn_alerts", new_callable=AsyncMock, return_value=0),
     ]
 
 
@@ -302,7 +303,7 @@ async def test_run_cycle_respects_siat_disabled():
 
     patches = _base_run_cycle_patches(_ASSESSMENT_LEVEL_3, prefs, push_return=0)
     with patches[0], patches[1], patches[2], patches[3], patches[4], \
-         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10]:
+         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11]:
         result = await run_cycle(db)
 
     assert result["notifications_sent"] == 0
@@ -319,7 +320,7 @@ async def test_run_cycle_respects_min_siat_level():
 
     patches = _base_run_cycle_patches(_ASSESSMENT_LEVEL_2, prefs, push_return=0)
     with patches[0], patches[1], patches[2], patches[3], patches[4], \
-         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10]:
+         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11]:
         result = await run_cycle(db)
 
     assert result["notifications_sent"] == 0
@@ -336,7 +337,140 @@ async def test_run_cycle_sends_push_when_prefs_allow():
 
     patches = _base_run_cycle_patches(_ASSESSMENT_LEVEL_2, prefs, push_return=1)
     with patches[0], patches[1], patches[2], patches[3], patches[4], \
-         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10]:
+         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11]:
         result = await run_cycle(db)
 
     assert result["notifications_sent"] == 1
+
+
+# ---------------------------------------------------------------------------
+# SMN/CONAGUA alerts → geocercado push — service-level tests
+# ---------------------------------------------------------------------------
+
+_FAKE_SMN_ALERT = {
+    "id": "alert-uuid-1",
+    "title": "Tormenta severa",
+    "short": "Lluvias intensas en la región",
+    "level": 3,
+    "lat": 20.5,
+    "lon": -98.0,
+}
+
+_FAKE_USER_NEARBY = {"id": 1, "lat": 20.5, "lon": -98.0}   # 0 km
+_FAKE_USER_FAR    = {"id": 2, "lat": 30.0, "lon": -80.0}   # > 500 km
+
+
+@pytest.mark.asyncio
+async def test_smn_recent_alert_user_in_range_sends_and_marks():
+    """Recent alert + user inside 500 km + default prefs → push sent and alert marked."""
+    from app.features.siat.service import _notify_smn_alerts
+
+    prefs = {"siat_enabled": True, "min_siat_level": 2, "map_events_enabled": True}
+    db = MagicMock()
+
+    with patch(f"{_SVC}._get_pending_smn_alerts", new_callable=AsyncMock, return_value=[_FAKE_SMN_ALERT]), \
+         patch(f"{_SVC}.get_preferences", new_callable=AsyncMock, return_value=prefs), \
+         patch(f"{_SVC}.get_tokens_for_users", new_callable=AsyncMock, return_value={1: ["token-abc"]}), \
+         patch(f"{_SVC}._mark_alert_notified", new_callable=AsyncMock) as mock_mark, \
+         patch(f"{_SVC}.messaging") as mock_messaging:
+
+        fake_response = MagicMock()
+        fake_response.success_count = 1
+        fake_response.failure_count = 0
+        fake_response.responses = [MagicMock(success=True)]
+        mock_messaging.send_each_for_multicast.return_value = fake_response
+        mock_messaging.MulticastMessage = MagicMock()
+        mock_messaging.Notification = MagicMock()
+        mock_messaging.AndroidConfig = MagicMock()
+        mock_messaging.APNSConfig = MagicMock()
+
+        total = await _notify_smn_alerts(db, [_FAKE_USER_NEARBY])
+
+    assert total == 1
+    mock_mark.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_smn_no_pending_alerts_returns_zero():
+    """No pending alerts → _notify_smn_alerts returns 0 without sending anything."""
+    from app.features.siat.service import _notify_smn_alerts
+
+    db = MagicMock()
+
+    with patch(f"{_SVC}._get_pending_smn_alerts", new_callable=AsyncMock, return_value=[]):
+        total = await _notify_smn_alerts(db, [_FAKE_USER_NEARBY])
+
+    assert total == 0
+
+
+@pytest.mark.asyncio
+async def test_smn_no_users_returns_zero():
+    """Empty user list → _notify_smn_alerts returns 0 immediately."""
+    from app.features.siat.service import _notify_smn_alerts
+
+    db = MagicMock()
+
+    with patch(f"{_SVC}._get_pending_smn_alerts", new_callable=AsyncMock) as mock_alerts:
+        total = await _notify_smn_alerts(db, [])
+
+    assert total == 0
+    mock_alerts.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_smn_user_out_of_range_no_push():
+    """User beyond 500 km → push skipped and alert NOT marked as notified."""
+    from app.features.siat.service import _notify_smn_alerts
+
+    db = MagicMock()
+    prefs = {"siat_enabled": True, "min_siat_level": 2, "map_events_enabled": True}
+
+    with patch(f"{_SVC}._get_pending_smn_alerts", new_callable=AsyncMock, return_value=[_FAKE_SMN_ALERT]), \
+         patch(f"{_SVC}.get_preferences", new_callable=AsyncMock, return_value=prefs), \
+         patch(f"{_SVC}.get_tokens_for_users", new_callable=AsyncMock, return_value={}) as mock_tokens, \
+         patch(f"{_SVC}._mark_alert_notified", new_callable=AsyncMock) as mock_mark:
+
+        total = await _notify_smn_alerts(db, [_FAKE_USER_FAR])
+
+    assert total == 0
+    mock_mark.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_smn_siat_disabled_no_push():
+    """User with siat_enabled=False → push filtered even if inside radius."""
+    from app.features.siat.service import _notify_smn_alerts
+
+    db = MagicMock()
+    prefs = {"siat_enabled": False, "min_siat_level": 2, "map_events_enabled": True}
+
+    with patch(f"{_SVC}._get_pending_smn_alerts", new_callable=AsyncMock, return_value=[_FAKE_SMN_ALERT]), \
+         patch(f"{_SVC}.get_preferences", new_callable=AsyncMock, return_value=prefs), \
+         patch(f"{_SVC}.get_tokens_for_users", new_callable=AsyncMock, return_value={}) as mock_tokens, \
+         patch(f"{_SVC}._mark_alert_notified", new_callable=AsyncMock) as mock_mark:
+
+        total = await _notify_smn_alerts(db, [_FAKE_USER_NEARBY])
+
+    assert total == 0
+    mock_mark.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_smn_min_siat_level_filters_alert():
+    """Alert level=2 but user min_siat_level=3 → push filtered."""
+    from app.features.siat.service import _notify_smn_alerts
+
+    db = MagicMock()
+    prefs = {"siat_enabled": True, "min_siat_level": 3, "map_events_enabled": True}
+
+    alert_level2 = {**_FAKE_SMN_ALERT, "level": 2}
+
+    with patch(f"{_SVC}._get_pending_smn_alerts", new_callable=AsyncMock, return_value=[alert_level2]), \
+         patch(f"{_SVC}.get_preferences", new_callable=AsyncMock, return_value=prefs), \
+         patch(f"{_SVC}.get_tokens_for_users", new_callable=AsyncMock, return_value={}) as mock_tokens, \
+         patch(f"{_SVC}._mark_alert_notified", new_callable=AsyncMock) as mock_mark:
+
+        total = await _notify_smn_alerts(db, [_FAKE_USER_NEARBY])
+
+    assert total == 0
+    mock_mark.assert_not_called()


### PR DESCRIPTION
## Qué incluye
- Procesamiento automático de alerts SMN/CONAGUA en run_cycle()
- Geofencing de usuarios por distancia
- Respeto de notification_preferences
- Columna `alerts.notified_at`
- Prevención de re-notificaciones
- Push notifications targeted
- Helpers privados para mantener run_cycle modular
- Tests de integración y edge cases

## Tests
- `python3 -m pytest app/features/siat/tests/ -v`
- `python3 -m pytest -v`
- Resultado: 54 passed

## Fuera de alcance
- Frontend
- AlarmScreen
- AI summary