### PR TITLE
feat: connect AlarmScreen to push notifications

### DIFF
--- a/frontend/app/AlarmScreen.jsx
+++ b/frontend/app/AlarmScreen.jsx
@@ -1,82 +1,36 @@
-// Component for displaying an emergency alert modal with options to view on map or get more details. Not displayed on production.
-import { useState, useEffect } from "react";
 import { Modal, View, Text, TouchableOpacity } from "react-native";
-import { Link, useRouter } from "expo-router";
+import { Link, useRouter, useLocalSearchParams } from "expo-router";
 import { colorForLevel } from "./alerts/_components/AlertCard";
 
-// 5 alertas reales del backend (Huracán Otis)
-const MOCK_ALERTS = [
-  {
-    id: "684e081d-e71f-4137-8d06-7a57ca67da17",
-    category: 1,
-    title: "Huracán Otis – Alerta",
-    message: "Monitoreo preventivo, ciclón a distancia. Manténgase informado y prepare su kit de emergencia.",
-    distanceKm: 250,
-    etaHours: 36,
-  },
-  {
-    id: "bcab852c-9425-4d9b-afa2-91967b0ecd3f",
-    category: 2,
-    title: "Huracán Otis – Alerta Verde",
-    message: "Mayor vigilancia, condiciones adversas probables. Refuerce ventanas y asegure objetos exteriores.",
-    distanceKm: 180,
-    etaHours: 24,
-  },
-  {
-    id: "05252d37-9a24-445e-aa4b-8dbe041a256c",
-    category: 3,
-    title: "Huracán Otis – Alerta Amarilla",
-    message: "Condiciones peligrosas, el ciclón se acerca. Prepárate para evacuar y sigue las indicaciones oficiales.",
-    distanceKm: 100,
-    etaHours: 14,
-  },
-  {
-    id: "7d921fa3-6a6d-4b5b-ba48-539818675a27",
-    category: 4,
-    title: "Huracán Otis – Alerta Roja",
-    message: "¡PELIGRO EXTREMO! Condiciones extremadamente peligrosas en avance. EVACUE INMEDIATAMENTE si está en zona de riesgo.",
-    distanceKm: 60,
-    etaHours: 8,
-  },
-  {
-    id: "b74faf40-88cd-419f-8c7d-9d2c23ddc43f",
-    category: 5,
-    title: "Huracán Otis – Impacto Máximo",
-    message: "⚠️ ALERTA MÁXIMA ⚠️ Vientos extremos y lluvias torrenciales. Impacto INMINENTE. BUSQUE REFUGIO SEGURO AHORA.",
-    distanceKm: 30,
-    etaHours: 4,
-  },
-];
-
 export default function AlarmScreen() {
-  const [visible, setVisible] = useState(false);
-  const [currentAlert, setCurrentAlert] = useState(null);
-
-  useEffect(() => {
-    // Seleccionar alerta aleatoria al montar
-    const randomIndex = Math.floor(Math.random() * MOCK_ALERTS.length);
-    setCurrentAlert(MOCK_ALERTS[randomIndex]);
-
-    const t = setTimeout(() => setVisible(true), 250);
-    return () => clearTimeout(t);
-  }, []);
-
+  const { alertId, category, title, message } = useLocalSearchParams();
   const router = useRouter();
-  const handleMap = () => {
-    setVisible(false);
-    router.push("/MapScreen");
+
+  const alertData = {
+    id:       alertId  || null,
+    category: Number(category) || 4,
+    title:    String(title   || "Alerta de emergencia"),
+    message:  String(message || "Siga las indicaciones de las autoridades."),
   };
-  const handleClose = () => setVisible(false);
 
-  // No renderizar hasta tener alerta seleccionada
-  if (!currentAlert) return null;
+  const handleClose = () => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace("/(tabs)/MapScreen");
+    }
+  };
 
-  const baseColor = colorForLevel(currentAlert.category);
-  const buttonColor = `${baseColor}50`; // 50 = 31% opacity (semitransparente)
-  const categoryBadgeColor = `${baseColor}90`; // 90 = 56% opacity (más visible para el badge)
+  const handleMap = () => {
+    router.replace("/(tabs)/MapScreen");
+  };
+
+  const baseColor = colorForLevel(alertData.category);
+  const buttonColor = `${baseColor}50`;
+  const categoryBadgeColor = `${baseColor}90`;
 
   return (
-    <Modal animationType="slide" transparent visible={visible} onRequestClose={handleClose}>
+    <Modal animationType="slide" transparent visible onRequestClose={handleClose}>
       <View className="flex-1 justify-center items-center bg-black/70">
         <View
           className="w-11/12 max-w-md rounded-2xl p-6 shadow-xl bg-white"
@@ -89,31 +43,20 @@ export default function AlarmScreen() {
               style={{ backgroundColor: categoryBadgeColor }}
             >
               <Text className="text-white font-bold text-sm">
-                Categoría {currentAlert.category}
+                Categoría {alertData.category}
               </Text>
             </View>
           </View>
 
           {/* Título */}
           <Text className="text-2xl font-extrabold text-center mb-4" style={{ color: '#111827' }}>
-            {currentAlert.title}
+            {alertData.title}
           </Text>
 
           {/* Mensaje breve */}
           <Text className="text-base text-center mb-6" style={{ color: '#374151' }}>
-            {currentAlert.message}
+            {alertData.message}
           </Text>
-
-          {/* Datos clave */}
-          {/* <View className="space-y-1 mb-8">
-            <Stat label="Distancia" value={`${MOCK_ALERT.distanceKm} km`} />
-            <Stat label="ETA" value={`${MOCK_ALERT.etaHours} h`} />
-            <Stat label="Viento" value={`${MOCK_ALERT.windKmh} km/h`} />
-            <Stat label="Ráfagas" value={`${MOCK_ALERT.gustKmh} km/h`} />
-            <Stat label="Presión" value={`${MOCK_ALERT.pressureMb} mb`} />
-            <Stat label="Lluvia 1 h" value={`${MOCK_ALERT.rain1h} mm`} />
-            <Stat label="Prob. lluvia" value={`${Math.round(MOCK_ALERT.pop * 100)} %`} />
-          </View> */}
 
           {/* Botones */}
           <View className="flex-row justify-between mb-6">
@@ -125,7 +68,7 @@ export default function AlarmScreen() {
               <Text className="font-bold" style={{ color: baseColor }}>Ver en el mapa</Text>
             </TouchableOpacity>
 
-            <Link href={`/alerts/${currentAlert.id}`} asChild>
+            <Link href={alertData.id ? `/alerts/${alertData.id}` : "/alerts"} asChild>
               <TouchableOpacity
                 className="flex-1 ml-2 py-3 rounded-lg items-center"
                 style={{ backgroundColor: buttonColor }}
@@ -146,14 +89,5 @@ export default function AlarmScreen() {
         </View>
       </View>
     </Modal>
-  );
-}
-
-function Stat({ label, value }) {
-  return (
-    <Text className="text-phase2Titles">
-      <Text className="font-bold">{label}: </Text>
-      {value}
-    </Text>
   );
 }

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -9,7 +9,7 @@ import { DaltonicModeProvider } from "../context/DaltonicModeContext";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { LinearGradient } from "expo-linear-gradient";
 import { gradients } from "../utils/theme";
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { useFonts } from "expo-font";
 import { AppState, Platform, StatusBar as RNStatusBar } from "react-native";
 import { StatusBar } from "expo-status-bar";
@@ -53,12 +53,37 @@ const DEV_BYPASS_AUTH = process.env.EXPO_PUBLIC_DEV_BYPASS_AUTH === 'true'
 
 interface NotificationData {
   alertId?: string
+  alert_id?: string
   alertLevel?: string
+  level?: string
+  siat_level?: string
+  siat_color?: string
   fullScreen?: string
   category?: string
   alertTitle?: string
   alertMessage?: string
   bulletinUrl?: string
+}
+
+function resolveNotifPayload(
+  data: NotificationData,
+  content?: { title?: string | null; body?: string | null }
+) {
+  const id = data.alertId || data.alert_id
+  const levelNum = Number(data.level ?? data.siat_level ?? data.alertLevel ?? 0)
+  const isFullScreen = data.fullScreen === 'true' || levelNum >= 4
+  return {
+    id,
+    levelNum,
+    isFullScreen,
+    params: {
+      alertId: id,
+      category: data.category ?? String(levelNum),
+      title: data.alertTitle ?? content?.title ?? "Alerta de emergencia",
+      message: data.alertMessage ?? content?.body ?? "Siga las indicaciones de las autoridades.",
+      bulletinUrl: data.bulletinUrl,
+    },
+  }
 }
 
 function AuthGate({ children }) {
@@ -105,6 +130,7 @@ function AuthGate({ children }) {
 /* ---------- Layout raíz ---------- */
 export default Sentry.wrap(function Layout() {
   const router = useRouter();
+  const alarmActiveRef = React.useRef(false);
 
   const [fontsLoaded] = useFonts({
     'Square721': require('../assets/fonts/square-721-bold-extended-bt.ttf'),
@@ -124,78 +150,68 @@ export default Sentry.wrap(function Layout() {
   useEffect(() => {
     setForegroundNotificationHandler();
 
-    // 👇 Cuando el usuario pulse la notificación (o llegue automáticamente si es critical)
-    const sub = addNotificationResponseListener(async (rawData) => {
+    // Tap en notificación (background → foreground, o foreground tap)
+    const tapSub = addNotificationResponseListener(async (rawData) => {
       const data = rawData as NotificationData
-      if (data?.alertId) {
-        await initAnalytics();
-        track("push_open", {
-          alertId: String(data.alertId),
-          alertLevel: data.alertLevel ? Number(data.alertLevel) : undefined,
-          fullScreen: data.fullScreen === 'true',
-          origin: "listener",
-        });
+      const { id, isFullScreen, params } = resolveNotifPayload(data)
+      if (!id && !isFullScreen) return
 
-        // Si es full-screen (crítica cat 3+) → AlarmScreen
-        // Si no → Alert details
-        if (data.fullScreen === 'true') {
-          router.push({
-            pathname: "AlarmScreen",
-            params: {
-              alertId: data.alertId,
-              category: data.category || data.alertLevel,
-              title: data.alertTitle || "Alerta de huracán",
-              message: data.alertMessage || "Diríjase a un refugio seguro",
-              bulletinUrl: data.bulletinUrl || "https://www.nhc.noaa.gov/",
-            },
-          });
-        } else {
-          router.push({
-            pathname: "/alerts/[id]",
-            params: { id: data.alertId },
-          });
-        }
+      await initAnalytics();
+      track("push_open", {
+        alertId: id ? String(id) : undefined,
+        alertLevel: params.category ? Number(params.category) : undefined,
+        fullScreen: isFullScreen,
+        origin: "listener",
+      });
+
+      if (isFullScreen) {
+        router.push({ pathname: "AlarmScreen", params });
+      } else if (id) {
+        router.push({ pathname: "/alerts/[id]", params: { id } });
       }
     });
 
-    return () => sub.remove(); // limpia al desmontar
+    // Notificación recibida mientras la app está abierta → AlarmScreen si nivel >= 4
+    const receivedSub = Notifications.addNotificationReceivedListener((notification) => {
+      const rawData = notification.request.content.data as NotificationData
+      const content = notification.request.content
+      const { isFullScreen, params } = resolveNotifPayload(rawData, content)
+      if (isFullScreen && !alarmActiveRef.current) {
+        alarmActiveRef.current = true
+        router.push({ pathname: "AlarmScreen", params })
+        // Liberar el guard después de un debounce para cubrir multi-push
+        setTimeout(() => { alarmActiveRef.current = false }, 5000)
+      }
+    });
+
+    return () => {
+      tapSub.remove();
+      receivedSub.remove();
+    };
   }, []);
 
-  // Si la app se abrió tocando una notificación, esta llamada la devuelve
+  // App abierta tocando una notificación desde cold start
   useEffect(() => {
     (async () => {
       const initial = await Notifications.getLastNotificationResponseAsync();
       const data = initial?.notification?.request?.content?.data as NotificationData | undefined
-      const alertId = data?.alertId;
+      if (!data) return
 
-      if (alertId) {
-        await initAnalytics();
-        track("push_open", {
-          alertId: String(alertId),
-          alertLevel: data?.alertLevel ? Number(data.alertLevel) : undefined,
-          fullScreen: data?.fullScreen === 'true',
-          origin: "initial",
-        });
+      const { id, isFullScreen, params } = resolveNotifPayload(data)
+      if (!id && !isFullScreen) return
 
-        // Si es full-screen (crítica cat 3+) → AlarmScreen
-        // Si no → Alert details
-        if (data?.fullScreen === 'true') {
-          router.push({
-            pathname: "AlarmScreen",
-            params: {
-              alertId: data.alertId,
-              category: data.category || data.alertLevel,
-              title: data.alertTitle || "Alerta de huracán",
-              message: data.alertMessage || "Diríjase a un refugio seguro",
-              bulletinUrl: data.bulletinUrl || "https://www.nhc.noaa.gov/",
-            },
-          });
-        } else {
-          router.push({
-            pathname: "/alerts/[id]",
-            params: { id: alertId },
-          });
-        }
+      await initAnalytics();
+      track("push_open", {
+        alertId: id ? String(id) : undefined,
+        alertLevel: params.category ? Number(params.category) : undefined,
+        fullScreen: isFullScreen,
+        origin: "initial",
+      });
+
+      if (isFullScreen) {
+        router.push({ pathname: "AlarmScreen", params });
+      } else if (id) {
+        router.push({ pathname: "/alerts/[id]", params: { id } });
       }
     })();
   }, []);


### PR DESCRIPTION
## Qué incluye
- AlarmScreen ahora usa datos reales del push payload
- Integración con expo-notifications
- Foreground notification routing
- Background/cold-start routing
- Compatibilidad snake_case/camelCase para payloads backend
- Navegación a /alerts/[id]
- Protección contra múltiples AlarmScreens consecutivos
- Fallback seguro para router.back()

## Fuera de alcance
- Backend
- AI summary
- Notification preferences UI