### PR TITLE
feat: add AI alert summary

### DIFF
--- a/backend/app/features/ai/router.py
+++ b/backend/app/features/ai/router.py
@@ -1,6 +1,8 @@
 from fastapi import HTTPException, APIRouter, Depends
-from app.features.ai.service import chat
-from app.features.ai.schemas import ChatRequest, ChatResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.core.database import get_db
+from app.features.ai.service import chat, alert_summary
+from app.features.ai.schemas import ChatRequest, ChatResponse, AlertSummaryRequest, AlertSummaryResponse
 from app.core.auth import get_current_user
 
 
@@ -10,3 +12,18 @@ router = APIRouter()
 async def send_message(body: ChatRequest, user=Depends(get_current_user)):
     reply = await chat(body.messages, body.location, body.latitude, body.longitude)
     return ChatResponse(reply=reply)
+
+
+@router.post("/api/v1/ai/alert-summary", response_model=AlertSummaryResponse)
+async def post_alert_summary(
+    body: AlertSummaryRequest,
+    db: AsyncSession = Depends(get_db),
+    user=Depends(get_current_user),
+):
+    try:
+        summary = await alert_summary(db, body.alert_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Alerta no encontrada")
+    except RuntimeError:
+        raise HTTPException(status_code=503, detail="LLM no disponible")
+    return AlertSummaryResponse(alert_id=body.alert_id, summary=summary)

--- a/backend/app/features/ai/schemas.py
+++ b/backend/app/features/ai/schemas.py
@@ -12,3 +12,11 @@ class ChatRequest(BaseModel):
                                                                 
 class ChatResponse(BaseModel):
     reply: str
+
+
+class AlertSummaryRequest(BaseModel):
+    alert_id: str
+
+class AlertSummaryResponse(BaseModel):
+    alert_id: str
+    summary: str

--- a/backend/app/features/ai/service.py
+++ b/backend/app/features/ai/service.py
@@ -1,6 +1,11 @@
 import httpx
+import json
+import logging
 from app.core.config import settings
 from app.features.ai.rag import retrieve
+from app.features.alerts.service import get_alert_by_id
+
+logger = logging.getLogger(__name__)
 
 SYSTEM_PROMPT = """You are BluEye, an AI assistant specialized in hurricane preparedness, response, and recovery for residents of Mexico.
 
@@ -111,3 +116,54 @@ async def chat(messages: list[dict], location: str | None = None, latitude: floa
             raise RuntimeError(f"[chat:llm] LLM returned no choices: {data}")
 
         return data["choices"][0]["message"]["content"]
+
+
+_SUMMARY_SYSTEM_PROMPT = (
+    "Eres un asistente de alertas de emergencia para México. "
+    "Dado los datos de una alerta, genera un resumen conciso y útil para el ciudadano afectado. "
+    "Reglas estrictas: máximo 3 oraciones; español claro y directo; sin jerga técnica; "
+    "sin emojis; no repitas el título textualmente; no inventes datos que no estén en los datos proporcionados."
+)
+
+_SUMMARY_MAX_CHARS = 600
+
+
+async def alert_summary(db, alert_id: str) -> str:
+    alert = await get_alert_by_id(db, alert_id)
+    if alert is None:
+        raise ValueError("alert_not_found")
+
+    payload = json.dumps({
+        "titulo": alert["title"],
+        "descripcion": alert.get("short", ""),
+        "nivel": alert["level"],
+        "factores": alert.get("factors", []),
+        "recomendaciones": alert.get("recommendations", []),
+    }, ensure_ascii=False)
+
+    messages = [
+        {"role": "system", "content": _SUMMARY_SYSTEM_PROMPT},
+        {"role": "user",   "content": f"Genera un resumen de esta alerta:\n{payload}"},
+    ]
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                url=f"{settings.LLM_BASE_URL}/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {settings.LLM_API_KEY}",
+                    "Content-Type": "application/json",
+                },
+                json={"model": settings.LLM_MODEL, "messages": messages},
+                timeout=30.0,
+            )
+            data = response.json()
+            if "choices" not in data:
+                raise RuntimeError(f"LLM returned no choices: {data}")
+            summary = data["choices"][0]["message"]["content"]
+            return summary[:_SUMMARY_MAX_CHARS]
+    except RuntimeError:
+        raise
+    except Exception as exc:
+        logger.error("alert_summary LLM call failed: %s", exc, exc_info=True)
+        raise RuntimeError("llm_unavailable")

--- a/backend/app/features/ai/tests/test_router.py
+++ b/backend/app/features/ai/tests/test_router.py
@@ -61,12 +61,65 @@ def test_chat_no_auth():
             "messages": [
                 {"role": "user", "content": "hola"},
                 {"role": "bot", "content": "Wassup"}
-            ],    
+            ],
             "location": "Tuxpan",
             "latitude": 5,
             "longitude": 10,
         },
     )
     assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/ai/alert-summary
+# ---------------------------------------------------------------------------
+
+_AI = "app.features.ai.router"
+_FAKE_ALERT_ID = "00000000-0000-0000-0000-000000000001"
+
+
+def test_alert_summary_returns_summary():
+    with patch("app.core.auth.auth.verify_id_token", return_value={"uid": "test123"}):
+        with patch(f"{_AI}.alert_summary", new_callable=AsyncMock, return_value="Resumen de prueba.") as mock_svc:
+            r = client.post(
+                "/api/v1/ai/alert-summary",
+                json={"alert_id": _FAKE_ALERT_ID},
+                headers={"Authorization": "Bearer faketoken"},
+            )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["summary"] == "Resumen de prueba."
+    assert body["alert_id"] == _FAKE_ALERT_ID
+    mock_svc.assert_called_once()
+
+
+def test_alert_summary_404():
+    with patch("app.core.auth.auth.verify_id_token", return_value={"uid": "test123"}):
+        with patch(f"{_AI}.alert_summary", new_callable=AsyncMock, side_effect=ValueError("alert_not_found")):
+            r = client.post(
+                "/api/v1/ai/alert-summary",
+                json={"alert_id": "00000000-0000-0000-0000-000000000099"},
+                headers={"Authorization": "Bearer faketoken"},
+            )
+    assert r.status_code == 404
+
+
+def test_alert_summary_503():
+    with patch("app.core.auth.auth.verify_id_token", return_value={"uid": "test123"}):
+        with patch(f"{_AI}.alert_summary", new_callable=AsyncMock, side_effect=RuntimeError("llm_unavailable")):
+            r = client.post(
+                "/api/v1/ai/alert-summary",
+                json={"alert_id": _FAKE_ALERT_ID},
+                headers={"Authorization": "Bearer faketoken"},
+            )
+    assert r.status_code == 503
+
+
+def test_alert_summary_no_auth():
+    r = client.post(
+        "/api/v1/ai/alert-summary",
+        json={"alert_id": _FAKE_ALERT_ID},
+    )
+    assert r.status_code == 422
 
 

--- a/frontend/app/alerts/[id].tsx
+++ b/frontend/app/alerts/[id].tsx
@@ -54,6 +54,8 @@ export default function AlertDetailsScreen() {
   const [alert, setAlert] = useState<AlertData | null>(null);
   const [loading, setLoad] = useState(true);
   const [error, setError] = useState<{ status?: number } | null>(null);
+  const [aiSummary, setAiSummary] = useState<string | null>(null);
+  const [aiLoading, setAiLoading] = useState(false);
 
   const handleOpenBoletin = async () => {
     const url = "https://preparados.gob.mx/SIAT-CT/";
@@ -97,6 +99,35 @@ export default function AlertDetailsScreen() {
         level: Number(alert.level),
         score: Number(alert.score ?? 0),
       });
+    }
+  }, [alert]);
+
+  useEffect(() => {
+    if (!alert) return
+    setAiLoading(true)
+    let live = true
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 8000)
+    ;(async () => {
+      try {
+        const res = await authFetch(`${API_BASE_URL}/api/v1/ai/alert-summary`, {
+          method: 'POST',
+          body: JSON.stringify({ alert_id: alert.id }),
+          signal: controller.signal,
+        })
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const data = await res.json()
+        if (live) setAiSummary(data.summary)
+      } catch {
+        // falla silenciosamente — sección oculta
+      } finally {
+        clearTimeout(timeout)
+        if (live) setAiLoading(false)
+      }
+    })()
+    return () => {
+      live = false
+      controller.abort()
     }
   }, [alert]);
 
@@ -164,6 +195,24 @@ export default function AlertDetailsScreen() {
             <Text style={{ color: 'rgba(255,255,255,0.8)', fontFamily: fonts.poppins, fontSize: 15, lineHeight: 22 }}>
               {alert.short}
             </Text>
+          )}
+
+          {/* AI Summary */}
+          {(aiLoading || aiSummary) && (
+            <View>
+              <SectionPill title="RESUMEN IA:" color={baseColor} />
+              {aiLoading ? (
+                <View style={[styles.glassCard, { alignItems: 'center', paddingVertical: 20 }]}>
+                  <ActivityIndicator size="small" color={colors.brandCyan} />
+                </View>
+              ) : aiSummary ? (
+                <View style={styles.glassCard}>
+                  <Text style={{ color: 'rgba(255,255,255,0.9)', fontFamily: fonts.poppins, fontSize: 14, lineHeight: 22 }}>
+                    {aiSummary}
+                  </Text>
+                </View>
+              ) : null}
+            </View>
           )}
 
           {/* Recommendations */}


### PR DESCRIPTION
## Qué incluye
- POST `/api/v1/ai/alert-summary`
- Resumen IA usando OpenRouter/Llama
- Prompt optimizado para alertas de emergencia
- Manejo de errores 404 y 503
- Truncado seguro del resumen
- Integración frontend en pantalla de detalle de alerta
- Loading state + fail-silent UX
- Tests backend AI

## Tests
- `python3 -m pytest app/features/ai/tests/ -v`
- `python3 -m pytest -v`
- Resultado: 58 passed

## Fuera de alcance
- AlarmScreen
- SMN notifications
- Notification preferences UI