### PR TITLE
feat: add notification preferences UI

### DIFF
--- a/backend/app/features/ai/router.py
+++ b/backend/app/features/ai/router.py
@@ -1,6 +1,8 @@
 from fastapi import HTTPException, APIRouter, Depends
-from app.features.ai.service import chat
-from app.features.ai.schemas import ChatRequest, ChatResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.core.database import get_db
+from app.features.ai.service import chat, alert_summary
+from app.features.ai.schemas import ChatRequest, ChatResponse, AlertSummaryRequest, AlertSummaryResponse
 from app.core.auth import get_current_user
 
 
@@ -10,3 +12,18 @@ router = APIRouter()
 async def send_message(body: ChatRequest, user=Depends(get_current_user)):
     reply = await chat(body.messages, body.location, body.latitude, body.longitude)
     return ChatResponse(reply=reply)
+
+
+@router.post("/api/v1/ai/alert-summary", response_model=AlertSummaryResponse)
+async def post_alert_summary(
+    body: AlertSummaryRequest,
+    db: AsyncSession = Depends(get_db),
+    user=Depends(get_current_user),
+):
+    try:
+        summary = await alert_summary(db, body.alert_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Alerta no encontrada")
+    except RuntimeError:
+        raise HTTPException(status_code=503, detail="LLM no disponible")
+    return AlertSummaryResponse(alert_id=body.alert_id, summary=summary)

--- a/backend/app/features/ai/schemas.py
+++ b/backend/app/features/ai/schemas.py
@@ -12,3 +12,11 @@ class ChatRequest(BaseModel):
                                                                 
 class ChatResponse(BaseModel):
     reply: str
+
+
+class AlertSummaryRequest(BaseModel):
+    alert_id: str
+
+class AlertSummaryResponse(BaseModel):
+    alert_id: str
+    summary: str

--- a/backend/app/features/ai/service.py
+++ b/backend/app/features/ai/service.py
@@ -1,6 +1,11 @@
 import httpx
+import json
+import logging
 from app.core.config import settings
 from app.features.ai.rag import retrieve
+from app.features.alerts.service import get_alert_by_id
+
+logger = logging.getLogger(__name__)
 
 SYSTEM_PROMPT = """You are BluEye, an AI assistant specialized in hurricane preparedness, response, and recovery for residents of Mexico.
 
@@ -111,3 +116,54 @@ async def chat(messages: list[dict], location: str | None = None, latitude: floa
             raise RuntimeError(f"[chat:llm] LLM returned no choices: {data}")
 
         return data["choices"][0]["message"]["content"]
+
+
+_SUMMARY_SYSTEM_PROMPT = (
+    "Eres un asistente de alertas de emergencia para México. "
+    "Dado los datos de una alerta, genera un resumen conciso y útil para el ciudadano afectado. "
+    "Reglas estrictas: máximo 3 oraciones; español claro y directo; sin jerga técnica; "
+    "sin emojis; no repitas el título textualmente; no inventes datos que no estén en los datos proporcionados."
+)
+
+_SUMMARY_MAX_CHARS = 600
+
+
+async def alert_summary(db, alert_id: str) -> str:
+    alert = await get_alert_by_id(db, alert_id)
+    if alert is None:
+        raise ValueError("alert_not_found")
+
+    payload = json.dumps({
+        "titulo": alert["title"],
+        "descripcion": alert.get("short", ""),
+        "nivel": alert["level"],
+        "factores": alert.get("factors", []),
+        "recomendaciones": alert.get("recommendations", []),
+    }, ensure_ascii=False)
+
+    messages = [
+        {"role": "system", "content": _SUMMARY_SYSTEM_PROMPT},
+        {"role": "user",   "content": f"Genera un resumen de esta alerta:\n{payload}"},
+    ]
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                url=f"{settings.LLM_BASE_URL}/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {settings.LLM_API_KEY}",
+                    "Content-Type": "application/json",
+                },
+                json={"model": settings.LLM_MODEL, "messages": messages},
+                timeout=30.0,
+            )
+            data = response.json()
+            if "choices" not in data:
+                raise RuntimeError(f"LLM returned no choices: {data}")
+            summary = data["choices"][0]["message"]["content"]
+            return summary[:_SUMMARY_MAX_CHARS]
+    except RuntimeError:
+        raise
+    except Exception as exc:
+        logger.error("alert_summary LLM call failed: %s", exc, exc_info=True)
+        raise RuntimeError("llm_unavailable")

--- a/backend/app/features/ai/tests/test_router.py
+++ b/backend/app/features/ai/tests/test_router.py
@@ -61,12 +61,65 @@ def test_chat_no_auth():
             "messages": [
                 {"role": "user", "content": "hola"},
                 {"role": "bot", "content": "Wassup"}
-            ],    
+            ],
             "location": "Tuxpan",
             "latitude": 5,
             "longitude": 10,
         },
     )
     assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/ai/alert-summary
+# ---------------------------------------------------------------------------
+
+_AI = "app.features.ai.router"
+_FAKE_ALERT_ID = "00000000-0000-0000-0000-000000000001"
+
+
+def test_alert_summary_returns_summary():
+    with patch("app.core.auth.auth.verify_id_token", return_value={"uid": "test123"}):
+        with patch(f"{_AI}.alert_summary", new_callable=AsyncMock, return_value="Resumen de prueba.") as mock_svc:
+            r = client.post(
+                "/api/v1/ai/alert-summary",
+                json={"alert_id": _FAKE_ALERT_ID},
+                headers={"Authorization": "Bearer faketoken"},
+            )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["summary"] == "Resumen de prueba."
+    assert body["alert_id"] == _FAKE_ALERT_ID
+    mock_svc.assert_called_once()
+
+
+def test_alert_summary_404():
+    with patch("app.core.auth.auth.verify_id_token", return_value={"uid": "test123"}):
+        with patch(f"{_AI}.alert_summary", new_callable=AsyncMock, side_effect=ValueError("alert_not_found")):
+            r = client.post(
+                "/api/v1/ai/alert-summary",
+                json={"alert_id": "00000000-0000-0000-0000-000000000099"},
+                headers={"Authorization": "Bearer faketoken"},
+            )
+    assert r.status_code == 404
+
+
+def test_alert_summary_503():
+    with patch("app.core.auth.auth.verify_id_token", return_value={"uid": "test123"}):
+        with patch(f"{_AI}.alert_summary", new_callable=AsyncMock, side_effect=RuntimeError("llm_unavailable")):
+            r = client.post(
+                "/api/v1/ai/alert-summary",
+                json={"alert_id": _FAKE_ALERT_ID},
+                headers={"Authorization": "Bearer faketoken"},
+            )
+    assert r.status_code == 503
+
+
+def test_alert_summary_no_auth():
+    r = client.post(
+        "/api/v1/ai/alert-summary",
+        json={"alert_id": _FAKE_ALERT_ID},
+    )
+    assert r.status_code == 422
 
 

--- a/backend/app/features/siat/service.py
+++ b/backend/app/features/siat/service.py
@@ -93,6 +93,9 @@ async def ensure_siat_tables(engine: AsyncEngine) -> None:
                 updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
             )
         """))
+        await conn.execute(text(
+            "ALTER TABLE alerts ADD COLUMN IF NOT EXISTS notified_at TIMESTAMPTZ"
+        ))
     logger.info("SIAT tables verified/created")
 
 
@@ -289,38 +292,122 @@ async def _push_per_user(
 
 
 # ---------------------------------------------------------------------------
+# SMN/CONAGUA alerts → geocercado push
+# ---------------------------------------------------------------------------
+
+_SMN_RADIUS_KM = 500.0
+
+
+async def _get_pending_smn_alerts(db: AsyncSession) -> list:
+    result = await db.execute(text("""
+        SELECT id, title, short, level, lat, lon
+        FROM alerts
+        WHERE lat IS NOT NULL
+          AND lon IS NOT NULL
+          AND notified_at IS NULL
+          AND timestamp > NOW() - INTERVAL '35 minutes'
+        ORDER BY timestamp DESC
+    """))
+    return result.mappings().all()
+
+
+async def _mark_alert_notified(db: AsyncSession, alert_id) -> None:
+    await db.execute(
+        text("UPDATE alerts SET notified_at = NOW() WHERE id = :id"),
+        {"id": alert_id},
+    )
+
+
+async def _push_smn_for_alert(
+    db: AsyncSession, alert: dict, users: list
+) -> int:
+    affected_user_ids = []
+    for user in users:
+        dist = haversine_km(alert["lat"], alert["lon"], user["lat"], user["lon"])
+        if dist > _SMN_RADIUS_KM:
+            continue
+        prefs = await get_preferences(db, user["id"])
+        if prefs["siat_enabled"] and alert["level"] >= prefs["min_siat_level"]:
+            affected_user_ids.append(user["id"])
+
+    if not affected_user_ids:
+        return 0
+
+    token_map = await get_tokens_for_users(db, affected_user_ids)
+    all_tokens = [t for tokens in token_map.values() for t in tokens]
+    if not all_tokens:
+        return 0
+
+    msg = messaging.MulticastMessage(
+        notification=messaging.Notification(
+            title=f"Nueva alerta — {alert['title']}",
+            body=alert["short"],
+        ),
+        data={
+            "alert_id": str(alert["id"]),
+            "level": str(alert["level"]),
+            "siat_level": str(alert["level"]),
+        },
+        android=messaging.AndroidConfig(priority="high"),
+        apns=messaging.APNSConfig(
+            headers={"apns-priority": "10"},
+        ),
+        tokens=all_tokens,
+    )
+
+    total_sent = 0
+    try:
+        response = await asyncio.to_thread(messaging.send_each_for_multicast, msg)
+        total_sent = response.success_count
+        logger.info(
+            "SMN push alert_id=%s level=%d users=%d success=%d failure=%d",
+            alert["id"], alert["level"], len(affected_user_ids),
+            response.success_count, response.failure_count,
+        )
+        if response.failure_count:
+            failed = [all_tokens[i] for i, r in enumerate(response.responses) if not r.success]
+            logger.warning("SMN push failures alert_id=%s: %s", alert["id"], failed[:5])
+    except Exception as exc:
+        logger.error("SMN push failed for alert_id=%s: %s", alert["id"], exc, exc_info=True)
+
+    if total_sent > 0:
+        await _mark_alert_notified(db, alert["id"])
+
+    return total_sent
+
+
+async def _notify_smn_alerts(db: AsyncSession, users: list) -> int:
+    if not users:
+        return 0
+
+    alerts = await _get_pending_smn_alerts(db)
+    if not alerts:
+        logger.debug("SMN: no pending alerts")
+        return 0
+
+    total_sent = 0
+    for alert in alerts:
+        total_sent += await _push_smn_for_alert(db, alert, users)
+
+    return total_sent
+
+
+# ---------------------------------------------------------------------------
 # Main orchestrator
 # ---------------------------------------------------------------------------
 
 async def run_cycle(db: AsyncSession) -> dict:
     logger.info("SIAT run-cycle started")
 
-    cyclones = await fetch_active_cyclones()
-    if not cyclones:
-        logger.info("SIAT run-cycle: no active cyclones, nothing to do")
-        return {
-            "cyclones_found": 0,
-            "users_evaluated": 0,
-            "notifications_sent": 0,
-            "assessments": [],
-        }
-
     users = await _get_users_with_location(db)
-    if not users:
-        logger.warning("SIAT run-cycle: %d cyclone(s) found but no users with location", len(cyclones))
-        return {
-            "cyclones_found": len(cyclones),
-            "users_evaluated": 0,
-            "notifications_sent": 0,
-            "assessments": [],
-        }
+    cyclones = await fetch_active_cyclones()
 
     logger.info("SIAT run-cycle: %d cyclone(s), %d user(s) with location", len(cyclones), len(users))
 
     all_assessments: list[dict] = []
     escalations: dict[int, dict] = {}  # user_id → highest assessment this cycle
 
-    for cyclone in cyclones:
+    for cyclone in (cyclones if users else []):
         try:
             cyclone_id = await _save_cyclone(db, cyclone)
             logger.info("Cyclone saved: id=%d name=%s status=%s", cyclone_id, cyclone["name"], cyclone["status"])
@@ -387,6 +474,8 @@ async def run_cycle(db: AsyncSession) -> dict:
             await _mark_notified(db, user_id, assessment["siat_level"])
     else:
         logger.info("SIAT run-cycle: no escalations, no push sent")
+
+    notifications_sent += await _notify_smn_alerts(db, users)
 
     await db.commit()
 

--- a/backend/app/features/siat/tests/test_router.py
+++ b/backend/app/features/siat/tests/test_router.py
@@ -288,6 +288,7 @@ def _base_run_cycle_patches(assessment, prefs, push_return=0):
         patch(f"{_SVC}.get_tokens_for_users", new_callable=AsyncMock, return_value={1: ["token-abc"]}),
         patch(f"{_SVC}._push_per_user", new_callable=AsyncMock, return_value=push_return),
         patch(f"{_SVC}._mark_notified", new_callable=AsyncMock, return_value=None),
+        patch(f"{_SVC}._notify_smn_alerts", new_callable=AsyncMock, return_value=0),
     ]
 
 
@@ -302,7 +303,7 @@ async def test_run_cycle_respects_siat_disabled():
 
     patches = _base_run_cycle_patches(_ASSESSMENT_LEVEL_3, prefs, push_return=0)
     with patches[0], patches[1], patches[2], patches[3], patches[4], \
-         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10]:
+         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11]:
         result = await run_cycle(db)
 
     assert result["notifications_sent"] == 0
@@ -319,7 +320,7 @@ async def test_run_cycle_respects_min_siat_level():
 
     patches = _base_run_cycle_patches(_ASSESSMENT_LEVEL_2, prefs, push_return=0)
     with patches[0], patches[1], patches[2], patches[3], patches[4], \
-         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10]:
+         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11]:
         result = await run_cycle(db)
 
     assert result["notifications_sent"] == 0
@@ -336,7 +337,140 @@ async def test_run_cycle_sends_push_when_prefs_allow():
 
     patches = _base_run_cycle_patches(_ASSESSMENT_LEVEL_2, prefs, push_return=1)
     with patches[0], patches[1], patches[2], patches[3], patches[4], \
-         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10]:
+         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11]:
         result = await run_cycle(db)
 
     assert result["notifications_sent"] == 1
+
+
+# ---------------------------------------------------------------------------
+# SMN/CONAGUA alerts → geocercado push — service-level tests
+# ---------------------------------------------------------------------------
+
+_FAKE_SMN_ALERT = {
+    "id": "alert-uuid-1",
+    "title": "Tormenta severa",
+    "short": "Lluvias intensas en la región",
+    "level": 3,
+    "lat": 20.5,
+    "lon": -98.0,
+}
+
+_FAKE_USER_NEARBY = {"id": 1, "lat": 20.5, "lon": -98.0}   # 0 km
+_FAKE_USER_FAR    = {"id": 2, "lat": 30.0, "lon": -80.0}   # > 500 km
+
+
+@pytest.mark.asyncio
+async def test_smn_recent_alert_user_in_range_sends_and_marks():
+    """Recent alert + user inside 500 km + default prefs → push sent and alert marked."""
+    from app.features.siat.service import _notify_smn_alerts
+
+    prefs = {"siat_enabled": True, "min_siat_level": 2, "map_events_enabled": True}
+    db = MagicMock()
+
+    with patch(f"{_SVC}._get_pending_smn_alerts", new_callable=AsyncMock, return_value=[_FAKE_SMN_ALERT]), \
+         patch(f"{_SVC}.get_preferences", new_callable=AsyncMock, return_value=prefs), \
+         patch(f"{_SVC}.get_tokens_for_users", new_callable=AsyncMock, return_value={1: ["token-abc"]}), \
+         patch(f"{_SVC}._mark_alert_notified", new_callable=AsyncMock) as mock_mark, \
+         patch(f"{_SVC}.messaging") as mock_messaging:
+
+        fake_response = MagicMock()
+        fake_response.success_count = 1
+        fake_response.failure_count = 0
+        fake_response.responses = [MagicMock(success=True)]
+        mock_messaging.send_each_for_multicast.return_value = fake_response
+        mock_messaging.MulticastMessage = MagicMock()
+        mock_messaging.Notification = MagicMock()
+        mock_messaging.AndroidConfig = MagicMock()
+        mock_messaging.APNSConfig = MagicMock()
+
+        total = await _notify_smn_alerts(db, [_FAKE_USER_NEARBY])
+
+    assert total == 1
+    mock_mark.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_smn_no_pending_alerts_returns_zero():
+    """No pending alerts → _notify_smn_alerts returns 0 without sending anything."""
+    from app.features.siat.service import _notify_smn_alerts
+
+    db = MagicMock()
+
+    with patch(f"{_SVC}._get_pending_smn_alerts", new_callable=AsyncMock, return_value=[]):
+        total = await _notify_smn_alerts(db, [_FAKE_USER_NEARBY])
+
+    assert total == 0
+
+
+@pytest.mark.asyncio
+async def test_smn_no_users_returns_zero():
+    """Empty user list → _notify_smn_alerts returns 0 immediately."""
+    from app.features.siat.service import _notify_smn_alerts
+
+    db = MagicMock()
+
+    with patch(f"{_SVC}._get_pending_smn_alerts", new_callable=AsyncMock) as mock_alerts:
+        total = await _notify_smn_alerts(db, [])
+
+    assert total == 0
+    mock_alerts.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_smn_user_out_of_range_no_push():
+    """User beyond 500 km → push skipped and alert NOT marked as notified."""
+    from app.features.siat.service import _notify_smn_alerts
+
+    db = MagicMock()
+    prefs = {"siat_enabled": True, "min_siat_level": 2, "map_events_enabled": True}
+
+    with patch(f"{_SVC}._get_pending_smn_alerts", new_callable=AsyncMock, return_value=[_FAKE_SMN_ALERT]), \
+         patch(f"{_SVC}.get_preferences", new_callable=AsyncMock, return_value=prefs), \
+         patch(f"{_SVC}.get_tokens_for_users", new_callable=AsyncMock, return_value={}) as mock_tokens, \
+         patch(f"{_SVC}._mark_alert_notified", new_callable=AsyncMock) as mock_mark:
+
+        total = await _notify_smn_alerts(db, [_FAKE_USER_FAR])
+
+    assert total == 0
+    mock_mark.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_smn_siat_disabled_no_push():
+    """User with siat_enabled=False → push filtered even if inside radius."""
+    from app.features.siat.service import _notify_smn_alerts
+
+    db = MagicMock()
+    prefs = {"siat_enabled": False, "min_siat_level": 2, "map_events_enabled": True}
+
+    with patch(f"{_SVC}._get_pending_smn_alerts", new_callable=AsyncMock, return_value=[_FAKE_SMN_ALERT]), \
+         patch(f"{_SVC}.get_preferences", new_callable=AsyncMock, return_value=prefs), \
+         patch(f"{_SVC}.get_tokens_for_users", new_callable=AsyncMock, return_value={}) as mock_tokens, \
+         patch(f"{_SVC}._mark_alert_notified", new_callable=AsyncMock) as mock_mark:
+
+        total = await _notify_smn_alerts(db, [_FAKE_USER_NEARBY])
+
+    assert total == 0
+    mock_mark.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_smn_min_siat_level_filters_alert():
+    """Alert level=2 but user min_siat_level=3 → push filtered."""
+    from app.features.siat.service import _notify_smn_alerts
+
+    db = MagicMock()
+    prefs = {"siat_enabled": True, "min_siat_level": 3, "map_events_enabled": True}
+
+    alert_level2 = {**_FAKE_SMN_ALERT, "level": 2}
+
+    with patch(f"{_SVC}._get_pending_smn_alerts", new_callable=AsyncMock, return_value=[alert_level2]), \
+         patch(f"{_SVC}.get_preferences", new_callable=AsyncMock, return_value=prefs), \
+         patch(f"{_SVC}.get_tokens_for_users", new_callable=AsyncMock, return_value={}) as mock_tokens, \
+         patch(f"{_SVC}._mark_alert_notified", new_callable=AsyncMock) as mock_mark:
+
+        total = await _notify_smn_alerts(db, [_FAKE_USER_NEARBY])
+
+    assert total == 0
+    mock_mark.assert_not_called()

--- a/frontend/app/AlarmScreen.jsx
+++ b/frontend/app/AlarmScreen.jsx
@@ -1,82 +1,36 @@
-// Component for displaying an emergency alert modal with options to view on map or get more details. Not displayed on production.
-import { useState, useEffect } from "react";
 import { Modal, View, Text, TouchableOpacity } from "react-native";
-import { Link, useRouter } from "expo-router";
+import { Link, useRouter, useLocalSearchParams } from "expo-router";
 import { colorForLevel } from "./alerts/_components/AlertCard";
 
-// 5 alertas reales del backend (Huracán Otis)
-const MOCK_ALERTS = [
-  {
-    id: "684e081d-e71f-4137-8d06-7a57ca67da17",
-    category: 1,
-    title: "Huracán Otis – Alerta",
-    message: "Monitoreo preventivo, ciclón a distancia. Manténgase informado y prepare su kit de emergencia.",
-    distanceKm: 250,
-    etaHours: 36,
-  },
-  {
-    id: "bcab852c-9425-4d9b-afa2-91967b0ecd3f",
-    category: 2,
-    title: "Huracán Otis – Alerta Verde",
-    message: "Mayor vigilancia, condiciones adversas probables. Refuerce ventanas y asegure objetos exteriores.",
-    distanceKm: 180,
-    etaHours: 24,
-  },
-  {
-    id: "05252d37-9a24-445e-aa4b-8dbe041a256c",
-    category: 3,
-    title: "Huracán Otis – Alerta Amarilla",
-    message: "Condiciones peligrosas, el ciclón se acerca. Prepárate para evacuar y sigue las indicaciones oficiales.",
-    distanceKm: 100,
-    etaHours: 14,
-  },
-  {
-    id: "7d921fa3-6a6d-4b5b-ba48-539818675a27",
-    category: 4,
-    title: "Huracán Otis – Alerta Roja",
-    message: "¡PELIGRO EXTREMO! Condiciones extremadamente peligrosas en avance. EVACUE INMEDIATAMENTE si está en zona de riesgo.",
-    distanceKm: 60,
-    etaHours: 8,
-  },
-  {
-    id: "b74faf40-88cd-419f-8c7d-9d2c23ddc43f",
-    category: 5,
-    title: "Huracán Otis – Impacto Máximo",
-    message: "⚠️ ALERTA MÁXIMA ⚠️ Vientos extremos y lluvias torrenciales. Impacto INMINENTE. BUSQUE REFUGIO SEGURO AHORA.",
-    distanceKm: 30,
-    etaHours: 4,
-  },
-];
-
 export default function AlarmScreen() {
-  const [visible, setVisible] = useState(false);
-  const [currentAlert, setCurrentAlert] = useState(null);
-
-  useEffect(() => {
-    // Seleccionar alerta aleatoria al montar
-    const randomIndex = Math.floor(Math.random() * MOCK_ALERTS.length);
-    setCurrentAlert(MOCK_ALERTS[randomIndex]);
-
-    const t = setTimeout(() => setVisible(true), 250);
-    return () => clearTimeout(t);
-  }, []);
-
+  const { alertId, category, title, message } = useLocalSearchParams();
   const router = useRouter();
-  const handleMap = () => {
-    setVisible(false);
-    router.push("/MapScreen");
+
+  const alertData = {
+    id:       alertId  || null,
+    category: Number(category) || 4,
+    title:    String(title   || "Alerta de emergencia"),
+    message:  String(message || "Siga las indicaciones de las autoridades."),
   };
-  const handleClose = () => setVisible(false);
 
-  // No renderizar hasta tener alerta seleccionada
-  if (!currentAlert) return null;
+  const handleClose = () => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace("/(tabs)/MapScreen");
+    }
+  };
 
-  const baseColor = colorForLevel(currentAlert.category);
-  const buttonColor = `${baseColor}50`; // 50 = 31% opacity (semitransparente)
-  const categoryBadgeColor = `${baseColor}90`; // 90 = 56% opacity (más visible para el badge)
+  const handleMap = () => {
+    router.replace("/(tabs)/MapScreen");
+  };
+
+  const baseColor = colorForLevel(alertData.category);
+  const buttonColor = `${baseColor}50`;
+  const categoryBadgeColor = `${baseColor}90`;
 
   return (
-    <Modal animationType="slide" transparent visible={visible} onRequestClose={handleClose}>
+    <Modal animationType="slide" transparent visible onRequestClose={handleClose}>
       <View className="flex-1 justify-center items-center bg-black/70">
         <View
           className="w-11/12 max-w-md rounded-2xl p-6 shadow-xl bg-white"
@@ -89,31 +43,20 @@ export default function AlarmScreen() {
               style={{ backgroundColor: categoryBadgeColor }}
             >
               <Text className="text-white font-bold text-sm">
-                Categoría {currentAlert.category}
+                Categoría {alertData.category}
               </Text>
             </View>
           </View>
 
           {/* Título */}
           <Text className="text-2xl font-extrabold text-center mb-4" style={{ color: '#111827' }}>
-            {currentAlert.title}
+            {alertData.title}
           </Text>
 
           {/* Mensaje breve */}
           <Text className="text-base text-center mb-6" style={{ color: '#374151' }}>
-            {currentAlert.message}
+            {alertData.message}
           </Text>
-
-          {/* Datos clave */}
-          {/* <View className="space-y-1 mb-8">
-            <Stat label="Distancia" value={`${MOCK_ALERT.distanceKm} km`} />
-            <Stat label="ETA" value={`${MOCK_ALERT.etaHours} h`} />
-            <Stat label="Viento" value={`${MOCK_ALERT.windKmh} km/h`} />
-            <Stat label="Ráfagas" value={`${MOCK_ALERT.gustKmh} km/h`} />
-            <Stat label="Presión" value={`${MOCK_ALERT.pressureMb} mb`} />
-            <Stat label="Lluvia 1 h" value={`${MOCK_ALERT.rain1h} mm`} />
-            <Stat label="Prob. lluvia" value={`${Math.round(MOCK_ALERT.pop * 100)} %`} />
-          </View> */}
 
           {/* Botones */}
           <View className="flex-row justify-between mb-6">
@@ -125,7 +68,7 @@ export default function AlarmScreen() {
               <Text className="font-bold" style={{ color: baseColor }}>Ver en el mapa</Text>
             </TouchableOpacity>
 
-            <Link href={`/alerts/${currentAlert.id}`} asChild>
+            <Link href={alertData.id ? `/alerts/${alertData.id}` : "/alerts"} asChild>
               <TouchableOpacity
                 className="flex-1 ml-2 py-3 rounded-lg items-center"
                 style={{ backgroundColor: buttonColor }}
@@ -146,14 +89,5 @@ export default function AlarmScreen() {
         </View>
       </View>
     </Modal>
-  );
-}
-
-function Stat({ label, value }) {
-  return (
-    <Text className="text-phase2Titles">
-      <Text className="font-bold">{label}: </Text>
-      {value}
-    </Text>
   );
 }

--- a/frontend/app/NotificationPreferencesScreen.tsx
+++ b/frontend/app/NotificationPreferencesScreen.tsx
@@ -1,0 +1,218 @@
+import "../global.css";
+import { useState, useEffect } from "react";
+import { View, Text, Switch, ScrollView, TouchableOpacity, Alert, ActivityIndicator, StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import ScreenHeader from "../components/ScreenHeader";
+import OptionCard from "../components/OptionCard";
+import { authFetch } from "../utils/api";
+import { API_BASE_URL } from "../utils/config";
+import { colors, fonts } from "../utils/theme";
+
+interface Prefs {
+  siat_enabled: boolean;
+  min_siat_level: number;
+  map_events_enabled: boolean;
+}
+
+const DEFAULTS: Prefs = {
+  siat_enabled: true,
+  min_siat_level: 2,
+  map_events_enabled: true,
+};
+
+const LEVEL_OPTIONS = [
+  { label: "Verde",    value: 2, color: colors.brandGreen  },
+  { label: "Amarillo", value: 3, color: colors.brandYellow },
+  { label: "Naranja",  value: 4, color: colors.brandOrange },
+  { label: "Rojo",     value: 5, color: colors.brandRed    },
+];
+
+function normalizePrefs(data: Partial<Prefs>): Prefs {
+  return {
+    siat_enabled:       typeof data.siat_enabled === "boolean"   ? data.siat_enabled       : DEFAULTS.siat_enabled,
+    min_siat_level:     typeof data.min_siat_level === "number"  ? data.min_siat_level      : DEFAULTS.min_siat_level,
+    map_events_enabled: typeof data.map_events_enabled === "boolean" ? data.map_events_enabled : DEFAULTS.map_events_enabled,
+  };
+}
+
+export default function NotificationPreferencesScreen() {
+  const [prefs, setPrefs]   = useState<Prefs>(DEFAULTS);
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let live = true;
+    (async () => {
+      try {
+        const res = await authFetch(`${API_BASE_URL}/api/v1/notification-preferences`);
+        const data = await res.json();
+        if (live) setPrefs(normalizePrefs(data));
+      } catch {
+        if (live) setFetchError(true);
+      } finally {
+        if (live) setLoading(false);
+      }
+    })();
+    return () => { live = false; };
+  }, []);
+
+  async function patchPrefs(update: Partial<Prefs>) {
+    if (saving) return;
+    const prev = prefs;
+    setSaving(true);
+    setPrefs(p => ({ ...p, ...update }));
+    try {
+      const res = await authFetch(`${API_BASE_URL}/api/v1/notification-preferences`, {
+        method: "PATCH",
+        body: JSON.stringify(update),
+      });
+      if (!res.ok) throw new Error();
+    } catch {
+      setPrefs(prev);
+      Alert.alert("Error", "No se pudo guardar el cambio. Intenta de nuevo.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const switchProps = {
+    thumbColor: "#fff",
+    trackColor: { false: "#9ca3af", true: colors.brandCyan },
+    ios_backgroundColor: "#9ca3af",
+    disabled: saving,
+  };
+
+  if (loading) {
+    return (
+      <SafeAreaView className="flex-1 bg-transparent" edges={["top", "bottom"]}>
+        <ScreenHeader title="Notificaciones" />
+        <View style={styles.centered}>
+          <View style={styles.glassCard}>
+            <ActivityIndicator size="large" color={colors.brandCyan} />
+          </View>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <SafeAreaView className="flex-1 bg-transparent" edges={["top", "bottom"]}>
+        <ScreenHeader title="Notificaciones" />
+        <View style={styles.centered}>
+          <View style={styles.glassCard}>
+            <Text style={{ color: "white", fontFamily: fonts.poppins, textAlign: "center" }}>
+              Error al cargar preferencias. Vuelve a intentarlo.
+            </Text>
+          </View>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView className="flex-1 bg-transparent" edges={["top", "bottom"]}>
+      <ScreenHeader title="Notificaciones" />
+
+      <ScrollView className="flex-1 pt-6" showsVerticalScrollIndicator={false}>
+
+        {/* Toggle: Alertas SIAT */}
+        <OptionCard
+          icon="bell-ring-outline"
+          title="Alertas SIAT"
+          rightElement={
+            <Switch
+              value={prefs.siat_enabled}
+              onValueChange={v => patchPrefs({ siat_enabled: v })}
+              {...switchProps}
+            />
+          }
+        />
+
+        {/* Nivel mínimo — visible solo cuando SIAT está activo */}
+        {prefs.siat_enabled && (
+          <View style={{ marginHorizontal: 16, marginTop: 8 }}>
+            <Text style={styles.sectionLabel}>Nivel mínimo de alerta</Text>
+            <View style={{ flexDirection: "row" }}>
+              {LEVEL_OPTIONS.map(opt => {
+                const isSelected = prefs.min_siat_level === opt.value;
+                return (
+                  <TouchableOpacity
+                    key={opt.value}
+                    onPress={() => patchPrefs({ min_siat_level: opt.value })}
+                    disabled={saving}
+                    style={[
+                      styles.chip,
+                      {
+                        backgroundColor: isSelected ? opt.color : `${opt.color}4D`,
+                        borderWidth: isSelected ? 2 : 0,
+                        opacity: saving ? 0.6 : 1,
+                      },
+                    ]}
+                  >
+                    <Text style={[styles.chipLabel, { color: isSelected ? "#fff" : `${opt.color}CC` }]}>
+                      {opt.label}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+          </View>
+        )}
+
+        {/* Toggle: Eventos del mapa */}
+        <OptionCard
+          icon="map-marker-outline"
+          title="Eventos del mapa"
+          rightElement={
+            <Switch
+              value={prefs.map_events_enabled}
+              onValueChange={v => patchPrefs({ map_events_enabled: v })}
+              {...switchProps}
+            />
+          }
+        />
+
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  centered: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 24,
+  },
+  glassCard: {
+    backgroundColor: "rgba(10, 28, 50, 0.6)",
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.1)",
+    padding: 24,
+    width: "100%",
+    alignItems: "center",
+  },
+  sectionLabel: {
+    color: "rgba(255,255,255,0.6)",
+    fontFamily: fonts.poppins,
+    fontSize: 12,
+    letterSpacing: 1,
+    textTransform: "uppercase",
+    marginBottom: 10,
+  },
+  chip: {
+    flex: 1,
+    marginHorizontal: 4,
+    paddingVertical: 10,
+    borderRadius: 12,
+    alignItems: "center",
+    borderColor: "white",
+  },
+  chipLabel: {
+    fontFamily: fonts.poppinsSemiBold,
+    fontSize: 12,
+  },
+});

--- a/frontend/app/SettingsScreen.tsx
+++ b/frontend/app/SettingsScreen.tsx
@@ -1,7 +1,6 @@
 import "../global.css";
 import { clearOnboardingData } from './onboarding/_services/onboardingService';
-import { useState } from "react";
-import { Alert, Switch, Text, ScrollView } from "react-native";
+import { Alert, Text, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
@@ -12,7 +11,6 @@ import ScreenHeader from "../components/ScreenHeader";
 import OptionCard from "../components/OptionCard";
 export default function SettingsScreen() {
   const router = useRouter();
-  const [isNotificationsEnabled, setNotificationsEnabled] = useState(false);
   const { modelOptedIn, optIn, optOut, retryDownload, downloadProgress, modelReady, modelError } = useModel();
   const { signOut, deleteAccount } = useAuth();
 
@@ -103,15 +101,7 @@ export default function SettingsScreen() {
         <OptionCard
           icon="bell-outline"
           title="Notificaciones"
-          rightElement={
-            <Switch
-              value={isNotificationsEnabled}
-              onValueChange={setNotificationsEnabled}
-              thumbColor="#fff"
-              trackColor={{ false: "#9ca3af", true: "rgb(60,200,220)" }}
-              ios_backgroundColor="#9ca3af"
-            />
-          }
+          onPress={() => router.push('/NotificationPreferencesScreen')}
         />
 
         <OptionCard icon="account-outline" title="Cuenta" onPress={showComingSoon} />

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -277,6 +277,10 @@ export default Sentry.wrap(function Layout() {
                       options={{ headerShown: false }}
                     />
                     <Stack.Screen
+                      name="NotificationPreferencesScreen"
+                      options={{ headerShown: false }}
+                    />
+                    <Stack.Screen
                       name="AlarmScreen"
                       options={{ headerShown: false }}
                     />

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -9,7 +9,7 @@ import { DaltonicModeProvider } from "../context/DaltonicModeContext";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { LinearGradient } from "expo-linear-gradient";
 import { gradients } from "../utils/theme";
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { useFonts } from "expo-font";
 import { AppState, Platform, StatusBar as RNStatusBar } from "react-native";
 import { StatusBar } from "expo-status-bar";
@@ -53,12 +53,37 @@ const DEV_BYPASS_AUTH = process.env.EXPO_PUBLIC_DEV_BYPASS_AUTH === 'true'
 
 interface NotificationData {
   alertId?: string
+  alert_id?: string
   alertLevel?: string
+  level?: string
+  siat_level?: string
+  siat_color?: string
   fullScreen?: string
   category?: string
   alertTitle?: string
   alertMessage?: string
   bulletinUrl?: string
+}
+
+function resolveNotifPayload(
+  data: NotificationData,
+  content?: { title?: string | null; body?: string | null }
+) {
+  const id = data.alertId || data.alert_id
+  const levelNum = Number(data.level ?? data.siat_level ?? data.alertLevel ?? 0)
+  const isFullScreen = data.fullScreen === 'true' || levelNum >= 4
+  return {
+    id,
+    levelNum,
+    isFullScreen,
+    params: {
+      alertId: id,
+      category: data.category ?? String(levelNum),
+      title: data.alertTitle ?? content?.title ?? "Alerta de emergencia",
+      message: data.alertMessage ?? content?.body ?? "Siga las indicaciones de las autoridades.",
+      bulletinUrl: data.bulletinUrl,
+    },
+  }
 }
 
 function AuthGate({ children }) {
@@ -105,6 +130,7 @@ function AuthGate({ children }) {
 /* ---------- Layout raíz ---------- */
 export default Sentry.wrap(function Layout() {
   const router = useRouter();
+  const alarmActiveRef = React.useRef(false);
 
   const [fontsLoaded] = useFonts({
     'Square721': require('../assets/fonts/square-721-bold-extended-bt.ttf'),
@@ -124,78 +150,68 @@ export default Sentry.wrap(function Layout() {
   useEffect(() => {
     setForegroundNotificationHandler();
 
-    // 👇 Cuando el usuario pulse la notificación (o llegue automáticamente si es critical)
-    const sub = addNotificationResponseListener(async (rawData) => {
+    // Tap en notificación (background → foreground, o foreground tap)
+    const tapSub = addNotificationResponseListener(async (rawData) => {
       const data = rawData as NotificationData
-      if (data?.alertId) {
-        await initAnalytics();
-        track("push_open", {
-          alertId: String(data.alertId),
-          alertLevel: data.alertLevel ? Number(data.alertLevel) : undefined,
-          fullScreen: data.fullScreen === 'true',
-          origin: "listener",
-        });
+      const { id, isFullScreen, params } = resolveNotifPayload(data)
+      if (!id && !isFullScreen) return
 
-        // Si es full-screen (crítica cat 3+) → AlarmScreen
-        // Si no → Alert details
-        if (data.fullScreen === 'true') {
-          router.push({
-            pathname: "AlarmScreen",
-            params: {
-              alertId: data.alertId,
-              category: data.category || data.alertLevel,
-              title: data.alertTitle || "Alerta de huracán",
-              message: data.alertMessage || "Diríjase a un refugio seguro",
-              bulletinUrl: data.bulletinUrl || "https://www.nhc.noaa.gov/",
-            },
-          });
-        } else {
-          router.push({
-            pathname: "/alerts/[id]",
-            params: { id: data.alertId },
-          });
-        }
+      await initAnalytics();
+      track("push_open", {
+        alertId: id ? String(id) : undefined,
+        alertLevel: params.category ? Number(params.category) : undefined,
+        fullScreen: isFullScreen,
+        origin: "listener",
+      });
+
+      if (isFullScreen) {
+        router.push({ pathname: "AlarmScreen", params });
+      } else if (id) {
+        router.push({ pathname: "/alerts/[id]", params: { id } });
       }
     });
 
-    return () => sub.remove(); // limpia al desmontar
+    // Notificación recibida mientras la app está abierta → AlarmScreen si nivel >= 4
+    const receivedSub = Notifications.addNotificationReceivedListener((notification) => {
+      const rawData = notification.request.content.data as NotificationData
+      const content = notification.request.content
+      const { isFullScreen, params } = resolveNotifPayload(rawData, content)
+      if (isFullScreen && !alarmActiveRef.current) {
+        alarmActiveRef.current = true
+        router.push({ pathname: "AlarmScreen", params })
+        // Liberar el guard después de un debounce para cubrir multi-push
+        setTimeout(() => { alarmActiveRef.current = false }, 5000)
+      }
+    });
+
+    return () => {
+      tapSub.remove();
+      receivedSub.remove();
+    };
   }, []);
 
-  // Si la app se abrió tocando una notificación, esta llamada la devuelve
+  // App abierta tocando una notificación desde cold start
   useEffect(() => {
     (async () => {
       const initial = await Notifications.getLastNotificationResponseAsync();
       const data = initial?.notification?.request?.content?.data as NotificationData | undefined
-      const alertId = data?.alertId;
+      if (!data) return
 
-      if (alertId) {
-        await initAnalytics();
-        track("push_open", {
-          alertId: String(alertId),
-          alertLevel: data?.alertLevel ? Number(data.alertLevel) : undefined,
-          fullScreen: data?.fullScreen === 'true',
-          origin: "initial",
-        });
+      const { id, isFullScreen, params } = resolveNotifPayload(data)
+      if (!id && !isFullScreen) return
 
-        // Si es full-screen (crítica cat 3+) → AlarmScreen
-        // Si no → Alert details
-        if (data?.fullScreen === 'true') {
-          router.push({
-            pathname: "AlarmScreen",
-            params: {
-              alertId: data.alertId,
-              category: data.category || data.alertLevel,
-              title: data.alertTitle || "Alerta de huracán",
-              message: data.alertMessage || "Diríjase a un refugio seguro",
-              bulletinUrl: data.bulletinUrl || "https://www.nhc.noaa.gov/",
-            },
-          });
-        } else {
-          router.push({
-            pathname: "/alerts/[id]",
-            params: { id: alertId },
-          });
-        }
+      await initAnalytics();
+      track("push_open", {
+        alertId: id ? String(id) : undefined,
+        alertLevel: params.category ? Number(params.category) : undefined,
+        fullScreen: isFullScreen,
+        origin: "initial",
+      });
+
+      if (isFullScreen) {
+        router.push({ pathname: "AlarmScreen", params });
+      } else if (id) {
+        router.push({ pathname: "/alerts/[id]", params: { id } });
       }
     })();
   }, []);

--- a/frontend/app/alerts/[id].tsx
+++ b/frontend/app/alerts/[id].tsx
@@ -54,6 +54,8 @@ export default function AlertDetailsScreen() {
   const [alert, setAlert] = useState<AlertData | null>(null);
   const [loading, setLoad] = useState(true);
   const [error, setError] = useState<{ status?: number } | null>(null);
+  const [aiSummary, setAiSummary] = useState<string | null>(null);
+  const [aiLoading, setAiLoading] = useState(false);
 
   const handleOpenBoletin = async () => {
     const url = "https://preparados.gob.mx/SIAT-CT/";
@@ -97,6 +99,35 @@ export default function AlertDetailsScreen() {
         level: Number(alert.level),
         score: Number(alert.score ?? 0),
       });
+    }
+  }, [alert]);
+
+  useEffect(() => {
+    if (!alert) return
+    setAiLoading(true)
+    let live = true
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 8000)
+    ;(async () => {
+      try {
+        const res = await authFetch(`${API_BASE_URL}/api/v1/ai/alert-summary`, {
+          method: 'POST',
+          body: JSON.stringify({ alert_id: alert.id }),
+          signal: controller.signal,
+        })
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const data = await res.json()
+        if (live) setAiSummary(data.summary)
+      } catch {
+        // falla silenciosamente — sección oculta
+      } finally {
+        clearTimeout(timeout)
+        if (live) setAiLoading(false)
+      }
+    })()
+    return () => {
+      live = false
+      controller.abort()
     }
   }, [alert]);
 
@@ -164,6 +195,24 @@ export default function AlertDetailsScreen() {
             <Text style={{ color: 'rgba(255,255,255,0.8)', fontFamily: fonts.poppins, fontSize: 15, lineHeight: 22 }}>
               {alert.short}
             </Text>
+          )}
+
+          {/* AI Summary */}
+          {(aiLoading || aiSummary) && (
+            <View>
+              <SectionPill title="RESUMEN IA:" color={baseColor} />
+              {aiLoading ? (
+                <View style={[styles.glassCard, { alignItems: 'center', paddingVertical: 20 }]}>
+                  <ActivityIndicator size="small" color={colors.brandCyan} />
+                </View>
+              ) : aiSummary ? (
+                <View style={styles.glassCard}>
+                  <Text style={{ color: 'rgba(255,255,255,0.9)', fontFamily: fonts.poppins, fontSize: 14, lineHeight: 22 }}>
+                    {aiSummary}
+                  </Text>
+                </View>
+              ) : null}
+            </View>
           )}
 
           {/* Recommendations */}


### PR DESCRIPTION
## Qué incluye
- Pantalla de preferencias de notificaciones
- Integración GET/PATCH con notification_preferences
- Toggle para alertas SIAT
- Selector de nivel mínimo (Verde/Amarillo/Naranja/Rojo)
- Toggle para eventos del mapa
- Optimistic updates con revert en error
- Protección contra race conditions
- Loading/error states
- Navegación desde Settings

## UX
- Cambios persistidos en tiempo real
- Controles deshabilitados durante guardado
- Fallback seguro a defaults frontend
- Estilo consistente con glassmorphism actual

## Fuera de alcance
- Backend
- AlarmScreen
- AI summary
- Quiet hours / preferencias avanzadas