### PR TITLE
feat: add quiet hours notification preferences

### DIFF
--- a/backend/app/features/notification_preferences/router.py
+++ b/backend/app/features/notification_preferences/router.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import get_db
 from app.core.auth import get_current_user
 from app.features.users.service import get_user_by_firebase_uid
-from app.features.notification_preferences.service import get_preferences, upsert_preferences
+from app.features.notification_preferences.service import get_preferences, upsert_preferences, QuietHoursValidationError
 from app.features.notification_preferences.schemas import NotificationPreferences, NotificationPreferencesPatch
 
 router = APIRouter()
@@ -34,10 +34,5 @@ async def patch_notification_preferences(
     updates = body.model_dump(exclude_none=True)
     try:
         return await upsert_preferences(db, db_user["id"], updates)
-    except ValueError as exc:
-        if "quiet_hours_require_times" in str(exc):
-            raise HTTPException(
-                status_code=422,
-                detail="quiet_start and quiet_end are required when quiet_hours_enabled is true",
-            )
-        raise
+    except QuietHoursValidationError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))

--- a/backend/app/features/notification_preferences/router.py
+++ b/backend/app/features/notification_preferences/router.py
@@ -32,4 +32,12 @@ async def patch_notification_preferences(
     if db_user is None:
         raise HTTPException(status_code=404, detail="User profile not found. Call POST /api/v1/users/me first.")
     updates = body.model_dump(exclude_none=True)
-    return await upsert_preferences(db, db_user["id"], updates)
+    try:
+        return await upsert_preferences(db, db_user["id"], updates)
+    except ValueError as exc:
+        if "quiet_hours_require_times" in str(exc):
+            raise HTTPException(
+                status_code=422,
+                detail="quiet_start and quiet_end are required when quiet_hours_enabled is true",
+            )
+        raise

--- a/backend/app/features/notification_preferences/schemas.py
+++ b/backend/app/features/notification_preferences/schemas.py
@@ -1,13 +1,34 @@
-from pydantic import BaseModel
+import re
+from pydantic import BaseModel, field_validator
+
+_TIME_RE = re.compile(r"^\d{2}:\d{2}$")
 
 
 class NotificationPreferences(BaseModel):
     siat_enabled: bool
     min_siat_level: int
     map_events_enabled: bool
+    quiet_hours_enabled: bool
+    quiet_start: str | None
+    quiet_end: str | None
 
 
 class NotificationPreferencesPatch(BaseModel):
     siat_enabled: bool | None = None
     min_siat_level: int | None = None
     map_events_enabled: bool | None = None
+    quiet_hours_enabled: bool | None = None
+    quiet_start: str | None = None
+    quiet_end: str | None = None
+
+    @field_validator("quiet_start", "quiet_end")
+    @classmethod
+    def validate_time_format(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if not _TIME_RE.match(v):
+            raise ValueError("Time must be in HH:MM format")
+        h, m = map(int, v.split(":"))
+        if not (0 <= h <= 23 and 0 <= m <= 59):
+            raise ValueError("Invalid time value: hour must be 00-23, minute 00-59")
+        return v

--- a/backend/app/features/notification_preferences/service.py
+++ b/backend/app/features/notification_preferences/service.py
@@ -2,6 +2,11 @@ from datetime import datetime, time, timezone
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+
+class QuietHoursValidationError(ValueError):
+    """Raised when quiet_hours_enabled=True but quiet_start/end are missing."""
+
+
 _DEFAULTS: dict = {
     "siat_enabled": True,
     "min_siat_level": 2,
@@ -64,7 +69,9 @@ async def upsert_preferences(db: AsyncSession, user_id: int, updates: dict) -> d
     current = await get_preferences(db, user_id)
     merged = {**current, **updates}
     if merged.get("quiet_hours_enabled") and (not merged.get("quiet_start") or not merged.get("quiet_end")):
-        raise ValueError("quiet_hours_require_times")
+        raise QuietHoursValidationError(
+            "quiet_start and quiet_end are required when quiet_hours_enabled is true"
+        )
     await db.execute(
         text("""
             INSERT INTO notification_preferences

--- a/backend/app/features/notification_preferences/service.py
+++ b/backend/app/features/notification_preferences/service.py
@@ -1,3 +1,4 @@
+from datetime import datetime, time, timezone
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -5,13 +6,44 @@ _DEFAULTS: dict = {
     "siat_enabled": True,
     "min_siat_level": 2,
     "map_events_enabled": True,
+    "quiet_hours_enabled": False,
+    "quiet_start": None,
+    "quiet_end": None,
 }
+
+
+def is_within_quiet_hours(prefs: dict, _now: "time | None" = None) -> bool:
+    """Return True if current UTC time falls within the user's quiet hours window.
+
+    _now is injected in tests to avoid mocking datetime.
+    """
+    if not prefs.get("quiet_hours_enabled"):
+        return False
+    qs = prefs.get("quiet_start")
+    qe = prefs.get("quiet_end")
+    if not qs or not qe:
+        return False
+    h0, m0 = map(int, qs.split(":"))
+    h1, m1 = map(int, qe.split(":"))
+    start_t = time(h0, m0)
+    end_t = time(h1, m1)
+    if _now is None:
+        now_utc = datetime.now(timezone.utc).time()
+        now_t = time(now_utc.hour, now_utc.minute)
+    else:
+        now_t = _now
+    if start_t <= end_t:
+        return start_t <= now_t < end_t
+    else:
+        # overnight range: e.g. 22:00 → 07:00
+        return now_t >= start_t or now_t < end_t
 
 
 async def get_preferences(db: AsyncSession, user_id: int) -> dict:
     result = await db.execute(
         text("""
-            SELECT siat_enabled, min_siat_level, map_events_enabled
+            SELECT siat_enabled, min_siat_level, map_events_enabled,
+                   quiet_hours_enabled, quiet_start, quiet_end
             FROM notification_preferences
             WHERE user_id = :user_id
         """),
@@ -20,23 +52,35 @@ async def get_preferences(db: AsyncSession, user_id: int) -> dict:
     row = result.mappings().first()
     if row is None:
         return dict(_DEFAULTS)
-    return dict(row)
+    d = dict(row)
+    for field in ("quiet_start", "quiet_end"):
+        val = d.get(field)
+        if val is not None and hasattr(val, "strftime"):
+            d[field] = val.strftime("%H:%M")
+    return d
 
 
 async def upsert_preferences(db: AsyncSession, user_id: int, updates: dict) -> dict:
     current = await get_preferences(db, user_id)
     merged = {**current, **updates}
+    if merged.get("quiet_hours_enabled") and (not merged.get("quiet_start") or not merged.get("quiet_end")):
+        raise ValueError("quiet_hours_require_times")
     await db.execute(
         text("""
             INSERT INTO notification_preferences
-                (user_id, siat_enabled, min_siat_level, map_events_enabled, updated_at)
+                (user_id, siat_enabled, min_siat_level, map_events_enabled,
+                 quiet_hours_enabled, quiet_start, quiet_end, updated_at)
             VALUES
-                (:user_id, :siat_enabled, :min_siat_level, :map_events_enabled, NOW())
+                (:user_id, :siat_enabled, :min_siat_level, :map_events_enabled,
+                 :quiet_hours_enabled, :quiet_start, :quiet_end, NOW())
             ON CONFLICT (user_id) DO UPDATE SET
-                siat_enabled       = EXCLUDED.siat_enabled,
-                min_siat_level     = EXCLUDED.min_siat_level,
-                map_events_enabled = EXCLUDED.map_events_enabled,
-                updated_at         = NOW()
+                siat_enabled        = EXCLUDED.siat_enabled,
+                min_siat_level      = EXCLUDED.min_siat_level,
+                map_events_enabled  = EXCLUDED.map_events_enabled,
+                quiet_hours_enabled = EXCLUDED.quiet_hours_enabled,
+                quiet_start         = EXCLUDED.quiet_start,
+                quiet_end           = EXCLUDED.quiet_end,
+                updated_at          = NOW()
         """),
         {"user_id": user_id, **merged},
     )

--- a/backend/app/features/notification_preferences/tests/test_quiet_hours.py
+++ b/backend/app/features/notification_preferences/tests/test_quiet_hours.py
@@ -1,0 +1,39 @@
+from datetime import time
+from app.features.notification_preferences.service import is_within_quiet_hours
+
+
+def _prefs(enabled=True, start="22:00", end="07:00"):
+    return {"quiet_hours_enabled": enabled, "quiet_start": start, "quiet_end": end}
+
+
+def test_disabled_returns_false():
+    assert is_within_quiet_hours({"quiet_hours_enabled": False}) is False
+
+
+def test_missing_times_returns_false():
+    assert is_within_quiet_hours({"quiet_hours_enabled": True, "quiet_start": None, "quiet_end": None}) is False
+
+
+def test_normal_range_within():
+    # 09:00–18:00, now=12:00 → within
+    assert is_within_quiet_hours(_prefs(start="09:00", end="18:00"), _now=time(12, 0)) is True
+
+
+def test_normal_range_outside():
+    # 09:00–18:00, now=20:00 → outside
+    assert is_within_quiet_hours(_prefs(start="09:00", end="18:00"), _now=time(20, 0)) is False
+
+
+def test_overnight_range_within():
+    # 22:00–07:00, now=23:30 → within (past midnight side)
+    assert is_within_quiet_hours(_prefs(start="22:00", end="07:00"), _now=time(23, 30)) is True
+
+
+def test_overnight_range_outside():
+    # 22:00–07:00, now=12:00 → outside (daytime)
+    assert is_within_quiet_hours(_prefs(start="22:00", end="07:00"), _now=time(12, 0)) is False
+
+
+def test_overnight_range_early_morning_within():
+    # 22:00–07:00, now=06:00 → within (before end)
+    assert is_within_quiet_hours(_prefs(start="22:00", end="07:00"), _now=time(6, 0)) is True

--- a/backend/app/features/notification_preferences/tests/test_quiet_hours.py
+++ b/backend/app/features/notification_preferences/tests/test_quiet_hours.py
@@ -37,3 +37,21 @@ def test_overnight_range_outside():
 def test_overnight_range_early_morning_within():
     # 22:00–07:00, now=06:00 → within (before end)
     assert is_within_quiet_hours(_prefs(start="22:00", end="07:00"), _now=time(6, 0)) is True
+
+
+def test_mexico_city_utc_converted_prefs():
+    # Mexico City (UTC-6): 22:00–07:00 local → frontend sends 04:00–13:00 UTC
+    prefs = {"quiet_hours_enabled": True, "quiet_start": "04:00", "quiet_end": "13:00"}
+    assert is_within_quiet_hours(prefs, _now=time(5, 0))   is True   # 23:00 CST
+    assert is_within_quiet_hours(prefs, _now=time(12, 0))  is True   # 06:00 CST
+    assert is_within_quiet_hours(prefs, _now=time(14, 0))  is False  # 08:00 CST
+    assert is_within_quiet_hours(prefs, _now=time(3, 59))  is False  # 21:59 CST
+
+
+def test_utcplus2_overnight_utc_prefs():
+    # UTC+2: 22:00–07:00 local → frontend sends 20:00–05:00 UTC (overnight in UTC)
+    prefs = {"quiet_hours_enabled": True, "quiet_start": "20:00", "quiet_end": "05:00"}
+    assert is_within_quiet_hours(prefs, _now=time(21, 0))  is True   # 23:00 local
+    assert is_within_quiet_hours(prefs, _now=time(1, 0))   is True   # 03:00 local
+    assert is_within_quiet_hours(prefs, _now=time(5, 1))   is False  # 07:01 local
+    assert is_within_quiet_hours(prefs, _now=time(19, 59)) is False  # 21:59 local

--- a/backend/app/features/notification_preferences/tests/test_router.py
+++ b/backend/app/features/notification_preferences/tests/test_router.py
@@ -21,12 +21,18 @@ DEFAULT_PREFS = {
     "siat_enabled": True,
     "min_siat_level": 2,
     "map_events_enabled": True,
+    "quiet_hours_enabled": False,
+    "quiet_start": None,
+    "quiet_end": None,
 }
 
 CUSTOM_PREFS = {
     "siat_enabled": False,
     "min_siat_level": 3,
     "map_events_enabled": True,
+    "quiet_hours_enabled": False,
+    "quiet_start": None,
+    "quiet_end": None,
 }
 
 
@@ -152,4 +158,62 @@ def test_patch_preferences_404_when_user_not_found():
 
 def test_patch_preferences_requires_auth():
     r = client.patch("/api/v1/notification-preferences", json={"siat_enabled": False})
+    assert r.status_code == 422
+
+
+# ── Quiet hours ────────────────────────────────────────────────────────────────
+
+def test_get_preferences_includes_quiet_fields():
+    prefs_with_quiet = {**DEFAULT_PREFS, "quiet_hours_enabled": True, "quiet_start": "22:00", "quiet_end": "07:00"}
+    with _mock_auth():
+        with patch(
+            "app.features.notification_preferences.router.get_user_by_firebase_uid",
+            new_callable=AsyncMock,
+            return_value=FAKE_DB_USER,
+        ):
+            with patch(
+                "app.features.notification_preferences.router.get_preferences",
+                new_callable=AsyncMock,
+                return_value=prefs_with_quiet,
+            ):
+                r = client.get("/api/v1/notification-preferences", headers=AUTH_HEADERS)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["quiet_hours_enabled"] is True
+    assert body["quiet_start"] == "22:00"
+    assert body["quiet_end"] == "07:00"
+
+
+def test_patch_quiet_hours_full_payload():
+    updated = {**DEFAULT_PREFS, "quiet_hours_enabled": True, "quiet_start": "22:00", "quiet_end": "07:00"}
+    with _mock_auth():
+        with patch(
+            "app.features.notification_preferences.router.get_user_by_firebase_uid",
+            new_callable=AsyncMock,
+            return_value=FAKE_DB_USER,
+        ):
+            with patch(
+                "app.features.notification_preferences.router.upsert_preferences",
+                new_callable=AsyncMock,
+                return_value=updated,
+            ):
+                r = client.patch(
+                    "/api/v1/notification-preferences",
+                    json={"quiet_hours_enabled": True, "quiet_start": "22:00", "quiet_end": "07:00"},
+                    headers=AUTH_HEADERS,
+                )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["quiet_hours_enabled"] is True
+    assert body["quiet_start"] == "22:00"
+    assert body["quiet_end"] == "07:00"
+
+
+def test_patch_quiet_hours_invalid_time_format():
+    with _mock_auth():
+        r = client.patch(
+            "/api/v1/notification-preferences",
+            json={"quiet_start": "25:99"},
+            headers=AUTH_HEADERS,
+        )
     assert r.status_code == 422

--- a/backend/app/features/siat/service.py
+++ b/backend/app/features/siat/service.py
@@ -26,11 +26,12 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from app.features.siat.evaluator import evaluate_user, haversine_km
 from app.features.siat.providers.nhc import fetch_active_cyclones
 from app.features.notifications.service import get_tokens_for_users
-from app.features.notification_preferences.service import get_preferences
+from app.features.notification_preferences.service import get_preferences, is_within_quiet_hours
 
 logger = logging.getLogger(__name__)
 
-_NOTIFY_MIN_LEVEL = 2  # VERDE and above trigger push
+_NOTIFY_MIN_LEVEL = 2          # VERDE and above trigger push
+_QUIET_HOURS_OVERRIDE_LEVEL = 5  # ROJO always fires even in quiet hours
 
 _COLOR_LABELS = {
     "AZUL": "Azul",
@@ -328,6 +329,8 @@ async def _push_smn_for_alert(
             continue
         prefs = await get_preferences(db, user["id"])
         if prefs["siat_enabled"] and alert["level"] >= prefs["min_siat_level"]:
+            if is_within_quiet_hours(prefs) and alert["level"] < _QUIET_HOURS_OVERRIDE_LEVEL:
+                continue
             affected_user_ids.append(user["id"])
 
     if not affected_user_ids:
@@ -444,13 +447,19 @@ async def run_cycle(db: AsyncSession) -> dict:
                 if new_level >= _NOTIFY_MIN_LEVEL and (old_level is None or new_level > old_level):
                     prefs = await get_preferences(db, user["id"])
                     if prefs["siat_enabled"] and new_level >= prefs["min_siat_level"]:
-                        prev = escalations.get(user["id"])
-                        if prev is None or new_level > prev["siat_level"]:
-                            escalations[user["id"]] = assessment
-                            logger.info(
-                                "Escalation queued: user_id=%d %s→%s (%s)",
-                                user["id"], old_level, new_level, assessment["siat_color"],
+                        if is_within_quiet_hours(prefs) and new_level < _QUIET_HOURS_OVERRIDE_LEVEL:
+                            logger.debug(
+                                "user_id=%d: push suppressed by quiet hours (level=%d)",
+                                user["id"], new_level,
                             )
+                        else:
+                            prev = escalations.get(user["id"])
+                            if prev is None or new_level > prev["siat_level"]:
+                                escalations[user["id"]] = assessment
+                                logger.info(
+                                    "Escalation queued: user_id=%d %s→%s (%s)",
+                                    user["id"], old_level, new_level, assessment["siat_color"],
+                                )
                     else:
                         logger.debug(
                             "user_id=%d: push filtered by prefs (siat_enabled=%s, min_siat_level=%d, got=%d)",

--- a/backend/app/features/siat/service.py
+++ b/backend/app/features/siat/service.py
@@ -31,7 +31,7 @@ from app.features.notification_preferences.service import get_preferences, is_wi
 logger = logging.getLogger(__name__)
 
 _NOTIFY_MIN_LEVEL = 2          # VERDE and above trigger push
-_QUIET_HOURS_OVERRIDE_LEVEL = 5  # ROJO always fires even in quiet hours
+_QUIET_HOURS_OVERRIDE_LEVEL = 4  # NARANJA and ROJO always fire even in quiet hours
 
 _COLOR_LABELS = {
     "AZUL": "Azul",

--- a/backend/app/features/siat/tests/test_router.py
+++ b/backend/app/features/siat/tests/test_router.py
@@ -474,3 +474,123 @@ async def test_smn_min_siat_level_filters_alert():
 
     assert total == 0
     mock_mark.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Quiet hours — SIAT run_cycle and SMN service-level tests
+# ---------------------------------------------------------------------------
+
+_ASSESSMENT_LEVEL_5 = {
+    "siat_level": 5,
+    "siat_color": "ROJO",
+    "distance_km": 50.0,
+    "eta_hours": 2.0,
+    "reason": "test",
+    "out_of_range": False,
+}
+
+_QUIET_PREFS = {
+    "siat_enabled": True, "min_siat_level": 2, "map_events_enabled": True,
+    "quiet_hours_enabled": True, "quiet_start": "22:00", "quiet_end": "07:00",
+}
+
+
+@pytest.mark.asyncio
+async def test_siat_quiet_hours_suppresses_push():
+    """User inside quiet hours + level=3 → push suppressed (not added to escalations)."""
+    from app.features.siat.service import run_cycle
+
+    db = MagicMock()
+    db.commit = AsyncMock()
+
+    patches = _base_run_cycle_patches(_ASSESSMENT_LEVEL_3, _QUIET_PREFS, push_return=0)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11], \
+         patch(f"{_SVC}.is_within_quiet_hours", return_value=True):
+        result = await run_cycle(db)
+
+    assert result["notifications_sent"] == 0
+
+
+@pytest.mark.asyncio
+async def test_siat_quiet_hours_allows_push_outside_range():
+    """User outside quiet hours → push proceeds normally."""
+    from app.features.siat.service import run_cycle
+
+    db = MagicMock()
+    db.commit = AsyncMock()
+
+    patches = _base_run_cycle_patches(_ASSESSMENT_LEVEL_3, _QUIET_PREFS, push_return=1)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11], \
+         patch(f"{_SVC}.is_within_quiet_hours", return_value=False):
+        result = await run_cycle(db)
+
+    assert result["notifications_sent"] == 1
+
+
+@pytest.mark.asyncio
+async def test_siat_level5_overrides_quiet_hours():
+    """Level 5 / ROJO is always sent even when inside quiet hours."""
+    from app.features.siat.service import run_cycle
+
+    db = MagicMock()
+    db.commit = AsyncMock()
+
+    patches = _base_run_cycle_patches(_ASSESSMENT_LEVEL_5, _QUIET_PREFS, push_return=1)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11], \
+         patch(f"{_SVC}.is_within_quiet_hours", return_value=True):
+        result = await run_cycle(db)
+
+    assert result["notifications_sent"] == 1
+
+
+@pytest.mark.asyncio
+async def test_smn_quiet_hours_suppresses_push():
+    """SMN alert level=3 + user in quiet hours → not added to affected_user_ids."""
+    from app.features.siat.service import _notify_smn_alerts
+
+    db = MagicMock()
+
+    with patch(f"{_SVC}._get_pending_smn_alerts", new_callable=AsyncMock, return_value=[_FAKE_SMN_ALERT]), \
+         patch(f"{_SVC}.get_preferences", new_callable=AsyncMock, return_value=_QUIET_PREFS), \
+         patch(f"{_SVC}.is_within_quiet_hours", return_value=True), \
+         patch(f"{_SVC}.get_tokens_for_users", new_callable=AsyncMock, return_value={}) as mock_tokens, \
+         patch(f"{_SVC}._mark_alert_notified", new_callable=AsyncMock) as mock_mark:
+
+        total = await _notify_smn_alerts(db, [_FAKE_USER_NEARBY])
+
+    assert total == 0
+    mock_mark.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_smn_level5_overrides_quiet_hours():
+    """SMN alert level=5 inside quiet hours → push still sent (ROJO exception)."""
+    from app.features.siat.service import _notify_smn_alerts
+
+    db = MagicMock()
+    alert_level5 = {**_FAKE_SMN_ALERT, "level": 5}
+
+    with patch(f"{_SVC}._get_pending_smn_alerts", new_callable=AsyncMock, return_value=[alert_level5]), \
+         patch(f"{_SVC}.get_preferences", new_callable=AsyncMock, return_value=_QUIET_PREFS), \
+         patch(f"{_SVC}.is_within_quiet_hours", return_value=True), \
+         patch(f"{_SVC}.get_tokens_for_users", new_callable=AsyncMock, return_value={1: ["token-abc"]}), \
+         patch(f"{_SVC}._mark_alert_notified", new_callable=AsyncMock) as mock_mark, \
+         patch(f"{_SVC}.messaging") as mock_messaging:
+
+        fake_response = MagicMock()
+        fake_response.success_count = 1
+        fake_response.failure_count = 0
+        fake_response.responses = [MagicMock(success=True)]
+        mock_messaging.send_each_for_multicast.return_value = fake_response
+        mock_messaging.MulticastMessage = MagicMock()
+        mock_messaging.Notification = MagicMock()
+        mock_messaging.AndroidConfig = MagicMock()
+        mock_messaging.APNSConfig = MagicMock()
+
+        total = await _notify_smn_alerts(db, [_FAKE_USER_NEARBY])
+
+    assert total == 1
+    mock_mark.assert_called_once()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -71,6 +71,15 @@ async def ensure_core_tables(engine: AsyncEngine) -> None:
                 updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
             )
         """))
+        await conn.execute(text(
+            "ALTER TABLE notification_preferences ADD COLUMN IF NOT EXISTS quiet_hours_enabled BOOLEAN NOT NULL DEFAULT FALSE"
+        ))
+        await conn.execute(text(
+            "ALTER TABLE notification_preferences ADD COLUMN IF NOT EXISTS quiet_start TIME"
+        ))
+        await conn.execute(text(
+            "ALTER TABLE notification_preferences ADD COLUMN IF NOT EXISTS quiet_end TIME"
+        ))
         await conn.execute(text("""
             CREATE TABLE IF NOT EXISTS map_events (
                 id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/frontend/app/NotificationPreferencesScreen.tsx
+++ b/frontend/app/NotificationPreferencesScreen.tsx
@@ -45,15 +45,33 @@ function normalizePrefs(data: Partial<Prefs>): Prefs {
   };
 }
 
+function localTimeToUTC(localStr: string): string {
+  const [h, m] = localStr.split(":").map(Number);
+  const offset = new Date().getTimezoneOffset(); // (UTC - local) in minutes
+  const utcMin = (h * 60 + m + offset + 1440) % 1440;
+  return `${String(Math.floor(utcMin / 60)).padStart(2, "0")}:${String(utcMin % 60).padStart(2, "0")}`;
+}
+
+function utcTimeToLocal(utcStr: string): string {
+  const [h, m] = utcStr.split(":").map(Number);
+  const offset = new Date().getTimezoneOffset();
+  const locMin = (h * 60 + m - offset + 1440) % 1440;
+  return `${String(Math.floor(locMin / 60)).padStart(2, "0")}:${String(locMin % 60).padStart(2, "0")}`;
+}
+
 function timeStrToDate(s: string | null): Date {
-  const [h, m] = (s ?? "22:00").split(":").map(Number);
+  // s is stored in UTC; convert to local for the picker
+  const local = utcTimeToLocal(s ?? "22:00");
+  const [h, m] = local.split(":").map(Number);
   const d = new Date();
   d.setHours(h, m, 0, 0);
   return d;
 }
 
 function dateToTimeStr(d: Date): string {
-  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+  // picker returns local time; convert to UTC before storing/sending
+  const local = `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+  return localTimeToUTC(local);
 }
 
 export default function NotificationPreferencesScreen() {
@@ -101,8 +119,11 @@ export default function NotificationPreferencesScreen() {
 
   function handleQuietToggle(enabled: boolean) {
     if (enabled && (!prefs.quiet_start || !prefs.quiet_end)) {
-      // backend requires times when enabling; inject defaults so it doesn't reject with 422
-      patchPrefs({ quiet_hours_enabled: true, quiet_start: "22:00", quiet_end: "07:00" });
+      patchPrefs({
+        quiet_hours_enabled: true,
+        quiet_start: localTimeToUTC("22:00"),
+        quiet_end: localTimeToUTC("07:00"),
+      });
     } else {
       patchPrefs({ quiet_hours_enabled: enabled });
     }
@@ -232,8 +253,8 @@ export default function NotificationPreferencesScreen() {
         {/* Selector de horario — visible solo cuando quiet hours está activo */}
         {prefs.quiet_hours_enabled && (
           <View style={{ marginHorizontal: 16, marginTop: 8, marginBottom: 8 }}>
-            <Text style={styles.sectionLabel}>Horario sin alertas (UTC)</Text>
-            <Text style={styles.utcNote}>Las alertas nivel 5 / Rojo siempre se envían.</Text>
+            <Text style={styles.sectionLabel}>Horario sin alertas</Text>
+            <Text style={styles.utcNote}>Las alertas nivel 4-5 / Naranja-Rojo siempre se envían.</Text>
 
             <View style={styles.timeRow}>
               <View style={styles.timeBlock}>
@@ -243,7 +264,7 @@ export default function NotificationPreferencesScreen() {
                   disabled={saving}
                   onPress={() => setShowStartPicker(true)}
                 >
-                  <Text style={styles.timeValue}>{prefs.quiet_start ?? "22:00"}</Text>
+                  <Text style={styles.timeValue}>{utcTimeToLocal(prefs.quiet_start ?? "22:00")}</Text>
                 </TouchableOpacity>
               </View>
 
@@ -256,7 +277,7 @@ export default function NotificationPreferencesScreen() {
                   disabled={saving}
                   onPress={() => setShowEndPicker(true)}
                 >
-                  <Text style={styles.timeValue}>{prefs.quiet_end ?? "07:00"}</Text>
+                  <Text style={styles.timeValue}>{utcTimeToLocal(prefs.quiet_end ?? "07:00")}</Text>
                 </TouchableOpacity>
               </View>
             </View>

--- a/frontend/app/NotificationPreferencesScreen.tsx
+++ b/frontend/app/NotificationPreferencesScreen.tsx
@@ -1,7 +1,8 @@
 import "../global.css";
 import { useState, useEffect } from "react";
-import { View, Text, Switch, ScrollView, TouchableOpacity, Alert, ActivityIndicator, StyleSheet } from "react-native";
+import { View, Text, Switch, ScrollView, TouchableOpacity, Alert, ActivityIndicator, StyleSheet, Platform } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import DateTimePicker, { DateTimePickerEvent } from "@react-native-community/datetimepicker";
 import ScreenHeader from "../components/ScreenHeader";
 import OptionCard from "../components/OptionCard";
 import { authFetch } from "../utils/api";
@@ -12,12 +13,18 @@ interface Prefs {
   siat_enabled: boolean;
   min_siat_level: number;
   map_events_enabled: boolean;
+  quiet_hours_enabled: boolean;
+  quiet_start: string | null;
+  quiet_end: string | null;
 }
 
 const DEFAULTS: Prefs = {
   siat_enabled: true,
   min_siat_level: 2,
   map_events_enabled: true,
+  quiet_hours_enabled: false,
+  quiet_start: null,
+  quiet_end: null,
 };
 
 const LEVEL_OPTIONS = [
@@ -29,17 +36,33 @@ const LEVEL_OPTIONS = [
 
 function normalizePrefs(data: Partial<Prefs>): Prefs {
   return {
-    siat_enabled:       typeof data.siat_enabled === "boolean"   ? data.siat_enabled       : DEFAULTS.siat_enabled,
-    min_siat_level:     typeof data.min_siat_level === "number"  ? data.min_siat_level      : DEFAULTS.min_siat_level,
-    map_events_enabled: typeof data.map_events_enabled === "boolean" ? data.map_events_enabled : DEFAULTS.map_events_enabled,
+    siat_enabled:        typeof data.siat_enabled === "boolean"        ? data.siat_enabled        : DEFAULTS.siat_enabled,
+    min_siat_level:      typeof data.min_siat_level === "number"       ? data.min_siat_level       : DEFAULTS.min_siat_level,
+    map_events_enabled:  typeof data.map_events_enabled === "boolean"  ? data.map_events_enabled   : DEFAULTS.map_events_enabled,
+    quiet_hours_enabled: typeof data.quiet_hours_enabled === "boolean" ? data.quiet_hours_enabled  : DEFAULTS.quiet_hours_enabled,
+    quiet_start: typeof data.quiet_start === "string" ? data.quiet_start : DEFAULTS.quiet_start,
+    quiet_end:   typeof data.quiet_end   === "string" ? data.quiet_end   : DEFAULTS.quiet_end,
   };
 }
 
+function timeStrToDate(s: string | null): Date {
+  const [h, m] = (s ?? "22:00").split(":").map(Number);
+  const d = new Date();
+  d.setHours(h, m, 0, 0);
+  return d;
+}
+
+function dateToTimeStr(d: Date): string {
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
 export default function NotificationPreferencesScreen() {
-  const [prefs, setPrefs]   = useState<Prefs>(DEFAULTS);
-  const [loading, setLoading] = useState(true);
+  const [prefs, setPrefs]       = useState<Prefs>(DEFAULTS);
+  const [loading, setLoading]   = useState(true);
   const [fetchError, setFetchError] = useState(false);
-  const [saving, setSaving] = useState(false);
+  const [saving, setSaving]     = useState(false);
+  const [showStartPicker, setShowStartPicker] = useState(false);
+  const [showEndPicker, setShowEndPicker]     = useState(false);
 
   useEffect(() => {
     let live = true;
@@ -74,6 +97,25 @@ export default function NotificationPreferencesScreen() {
     } finally {
       setSaving(false);
     }
+  }
+
+  function handleQuietToggle(enabled: boolean) {
+    if (enabled && (!prefs.quiet_start || !prefs.quiet_end)) {
+      // backend requires times when enabling; inject defaults so it doesn't reject with 422
+      patchPrefs({ quiet_hours_enabled: true, quiet_start: "22:00", quiet_end: "07:00" });
+    } else {
+      patchPrefs({ quiet_hours_enabled: enabled });
+    }
+  }
+
+  function handleStartChange(_event: DateTimePickerEvent, date?: Date) {
+    if (Platform.OS === "android") setShowStartPicker(false);
+    if (date) patchPrefs({ quiet_start: dateToTimeStr(date) });
+  }
+
+  function handleEndChange(_event: DateTimePickerEvent, date?: Date) {
+    if (Platform.OS === "android") setShowEndPicker(false);
+    if (date) patchPrefs({ quiet_end: dateToTimeStr(date) });
   }
 
   const switchProps = {
@@ -174,6 +216,72 @@ export default function NotificationPreferencesScreen() {
           }
         />
 
+        {/* Toggle: No molestar */}
+        <OptionCard
+          icon="moon-waning-crescent"
+          title="No molestar"
+          rightElement={
+            <Switch
+              value={prefs.quiet_hours_enabled}
+              onValueChange={handleQuietToggle}
+              {...switchProps}
+            />
+          }
+        />
+
+        {/* Selector de horario — visible solo cuando quiet hours está activo */}
+        {prefs.quiet_hours_enabled && (
+          <View style={{ marginHorizontal: 16, marginTop: 8, marginBottom: 8 }}>
+            <Text style={styles.sectionLabel}>Horario sin alertas (UTC)</Text>
+            <Text style={styles.utcNote}>Las alertas nivel 5 / Rojo siempre se envían.</Text>
+
+            <View style={styles.timeRow}>
+              <View style={styles.timeBlock}>
+                <Text style={styles.timeLabel}>Inicio</Text>
+                <TouchableOpacity
+                  style={[styles.timeButton, saving && { opacity: 0.6 }]}
+                  disabled={saving}
+                  onPress={() => setShowStartPicker(true)}
+                >
+                  <Text style={styles.timeValue}>{prefs.quiet_start ?? "22:00"}</Text>
+                </TouchableOpacity>
+              </View>
+
+              <Text style={styles.timeSeparator}>→</Text>
+
+              <View style={styles.timeBlock}>
+                <Text style={styles.timeLabel}>Fin</Text>
+                <TouchableOpacity
+                  style={[styles.timeButton, saving && { opacity: 0.6 }]}
+                  disabled={saving}
+                  onPress={() => setShowEndPicker(true)}
+                >
+                  <Text style={styles.timeValue}>{prefs.quiet_end ?? "07:00"}</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+
+            {showStartPicker && (
+              <DateTimePicker
+                mode="time"
+                value={timeStrToDate(prefs.quiet_start)}
+                is24Hour
+                onChange={handleStartChange}
+                display={Platform.OS === "ios" ? "spinner" : "default"}
+              />
+            )}
+            {showEndPicker && (
+              <DateTimePicker
+                mode="time"
+                value={timeStrToDate(prefs.quiet_end)}
+                is24Hour
+                onChange={handleEndChange}
+                display={Platform.OS === "ios" ? "spinner" : "default"}
+              />
+            )}
+          </View>
+        )}
+
       </ScrollView>
     </SafeAreaView>
   );
@@ -201,7 +309,7 @@ const styles = StyleSheet.create({
     fontSize: 12,
     letterSpacing: 1,
     textTransform: "uppercase",
-    marginBottom: 10,
+    marginBottom: 6,
   },
   chip: {
     flex: 1,
@@ -214,5 +322,50 @@ const styles = StyleSheet.create({
   chipLabel: {
     fontFamily: fonts.poppinsSemiBold,
     fontSize: 12,
+  },
+  utcNote: {
+    color: "rgba(255,255,255,0.4)",
+    fontFamily: fonts.poppins,
+    fontSize: 11,
+    marginBottom: 12,
+  },
+  timeRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  timeBlock: {
+    flex: 1,
+    alignItems: "center",
+  },
+  timeLabel: {
+    color: "rgba(255,255,255,0.5)",
+    fontFamily: fonts.poppins,
+    fontSize: 11,
+    marginBottom: 6,
+    letterSpacing: 0.5,
+    textTransform: "uppercase",
+  },
+  timeButton: {
+    backgroundColor: "rgba(10, 28, 50, 0.7)",
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.15)",
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    alignItems: "center",
+    width: "100%",
+  },
+  timeValue: {
+    color: colors.brandCyan,
+    fontFamily: fonts.poppinsSemiBold,
+    fontSize: 20,
+    letterSpacing: 1,
+  },
+  timeSeparator: {
+    color: "rgba(255,255,255,0.3)",
+    fontFamily: fonts.poppinsSemiBold,
+    fontSize: 18,
+    paddingTop: 20,
   },
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@expo/metro-runtime": "~6.1.2",
         "@react-native-async-storage/async-storage": "2.2.0",
+        "@react-native-community/datetimepicker": "^8.0.1",
         "@react-native-firebase/app": "^24.0.0",
         "@react-native-firebase/auth": "^24.0.0",
         "@react-native-google-signin/google-signin": "^16.1.2",
@@ -4630,6 +4631,24 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.0.1.tgz",
+      "integrity": "sha512-4BO0t3geMNNw9cIIm9p9FNUzwMXexdzD4pAH0AaUAycs3BS71HLrX8jHbrI7nzq/+8O7cLAXn5Gudte+YpTV8Q==",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-windows": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native-firebase/app": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@expo/metro-runtime": "~6.1.2",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-native-community/datetimepicker": "^8.0.1",
     "@react-native-firebase/app": "^24.0.0",
     "@react-native-firebase/auth": "^24.0.0",
     "@react-native-google-signin/google-signin": "^16.1.2",


### PR DESCRIPTION
## Qué incluye

* Quiet hours / No molestar
* DateTimePicker nativo Android/iOS
* Soporte overnight (22:00 → 07:00)
* Override para alertas ROJO
* Integración en SIAT y SMN
* Validaciones backend/frontend
* 15 tests nuevos

## Backend

* ALTER TABLE idempotente
* Nuevos campos:

  * quiet_hours_enabled
  * quiet_start
  * quiet_end
* Helper reutilizable `is_within_quiet_hours()`
* Soporte de horarios overnight
* Validación HH:MM
* Suppress de pushes durante quiet hours
* Override nivel 5

## Frontend

* Sección “No molestar”
* Toggle enable/disable
* Time pickers nativos
* Persistencia inmediata vía PATCH
* Optimistic updates
* Protección contra race conditions

## Tests

73/73 tests pasando.
