### PR TITLE
test: isolate API key tests from env

### DIFF
--- a/backend/app/features/notifications/tests/test_router.py
+++ b/backend/app/features/notifications/tests/test_router.py
@@ -1,13 +1,22 @@
+import pytest
 from unittest.mock import AsyncMock, patch
 from starlette.testclient import TestClient
 from app.main import app
+from app.core.config import settings
 from datetime import datetime, timezone
 
 client = TestClient(app)
 
 FAKE_USER = {"uid": "firebase-test-uid"}
 AUTH_HEADERS = {"Authorization": "Bearer faketoken"}
-API_KEY_HEADERS = {"X-Api-Key": "s3cret-xyz"}
+TEST_API_KEY = "test-notif-api-key"
+API_KEY_HEADERS = {"X-Api-Key": TEST_API_KEY}
+
+
+@pytest.fixture(autouse=True)
+def _patch_api_key():
+    with patch.object(settings, "NOTIF_API_KEY", TEST_API_KEY):
+        yield
 
 FAKE_DB_USER = {
     "id": 1,

--- a/backend/app/features/siat/tests/test_router.py
+++ b/backend/app/features/siat/tests/test_router.py
@@ -2,11 +2,19 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from starlette.testclient import TestClient
 from app.main import app
+from app.core.config import settings
 from datetime import datetime, timezone
 
 client = TestClient(app)
 
-API_KEY_HEADERS = {"X-Api-Key": "s3cret-xyz"}
+TEST_API_KEY = "test-siat-api-key"
+API_KEY_HEADERS = {"X-Api-Key": TEST_API_KEY}
+
+
+@pytest.fixture(autouse=True)
+def _patch_api_key():
+    with patch.object(settings, "NOTIF_API_KEY", TEST_API_KEY):
+        yield
 
 # Patch targets must reference WHERE the name is used (router module)
 _ROUTER = "app.features.siat.router"


### PR DESCRIPTION
## Resumen

Esta PR desacopla los tests de SIAT y Notifications del valor de `NOTIF_API_KEY` configurado en tiempo de ejecución.

Anteriormente, los tests dependían del valor definido en `.env`. Después de actualizar la API key de staging, varios tests comenzaron a fallar con `401 Unauthorized`, aunque la lógica de la aplicación no había cambiado.

Ahora los tests utilizan un valor de API key específico para pruebas mediante un parcheo (`patch`) de `settings.NOTIF_API_KEY`, haciéndolos independientes de la configuración local, de staging o de producción.

## Cambios realizados

* Se agregaron constantes de API key específicas para pruebas.
* Se agregaron fixtures `autouse` que reemplazan temporalmente `settings.NOTIF_API_KEY`.
* Se actualizaron los siguientes archivos:

  * `app/features/siat/tests/test_router.py`
  * `app/features/notifications/tests/test_router.py`

## Resultados

* Tests de SIAT: **30/30 exitosos**
* Tests de Notifications: **4/4 exitosos**
* Suite completa: **75/75 exitosos**

## Notas

* No se modificó código de la aplicación.
* Únicamente se actualizaron archivos de pruebas.
* Con este cambio, futuras modificaciones de `NOTIF_API_KEY` no provocarán fallos en los tests.
