### PR TITLE
Feat/11 notification test tool

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -23,6 +23,10 @@ class Settings(BaseSettings):
     # Dev-only bypasses
     DEV_BYPASS_MAP_EVENTS_AUTH: bool = False
 
+    # Notification test tool — comma-separated emails allowed to call POST /api/v1/notifications/test.
+    # Empty string disables the endpoint for everyone (production default).
+    NOTIFICATION_TEST_ADMIN_EMAILS: str = ""
+
     model_config = SettingsConfigDict(env_file=(".env", ".env.local"))
 
 settings = Settings()

--- a/backend/app/features/notifications/router.py
+++ b/backend/app/features/notifications/router.py
@@ -3,11 +3,39 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import get_db
 from app.core.auth import get_current_user
 from app.features.notifications.service import push_token, send_all_notifications
-from app.features.notifications.schemas import NotificationSend, NotificationResponse, PushTokenCreate
+from app.features.notifications.schemas import (
+    NotificationSend, NotificationResponse, PushTokenCreate,
+    NotificationTestType, NotificationTestRequest,
+)
 from app.middleware.api_key_auth import verify_api_key
+from app.core.config import settings
 from app.features.users.service import get_user_by_firebase_uid
 
 router = APIRouter()
+
+_TEST_PAYLOADS: dict[str, dict] = {
+    "hurricane_l2": {
+        "title": "Alerta SIAT-CT Verde [PRUEBA]",
+        "body": "Ciclón de prueba | Distancia: ~200 km | ETA: ~36h",
+        "data": {"siat_level": "2", "siat_color": "VERDE"},
+    },
+    "hurricane_l4": {
+        "title": "Alerta SIAT-CT Naranja [PRUEBA]",
+        "body": "Ciclón de prueba | Distancia: ~50 km | ETA: ~8h",
+        "data": {"siat_level": "4", "siat_color": "NARANJA", "fullScreen": "true"},
+    },
+    "sos_test": {
+        "title": "SOS — Equipo BluEye [PRUEBA]",
+        "body": "Necesita ayuda urgente. Toca para ver su ubicación.",
+        "data": {"category": "sos", "sender_name": "Test BluEye",
+                 "lat": "19.43264", "lon": "-99.13318"},
+    },
+    "generic": {
+        "title": "Notificación de prueba [PRUEBA]",
+        "body": "Esta es una notificación de prueba del equipo BluEye.",
+        "data": {},
+    },
+}
 
 
 @router.post("/api/v1/push-token", status_code=201)
@@ -33,6 +61,29 @@ async def send_notifications(
 ):
     result = await send_all_notifications(db, body.title, body.body, body.data)
     return result
+
+
+@router.post("/api/v1/notifications/test", response_model=NotificationResponse)
+async def send_test_notification(
+    body: NotificationTestRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
+):
+    """Send a test notification to all devices. Requires Firebase auth + admin email allowlist."""
+    admin_emails = [
+        e.strip().lower()
+        for e in settings.NOTIFICATION_TEST_ADMIN_EMAILS.split(",")
+        if e.strip()
+    ]
+    if not admin_emails:
+        raise HTTPException(status_code=403, detail="Test notifications not configured.")
+
+    user_email = (current_user.get("email") or "").lower()
+    if user_email not in admin_emails:
+        raise HTTPException(status_code=403, detail="Not authorized to send test notifications.")
+
+    payload = _TEST_PAYLOADS[body.type]
+    return await send_all_notifications(db, payload["title"], payload["body"], payload["data"])
 
 
 # Legacy aliases for cached tester app builds shipped before the /api/v1 migration.

--- a/backend/app/features/notifications/schemas.py
+++ b/backend/app/features/notifications/schemas.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from pydantic import BaseModel
 
 class NotificationSend(BaseModel):
@@ -12,4 +13,15 @@ class NotificationResponse(BaseModel):
 class PushTokenCreate(BaseModel):
     token: str
     user_id: int | None = None  # set server-side from Firebase UID lookup
+
+
+class NotificationTestType(str, Enum):
+    hurricane_l2 = "hurricane_l2"
+    hurricane_l4 = "hurricane_l4"
+    sos_test     = "sos_test"
+    generic      = "generic"
+
+
+class NotificationTestRequest(BaseModel):
+    type: NotificationTestType
 

--- a/backend/app/features/notifications/tests/test_router.py
+++ b/backend/app/features/notifications/tests/test_router.py
@@ -64,3 +64,75 @@ def test_push_token_404_no_profile():
 def test_send_all_requires_api_key():
     r = client.post("/api/v1/notifications/send-all", json={"title": "Test", "body": "msg", "data": {}})
     assert r.status_code == 422
+
+
+# --- Tests: POST /api/v1/notifications/test ---
+
+ADMIN_EMAIL = "admin@blueye.mx"
+NON_ADMIN_EMAIL = "user@blueye.mx"
+
+
+def _mock_auth_email(email: str):
+    return patch("app.core.auth.auth.verify_id_token", return_value={"uid": "test-uid", "email": email})
+
+
+def test_test_notif_no_auth():
+    """Missing Authorization header → 422 (FastAPI Header validation)."""
+    r = client.post("/api/v1/notifications/test", json={"type": "generic"})
+    assert r.status_code == 422
+
+
+def test_test_notif_not_configured():
+    """Empty allowlist → 403 even for a valid user."""
+    with patch.object(settings, "NOTIFICATION_TEST_ADMIN_EMAILS", ""):
+        with _mock_auth_email(ADMIN_EMAIL):
+            r = client.post(
+                "/api/v1/notifications/test",
+                json={"type": "generic"},
+                headers=AUTH_HEADERS,
+            )
+    assert r.status_code == 403
+    assert "not configured" in r.json()["detail"].lower()
+
+
+def test_test_notif_user_not_admin():
+    """Authenticated user whose email is not in the allowlist → 403."""
+    with patch.object(settings, "NOTIFICATION_TEST_ADMIN_EMAILS", ADMIN_EMAIL):
+        with _mock_auth_email(NON_ADMIN_EMAIL):
+            r = client.post(
+                "/api/v1/notifications/test",
+                json={"type": "generic"},
+                headers=AUTH_HEADERS,
+            )
+    assert r.status_code == 403
+    assert "not authorized" in r.json()["detail"].lower()
+
+
+def test_test_notif_admin_success():
+    """Admin email in allowlist → 200 with success_count."""
+    with patch.object(settings, "NOTIFICATION_TEST_ADMIN_EMAILS", ADMIN_EMAIL):
+        with _mock_auth_email(ADMIN_EMAIL):
+            with patch(
+                "app.features.notifications.router.send_all_notifications",
+                new_callable=AsyncMock,
+                return_value={"success_count": 2, "failure_count": 0},
+            ):
+                r = client.post(
+                    "/api/v1/notifications/test",
+                    json={"type": "hurricane_l2"},
+                    headers=AUTH_HEADERS,
+                )
+    assert r.status_code == 200
+    assert r.json()["success_count"] == 2
+
+
+def test_test_notif_invalid_type():
+    """Enum validation: unknown type → 422."""
+    with patch.object(settings, "NOTIFICATION_TEST_ADMIN_EMAILS", ADMIN_EMAIL):
+        with _mock_auth_email(ADMIN_EMAIL):
+            r = client.post(
+                "/api/v1/notifications/test",
+                json={"type": "hacked_payload"},
+                headers=AUTH_HEADERS,
+            )
+    assert r.status_code == 422

--- a/frontend/app/(tabs)/MoreScreen.tsx
+++ b/frontend/app/(tabs)/MoreScreen.tsx
@@ -4,6 +4,12 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import OptionCard from "../../components/OptionCard";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 
+const IS_DEV_BUILD =
+  (process.env.EXPO_PUBLIC_API_URL ?? '').includes('staging') ||
+  (process.env.EXPO_PUBLIC_API_URL ?? '').includes('localhost') ||
+  (process.env.EXPO_PUBLIC_API_URL ?? '').includes('192.168') ||
+  __DEV__;
+
 type MenuItem = {
   label: string;
   icon: keyof typeof MaterialCommunityIcons.glyphMap;
@@ -16,6 +22,9 @@ export default function MoreScreen() {
     { label: "Contactos SOS", icon: "account-heart-outline", route: "/SOSContactsScreen" },
     { label: "Feedback", icon: "message-reply-outline", route: "/FeedbackScreen" },
     // { label: "Suscripción", icon: "account-group-outline", route: "/subscription" },
+    ...(IS_DEV_BUILD
+      ? [{ label: "Dev: Notificaciones", icon: "bell-ring-outline" as const, route: "/NotificationTestScreen" }]
+      : []),
   ];
 
   return (

--- a/frontend/app/NotificationTestScreen.tsx
+++ b/frontend/app/NotificationTestScreen.tsx
@@ -1,0 +1,152 @@
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, ActivityIndicator, ScrollView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import Toast from 'react-native-toast-message';
+import { colors } from '../utils/theme';
+import { API_BASE_URL } from '../utils/config';
+
+const NOTIF_KEY = process.env.EXPO_PUBLIC_NOTIF_API_KEY as string | undefined;
+
+type MCIName = React.ComponentProps<typeof MaterialCommunityIcons>['name'];
+
+type TestButton = {
+  label: string;
+  icon: MCIName;
+  color: string;
+  payload: { title: string; body: string; data: Record<string, string> };
+};
+
+const BUTTONS: TestButton[] = [
+  {
+    label: 'Huracán Nivel 2 — Verde',
+    icon: 'weather-hurricane',
+    color: colors.brandGreen,
+    payload: {
+      title: 'Alerta SIAT-CT Verde [PRUEBA]',
+      body: 'Ciclón de prueba | Distancia: ~200 km | ETA: ~36h',
+      data: { siat_level: '2', siat_color: 'VERDE' },
+    },
+  },
+  {
+    label: 'Huracán Nivel 4 — Naranja (fullscreen)',
+    icon: 'alert-octagram',
+    color: colors.brandOrange,
+    payload: {
+      title: 'Alerta SIAT-CT Naranja [PRUEBA]',
+      body: 'Ciclón de prueba | Distancia: ~50 km | ETA: ~8h',
+      data: { siat_level: '4', siat_color: 'NARANJA', fullScreen: 'true' },
+    },
+  },
+  {
+    label: 'SOS de prueba',
+    icon: 'alarm-light-outline',
+    color: colors.brandRed,
+    payload: {
+      title: 'SOS — Equipo BluEye [PRUEBA]',
+      body: 'Necesita ayuda urgente. Toca para ver su ubicación.',
+      data: { category: 'sos', sender_name: 'Test BluEye', lat: '19.43264', lon: '-99.13318' },
+    },
+  },
+  {
+    label: 'Push genérico',
+    icon: 'bell-outline',
+    color: colors.brandBlue,
+    payload: {
+      title: 'Notificación de prueba [PRUEBA]',
+      body: 'Esta es una notificación de prueba del equipo BluEye.',
+      data: {},
+    },
+  },
+];
+
+export default function NotificationTestScreen() {
+  const [loadingIndex, setLoadingIndex] = useState<number | null>(null);
+  const keyMissing = !NOTIF_KEY;
+
+  const sendTest = async (index: number) => {
+    if (keyMissing || loadingIndex !== null) return;
+    setLoadingIndex(index);
+    try {
+      const { payload } = BUTTONS[index];
+      const res = await fetch(`${API_BASE_URL}/api/v1/notifications/send-all`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-API-Key': NOTIF_KEY! },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      Toast.show({ type: 'success', text1: 'Enviado', text2: `${data.success_count} dispositivo(s)` });
+    } catch (e) {
+      Toast.show({ type: 'error', text1: 'Error al enviar', text2: String(e) });
+    } finally {
+      setLoadingIndex(null);
+    }
+  };
+
+  return (
+    <SafeAreaView edges={['top', 'left', 'right', 'bottom']} className="flex-1 bg-transparent">
+      <ScrollView className="flex-1 px-6 pt-6" showsVerticalScrollIndicator={false}>
+        <Text className="text-xl font-poppins-semibold text-white mb-1">
+          Dev: Notificaciones
+        </Text>
+        <Text className="text-sm font-poppins text-white/50 mb-6">
+          Herramienta interna — solo visible en staging/dev
+        </Text>
+
+        {keyMissing && (
+          <View
+            className="mb-6 rounded-xl px-4 py-3"
+            style={{
+              backgroundColor: `${colors.brandOrange}22`,
+              borderWidth: 1,
+              borderColor: colors.brandOrange,
+            }}
+          >
+            <Text className="text-sm font-poppins-semibold" style={{ color: colors.brandOrange }}>
+              API key no configurada
+            </Text>
+            <Text className="text-xs font-poppins text-white/60 mt-1">
+              Agrega EXPO_PUBLIC_NOTIF_API_KEY en tu .env o en las variables de tu build.
+            </Text>
+          </View>
+        )}
+
+        {BUTTONS.map((btn, index) => (
+          <TouchableOpacity
+            key={btn.label}
+            onPress={() => sendTest(index)}
+            disabled={keyMissing || loadingIndex !== null}
+            className="flex-row items-center mb-4 rounded-2xl px-5 py-4"
+            style={{
+              backgroundColor: keyMissing ? 'rgba(255,255,255,0.03)' : `${btn.color}22`,
+              borderWidth: 1,
+              borderColor: keyMissing ? 'rgba(255,255,255,0.1)' : btn.color,
+              opacity: loadingIndex !== null && loadingIndex !== index ? 0.5 : 1,
+            }}
+          >
+            {loadingIndex === index ? (
+              <ActivityIndicator size="small" color={btn.color} style={{ marginRight: 12 }} />
+            ) : (
+              <MaterialCommunityIcons
+                name={btn.icon}
+                size={22}
+                color={keyMissing ? 'rgba(255,255,255,0.3)' : btn.color}
+                style={{ marginRight: 12 }}
+              />
+            )}
+            <Text
+              className="flex-1 font-poppins-semibold text-sm"
+              style={{ color: keyMissing ? 'rgba(255,255,255,0.3)' : 'white' }}
+            >
+              {btn.label}
+            </Text>
+            {loadingIndex !== null && loadingIndex !== index && (
+              <Text className="text-xs font-poppins text-white/30">espera...</Text>
+            )}
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/frontend/app/NotificationTestScreen.tsx
+++ b/frontend/app/NotificationTestScreen.tsx
@@ -4,76 +4,42 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import Toast from 'react-native-toast-message';
 import { colors } from '../utils/theme';
+import { authFetch } from '../utils/api';
 import { API_BASE_URL } from '../utils/config';
 
-const NOTIF_KEY = process.env.EXPO_PUBLIC_NOTIF_API_KEY as string | undefined;
-
 type MCIName = React.ComponentProps<typeof MaterialCommunityIcons>['name'];
+
+type NotificationTestType = 'hurricane_l2' | 'hurricane_l4' | 'sos_test' | 'generic';
 
 type TestButton = {
   label: string;
   icon: MCIName;
   color: string;
-  payload: { title: string; body: string; data: Record<string, string> };
+  type: NotificationTestType;
 };
 
 const BUTTONS: TestButton[] = [
-  {
-    label: 'Huracán Nivel 2 — Verde',
-    icon: 'weather-hurricane',
-    color: colors.brandGreen,
-    payload: {
-      title: 'Alerta SIAT-CT Verde [PRUEBA]',
-      body: 'Ciclón de prueba | Distancia: ~200 km | ETA: ~36h',
-      data: { siat_level: '2', siat_color: 'VERDE' },
-    },
-  },
-  {
-    label: 'Huracán Nivel 4 — Naranja (fullscreen)',
-    icon: 'alert-octagram',
-    color: colors.brandOrange,
-    payload: {
-      title: 'Alerta SIAT-CT Naranja [PRUEBA]',
-      body: 'Ciclón de prueba | Distancia: ~50 km | ETA: ~8h',
-      data: { siat_level: '4', siat_color: 'NARANJA', fullScreen: 'true' },
-    },
-  },
-  {
-    label: 'SOS de prueba',
-    icon: 'alarm-light-outline',
-    color: colors.brandRed,
-    payload: {
-      title: 'SOS — Equipo BluEye [PRUEBA]',
-      body: 'Necesita ayuda urgente. Toca para ver su ubicación.',
-      data: { category: 'sos', sender_name: 'Test BluEye', lat: '19.43264', lon: '-99.13318' },
-    },
-  },
-  {
-    label: 'Push genérico',
-    icon: 'bell-outline',
-    color: colors.brandBlue,
-    payload: {
-      title: 'Notificación de prueba [PRUEBA]',
-      body: 'Esta es una notificación de prueba del equipo BluEye.',
-      data: {},
-    },
-  },
+  { label: 'Huracán Nivel 2 — Verde',          icon: 'weather-hurricane',  color: colors.brandGreen,  type: 'hurricane_l2' },
+  { label: 'Huracán Nivel 4 — Naranja (fullscreen)', icon: 'alert-octagram', color: colors.brandOrange, type: 'hurricane_l4' },
+  { label: 'SOS de prueba',                    icon: 'alarm-light-outline', color: colors.brandRed,    type: 'sos_test' },
+  { label: 'Push genérico',                   icon: 'bell-outline',        color: colors.brandBlue,   type: 'generic' },
 ];
 
 export default function NotificationTestScreen() {
   const [loadingIndex, setLoadingIndex] = useState<number | null>(null);
-  const keyMissing = !NOTIF_KEY;
 
   const sendTest = async (index: number) => {
-    if (keyMissing || loadingIndex !== null) return;
+    if (loadingIndex !== null) return;
     setLoadingIndex(index);
     try {
-      const { payload } = BUTTONS[index];
-      const res = await fetch(`${API_BASE_URL}/api/v1/notifications/send-all`, {
+      const res = await authFetch(`${API_BASE_URL}/api/v1/notifications/test`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-API-Key': NOTIF_KEY! },
-        body: JSON.stringify(payload),
+        body: JSON.stringify({ type: BUTTONS[index].type }),
       });
+      if (res.status === 403) {
+        Toast.show({ type: 'error', text1: 'No autorizado', text2: 'Tu cuenta no tiene acceso a esta herramienta.' });
+        return;
+      }
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       Toast.show({ type: 'success', text1: 'Enviado', text2: `${data.success_count} dispositivo(s)` });
@@ -94,51 +60,25 @@ export default function NotificationTestScreen() {
           Herramienta interna — solo visible en staging/dev
         </Text>
 
-        {keyMissing && (
-          <View
-            className="mb-6 rounded-xl px-4 py-3"
-            style={{
-              backgroundColor: `${colors.brandOrange}22`,
-              borderWidth: 1,
-              borderColor: colors.brandOrange,
-            }}
-          >
-            <Text className="text-sm font-poppins-semibold" style={{ color: colors.brandOrange }}>
-              API key no configurada
-            </Text>
-            <Text className="text-xs font-poppins text-white/60 mt-1">
-              Agrega EXPO_PUBLIC_NOTIF_API_KEY en tu .env o en las variables de tu build.
-            </Text>
-          </View>
-        )}
-
         {BUTTONS.map((btn, index) => (
           <TouchableOpacity
-            key={btn.label}
+            key={btn.type}
             onPress={() => sendTest(index)}
-            disabled={keyMissing || loadingIndex !== null}
+            disabled={loadingIndex !== null}
             className="flex-row items-center mb-4 rounded-2xl px-5 py-4"
             style={{
-              backgroundColor: keyMissing ? 'rgba(255,255,255,0.03)' : `${btn.color}22`,
+              backgroundColor: `${btn.color}22`,
               borderWidth: 1,
-              borderColor: keyMissing ? 'rgba(255,255,255,0.1)' : btn.color,
+              borderColor: btn.color,
               opacity: loadingIndex !== null && loadingIndex !== index ? 0.5 : 1,
             }}
           >
             {loadingIndex === index ? (
               <ActivityIndicator size="small" color={btn.color} style={{ marginRight: 12 }} />
             ) : (
-              <MaterialCommunityIcons
-                name={btn.icon}
-                size={22}
-                color={keyMissing ? 'rgba(255,255,255,0.3)' : btn.color}
-                style={{ marginRight: 12 }}
-              />
+              <MaterialCommunityIcons name={btn.icon} size={22} color={btn.color} style={{ marginRight: 12 }} />
             )}
-            <Text
-              className="flex-1 font-poppins-semibold text-sm"
-              style={{ color: keyMissing ? 'rgba(255,255,255,0.3)' : 'white' }}
-            >
+            <Text className="flex-1 font-poppins-semibold text-sm" style={{ color: 'white' }}>
               {btn.label}
             </Text>
             {loadingIndex !== null && loadingIndex !== index && (

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -287,6 +287,10 @@ export default Sentry.wrap(function Layout() {
                       options={{ headerShown: false }}
                     />
                     <Stack.Screen
+                      name="NotificationTestScreen"
+                      options={{ headerShown: false }}
+                    />
+                    <Stack.Screen
                       name="sos-invite"
                       options={{ headerShown: false }}
                     />


### PR DESCRIPTION
## Resumen

Esta PR agrega una herramienta interna para probar notificaciones push desde la aplicación.

Permite que cualquier miembro del equipo envíe notificaciones de prueba directamente desde la app sin necesidad de herramientas externas ni llamadas manuales a la API.

La pantalla está disponible únicamente en entornos de desarrollo y staging.

## Funcionalidad

Se agrega una nueva pantalla:

* NotificationTestScreen

Incluye botones para enviar:

* Huracán Nivel 2 (notificación estándar)
* Huracán Nivel 4 (pantalla completa)
* SOS de prueba
* Push genérico de prueba

Cada acción:

* Llama al endpoint existente:
  `POST /api/v1/notifications/send-all`
* Utiliza `X-API-Key`
* Muestra feedback visual mediante Toast
* Maneja estados de carga y error

## Seguridad

* La pantalla solo aparece en builds de desarrollo o staging.
* No se agregan API keys al repositorio.
* La variable `EXPO_PUBLIC_NOTIF_API_KEY` se obtiene desde variables de entorno del build o entorno local.
* Si la variable no existe, la pantalla muestra una advertencia y los botones permanecen deshabilitados.

## Archivos modificados

* `frontend/app/NotificationTestScreen.tsx`
* `frontend/app/(tabs)/MoreScreen.tsx`
* `frontend/app/_layout.tsx`

## Casos de uso

* Verificar recepción de notificaciones en dispositivos físicos.
* Validar AlarmScreen.
* Validar flujo SOS.
* Validar configuración de Firebase.
* Validar registro de tokens.

## QA recomendado

* Verificar que la opción aparece únicamente en staging/dev.
* Verificar que no aparece en producción.
* Probar los cuatro tipos de notificación.
* Verificar recepción en dispositivos físicos.
* Verificar comportamiento cuando `EXPO_PUBLIC_NOTIF_API_KEY` no está configurada.

## Tamaño

* 3 archivos modificados
* 165 líneas agregadas
* Sin cambios de backend
