### PR TITLE
fix: refresh auth token on 401

### DIFF
--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -8,7 +8,7 @@ export async function getAuthToken(): Promise<string> {
 
 export async function authFetch(url: string, options: RequestInit = {}): Promise<Response> {
   const token = await getAuthToken()
-  return fetch(url, {
+  const res = await fetch(url, {
     ...options,
     headers: {
       'Content-Type': 'application/json',
@@ -16,4 +16,24 @@ export async function authFetch(url: string, options: RequestInit = {}): Promise
       Authorization: `Bearer ${token}`,
     },
   })
+
+  if (res.status === 401) {
+    const user = getAuth().currentUser
+    if (!user) return res
+    try {
+      const freshToken = await getIdToken(user, true)
+      return fetch(url, {
+        ...options,
+        headers: {
+          'Content-Type': 'application/json',
+          ...options.headers,
+          Authorization: `Bearer ${freshToken}`,
+        },
+      })
+    } catch {
+      return res
+    }
+  }
+
+  return res
 }


### PR DESCRIPTION
## Resumen

Esta PR mejora `authFetch` para manejar tokens Firebase expirados.

Cuando una request autenticada recibe `401`, se fuerza un refresh del token con `getIdToken(user, true)` y se reintenta la request una sola vez.

## Cambios

* Se mantiene la firma de `authFetch`.
* Se mantiene la firma de `getAuthToken`.
* Se agrega retry único cuando la respuesta es `401`.
* No se usa recursión.
* No se crean loops.
* Si el refresh falla, se devuelve el `401` original.
* Si el segundo `fetch` falla por red, el error sube al caller.

## Impacto

Mejora la estabilidad de llamadas autenticadas cuando la app lleva mucho tiempo abierta.

Esto beneficia flujos como:

* SOS
* Contactos SOS
* Invitaciones SOS
* Alertas
* IA
* Preferencias
* Endpoints autenticados en general

## Archivos modificados

* `frontend/utils/api.ts`

## Tamaño

* 1 archivo modificado
* 21 inserciones
* 1 eliminación
