### PR TITLE
feat: add SOS offline queue

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -21,7 +21,8 @@ import {
 } from "../utils/pushNotifications";
 import * as Notifications from "expo-notifications";
 import Toast from "react-native-toast-message";
-import { initAnalytics, track, flush } from "../utils/analytics";
+import { initAnalytics, track, flush } from "../utils/analytics"
+import { flushSOSQueue, shouldConfirmPendingSOS } from "./map/sosQueue";
 import { hasCompletedOnboarding } from "./onboarding/_services/onboardingService"
 import { usePathname } from "expo-router";
 import * as Sentry from '@sentry/react-native';
@@ -263,6 +264,12 @@ export default Sentry.wrap(function Layout() {
       if (state === "background") {
         track("app_background");
         flush();
+      }
+      if (state === "active") {
+        shouldConfirmPendingSOS().then((needsConfirm) => {
+          if (!needsConfirm) flushSOSQueue();
+          // Si needsConfirm: MapScreen mostrará el Alert cuando el usuario vuelva al mapa.
+        });
       }
     });
     return () => sub.remove();

--- a/frontend/app/map/index.tsx
+++ b/frontend/app/map/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import {
   View,
   Pressable,
@@ -10,6 +10,7 @@ import {
   TouchableOpacity,
   Alert,
   ActivityIndicator,
+  AppState,
   Image,
   KeyboardAvoidingView,
   Platform,
@@ -34,6 +35,9 @@ import { DEFAULT_REGION, ZONE_TYPES } from "./config";
 import { colors, fonts } from "../../utils/theme";
 import { authFetch } from "../../utils/api";
 import { API_BASE_URL } from "../../utils/config";
+import * as Network from "expo-network";
+import { useFocusEffect } from "expo-router";
+import { enqueueSOS, hasPendingSOSItem, getPendingSOSItem, flushSOSQueue, clearSOSQueue } from "./sosQueue";
 import type { Zone, ZoneType } from "./types";
 
 const OWM_API_KEY = process.env.EXPO_PUBLIC_OPENWEATHER_API_KEY;
@@ -79,6 +83,60 @@ export default function WeatherMapNativewind() {
   const [descriptionError, setDescriptionError] = useState(false);
   const [isSosSending, setIsSosSending] = useState(false);
   const [currentCoords, setCurrentCoords] = useState<{ latitude: number; longitude: number } | null>(null);
+  const [hasPendingSOS, setHasPendingSOS] = useState(false);
+
+  // Al montar y al volver al foco: verificar cola con control de antigüedad.
+  // Items < 30 min → flush automático. Items > 30 min → pedir confirmación al usuario.
+  useFocusEffect(
+    useCallback(() => {
+      (async () => {
+        const item = await getPendingSOSItem();
+        if (!item) {
+          setHasPendingSOS(false);
+          return;
+        }
+        setHasPendingSOS(true);
+        const ageMs = Date.now() - item.queuedAt;
+        if (ageMs > 30 * 60 * 1000) {
+          const mins = Math.round(ageMs / 60000);
+          Alert.alert(
+            'SOS pendiente',
+            `Tienes un SOS pendiente de hace ${mins} minuto(s). ¿Quieres enviarlo ahora o cancelarlo?`,
+            [
+              {
+                text: 'Cancelar SOS',
+                style: 'destructive',
+                onPress: async () => {
+                  await clearSOSQueue();
+                  setHasPendingSOS(false);
+                },
+              },
+              {
+                text: 'Enviar ahora',
+                onPress: async () => {
+                  await flushSOSQueue();
+                  setHasPendingSOS(await hasPendingSOSItem());
+                },
+              },
+            ]
+          );
+        } else {
+          await flushSOSQueue();
+          setHasPendingSOS(await hasPendingSOSItem());
+        }
+      })();
+    }, [])
+  );
+
+  // Al volver a foreground (desde background): re-chequear cola tras flush de _layout
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') {
+        hasPendingSOSItem().then(setHasPendingSOS);
+      }
+    });
+    return () => sub.remove();
+  }, []);
 
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout>;
@@ -337,14 +395,16 @@ export default function WeatherMapNativewind() {
   const doSendSOS = async () => {
     setIsSosSending(true);
     try {
+      // 1. Obtener GPS primero (funciona sin internet)
       let lat: number | undefined;
       let lon: number | undefined;
-
+      let gpsFailed = false;
+      let permDenied = false;
       const { status } = await Location.requestForegroundPermissionsAsync();
       if (status === "granted") {
         try {
           const timeoutPromise = new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error('timeout')), 5000)
+            setTimeout(() => reject(new Error("timeout")), 5000)
           );
           const { coords } = await Promise.race([
             Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced }),
@@ -353,59 +413,77 @@ export default function WeatherMapNativewind() {
           lat = coords.latitude;
           lon = coords.longitude;
         } catch {
-          Toast.show({
-            type: "info",
-            text1: "Sin ubicación precisa",
-            text2: "Se enviará el SOS sin coordenadas.",
-          });
+          gpsFailed = true;
         }
       } else {
+        permDenied = true;
+      }
+
+      // 2. Verificar conectividad (con coords ya en mano si las hay)
+      const net = await Network.getNetworkStateAsync();
+      if (net.isConnected === false || net.isInternetReachable === false) {
+        const hasCoords = lat !== undefined;
+        await enqueueSOS(lat, lon);
+        setHasPendingSOS(true);
         Toast.show({
           type: "info",
-          text1: "Permiso de ubicación denegado",
-          text2: "Se enviará el SOS sin coordenadas.",
+          text1: hasCoords ? "SOS guardado" : "SOS guardado sin ubicación",
+          text2: "Se enviará cuando recuperes conexión.",
         });
+        return;
+      }
+
+      // 3. Online: mostrar feedback de GPS si aplica
+      if (permDenied) {
+        Toast.show({ type: "info", text1: "Permiso de ubicación denegado", text2: "Se enviará el SOS sin coordenadas." });
+      } else if (gpsFailed) {
+        Toast.show({ type: "info", text1: "Sin ubicación precisa", text2: "Se enviará el SOS sin coordenadas." });
       }
 
       const body: { lat?: number; lon?: number } = {};
       if (lat !== undefined) body.lat = lat;
       if (lon !== undefined) body.lon = lon;
 
-      const res = await authFetch(`${API_BASE_URL}/api/v1/sos/trigger`, {
-        method: "POST",
-        body: JSON.stringify(body),
-      });
-
-      if (res.status === 429) {
-        Toast.show({
-          type: "error",
-          text1: "Límite alcanzado",
-          text2: "Demasiadas alertas SOS. Espera unos minutos.",
+      let res: Response;
+      try {
+        res = await authFetch(`${API_BASE_URL}/api/v1/sos/trigger`, {
+          method: "POST",
+          body: JSON.stringify(body),
         });
+      } catch {
+        await enqueueSOS(lat, lon);
+        setHasPendingSOS(true);
+        Toast.show({ type: "info", text1: "SOS guardado", text2: "Se enviará cuando recuperes conexión." });
         return;
       }
-      if (!res.ok) throw new Error();
+
+      if (res.status === 429) {
+        await enqueueSOS(lat, lon);
+        setHasPendingSOS(true);
+        Toast.show({ type: "error", text1: "Límite alcanzado", text2: "El SOS se enviará automáticamente pronto." });
+        return;
+      }
+
+      if (res.status >= 500) {
+        await enqueueSOS(lat, lon);
+        setHasPendingSOS(true);
+        Toast.show({ type: "info", text1: "SOS guardado", text2: "Error del servidor. Se reintentará automáticamente." });
+        return;
+      }
+
+      if (!res.ok) {
+        // 4xx (no 429): error de cliente, no encolar
+        Toast.show({ type: "error", text1: "Error", text2: "No se pudo enviar el SOS. Intenta de nuevo." });
+        return;
+      }
 
       const data = await res.json();
+      setHasPendingSOS(false);
       if (data.notified_count === 0) {
-        Toast.show({
-          type: "info",
-          text1: "SOS enviado",
-          text2: "No tienes contactos vinculados. Agrégalos en tu perfil.",
-        });
+        Toast.show({ type: "info", text1: "SOS enviado", text2: "No tienes contactos vinculados. Agrégalos en tu perfil." });
       } else {
-        Toast.show({
-          type: "success",
-          text1: "SOS enviado",
-          text2: `${data.notified_count} contacto(s) notificado(s).`,
-        });
+        Toast.show({ type: "success", text1: "SOS enviado", text2: `${data.notified_count} contacto(s) notificado(s).` });
       }
-    } catch {
-      Toast.show({
-        type: "error",
-        text1: "Error",
-        text2: "No se pudo enviar el SOS. Intenta de nuevo.",
-      });
     } finally {
       setIsSosSending(false);
     }
@@ -589,6 +667,27 @@ export default function WeatherMapNativewind() {
           : <MaterialCommunityIcons name="alarm-light-outline" size={24} color="#fff" />
         }
       </TouchableOpacity>
+
+      {/* SOS pendiente de envío */}
+      {hasPendingSOS && (
+        <View style={{
+          position: 'absolute',
+          top: 60,
+          left: 16,
+          right: 16,
+          backgroundColor: colors.brandOrange + 'dd',
+          borderRadius: 10,
+          paddingHorizontal: 14,
+          paddingVertical: 8,
+          flexDirection: 'row',
+          alignItems: 'center',
+        }}>
+          <MaterialCommunityIcons name="clock-outline" size={16} color="#fff" style={{ marginRight: 8 }} />
+          <Text style={{ color: '#fff', fontFamily: fonts.poppins, fontSize: 13 }}>
+            SOS pendiente de envío
+          </Text>
+        </View>
+      )}
 
       {/* Modal: Report Zone */}
       <Modal

--- a/frontend/app/map/sosQueue.ts
+++ b/frontend/app/map/sosQueue.ts
@@ -1,0 +1,123 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import Toast from 'react-native-toast-message'
+import { authFetch } from '../../utils/api'
+import { API_BASE_URL } from '../../utils/config'
+
+const QUEUE_KEY = '@BluEye:sos_queue'
+const MAX_AGE_MS = 24 * 60 * 60 * 1000
+
+// Guard: evita flush simultáneo (mount + _layout.tsx AppState disparan al mismo tiempo)
+let isFlushingSOSQueue = false
+
+export type SOSQueueItem = {
+  id: string
+  lat?: number
+  lon?: number
+  queuedAt: number
+}
+
+// Guarda un intento SOS. Solo mantiene 1 item (el más reciente con coords frescas).
+export async function enqueueSOS(lat?: number, lon?: number): Promise<void> {
+  const item: SOSQueueItem = {
+    id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    lat,
+    lon,
+    queuedAt: Date.now(),
+  }
+  await AsyncStorage.setItem(QUEUE_KEY, JSON.stringify([item]))
+}
+
+// Lee la cola y descarta items expirados (>24h).
+export async function getSOSQueue(): Promise<SOSQueueItem[]> {
+  try {
+    const raw = await AsyncStorage.getItem(QUEUE_KEY)
+    if (!raw) return []
+    const items: SOSQueueItem[] = JSON.parse(raw)
+    return items.filter((i) => Date.now() - i.queuedAt < MAX_AGE_MS)
+  } catch {
+    return []
+  }
+}
+
+export async function hasPendingSOSItem(): Promise<boolean> {
+  return (await getSOSQueue()).length > 0
+}
+
+export async function getPendingSOSItem(): Promise<SOSQueueItem | null> {
+  const items = await getSOSQueue()
+  return items.length > 0 ? items[0] : null
+}
+
+export async function clearSOSQueue(): Promise<void> {
+  await AsyncStorage.removeItem(QUEUE_KEY)
+}
+
+// Devuelve true si hay un SOS pendiente más antiguo que maxAgeMs.
+// Úsalo antes de un flush automático para evitar enviar SOS viejos sin confirmación del usuario.
+export async function shouldConfirmPendingSOS(maxAgeMs = 30 * 60 * 1000): Promise<boolean> {
+  const item = await getPendingSOSItem()
+  if (!item) return false
+  return Date.now() - item.queuedAt > maxAgeMs
+}
+
+async function removeSOSItem(id: string): Promise<void> {
+  const current = await getSOSQueue()
+  await AsyncStorage.setItem(QUEUE_KEY, JSON.stringify(current.filter((i) => i.id !== id)))
+}
+
+// Intenta enviar los items pendientes. Protegido con guard para evitar ejecuciones concurrentes.
+// Reglas de cola:
+//   - network error / 5xx / 429 → mantener en cola para reintentar
+//   - 4xx (no 429)              → eliminar de cola (no reintentable) + Toast de error
+//   - éxito                     → eliminar y mostrar Toast
+export async function flushSOSQueue(): Promise<void> {
+  if (isFlushingSOSQueue) return
+  isFlushingSOSQueue = true
+  try {
+    const items = await getSOSQueue()
+    if (items.length === 0) return
+
+    for (const item of items) {
+      try {
+        const body: { lat?: number; lon?: number } = {}
+        if (item.lat !== undefined) body.lat = item.lat
+        if (item.lon !== undefined) body.lon = item.lon
+
+        const res = await authFetch(`${API_BASE_URL}/api/v1/sos/trigger`, {
+          method: 'POST',
+          body: JSON.stringify(body),
+        })
+
+        if (res.status === 429) continue // rate limited → mantener
+
+        if (res.status >= 500) continue // error de servidor → mantener
+
+        if (!res.ok) {
+          // 4xx (no 429): error de cliente, no reintentable → eliminar con aviso
+          await removeSOSItem(item.id)
+          Toast.show({
+            type: 'error',
+            text1: 'SOS no enviado',
+            text2: 'Hubo un error. Tus contactos no fueron notificados.',
+          })
+          continue
+        }
+
+        await removeSOSItem(item.id)
+        const data = await res.json()
+        Toast.show({
+          type: 'success',
+          text1: 'SOS enviado',
+          text2:
+            data.notified_count === 0
+              ? 'No tienes contactos vinculados. Agrégalos en tu perfil.'
+              : `${data.notified_count} contacto(s) notificado(s).`,
+        })
+      } catch {
+        // Red no disponible → mantener en cola
+      }
+    }
+  } finally {
+    isFlushingSOSQueue = false
+  }
+}


### PR DESCRIPTION
## Resumen

Esta PR agrega una cola local para alertas SOS cuando el dispositivo no tiene conectividad o cuando el envío falla por errores temporales.

El objetivo es aumentar la confiabilidad del flujo SOS en escenarios reales de emergencia, evitando que una alerta se pierda por falta de red o problemas momentáneos de conexión.

## Funcionalidad

### Cola local de SOS

Se agrega un nuevo servicio:

* `frontend/app/map/sosQueue.ts`

Responsabilidades:

* Guardar SOS pendientes.
* Gestionar reintentos automáticos.
* Evitar envíos duplicados.
* Expirar alertas antiguas.
* Manejar errores reintentables y no reintentables.

### Envío offline

Si el usuario intenta enviar un SOS y:

* no tiene conexión,
* pierde conexión durante el envío,
* recibe un error 429,
* recibe un error 5xx,

la alerta se guarda localmente y se reintentará automáticamente más adelante.

### Ubicación

Antes de guardar el SOS se intenta obtener la ubicación actual.

Resultados:

* GPS disponible → SOS guardado con coordenadas.
* GPS no disponible → SOS guardado sin ubicación y se informa al usuario.

### Reintentos automáticos

Al volver la aplicación a primer plano:

* se revisa la cola local,
* se reintentan los envíos pendientes,
* los SOS enviados correctamente se eliminan de la cola.

### Prevención de duplicados

Se agrega un guard de concurrencia en `flushSOSQueue()` para evitar que múltiples eventos de foreground provoquen el envío duplicado de la misma alerta.

### Confirmación para SOS antiguos

Si existe un SOS pendiente con más de 30 minutos de antigüedad:

* no se envía automáticamente,
* el usuario debe confirmar si desea enviarlo o cancelarlo.

### Manejo de errores

* 429 → permanece en cola.
* 5xx → permanece en cola.
* 4xx no reintentables → se elimina de la cola y se informa al usuario.

## Archivos modificados

* `frontend/app/map/sosQueue.ts`
* `frontend/app/map/index.tsx`
* `frontend/app/_layout.tsx`

## QA recomendado

### SOS offline

1. Desactivar conexión.
2. Enviar SOS.
3. Verificar mensaje "SOS guardado".
4. Verificar banner de SOS pendiente.

### Recuperación automática

1. Reactivar conexión.
2. Volver la app a foreground.
3. Verificar envío automático y eliminación del banner.

### SOS antiguo

1. Simular un item pendiente > 30 minutos.
2. Verificar aparición del diálogo de confirmación.
3. Validar opciones "Enviar ahora" y "Cancelar SOS".

### Prevención de duplicados

1. Generar un SOS pendiente.
2. Provocar múltiples eventos de foreground.
3. Verificar un único envío y una sola notificación a contactos.

## Impacto

Esta PR mejora significativamente la resiliencia del sistema SOS ante fallos de conectividad y reduce la probabilidad de pérdida de alertas durante situaciones de emergencia reales.
