### PR TITLE
feat: add SOS contact badge and improve rate limit UX

### DIFF
--- a/backend/app/features/sos_trigger/service.py
+++ b/backend/app/features/sos_trigger/service.py
@@ -31,10 +31,21 @@ async def trigger_sos(
         {"sender_id": sender_id},
     )
     if count_row.scalar() >= _RATE_LIMIT_MAX:
+        oldest_row = await db.execute(
+            text(f"""
+                SELECT GREATEST(0, EXTRACT(EPOCH FROM
+                    (MIN(created_at) + INTERVAL '{_RATE_LIMIT_WINDOW}' - NOW()))::int)
+                FROM sos_events
+                WHERE sender_id = :sender_id
+                  AND created_at > NOW() - INTERVAL '{_RATE_LIMIT_WINDOW}'
+            """),
+            {"sender_id": sender_id},
+        )
+        retry_after = int(oldest_row.scalar() or 600)
         raise HTTPException(
             status_code=429,
             detail="Demasiadas alertas SOS. Espera unos minutos antes de enviar otra.",
-            headers={"Retry-After": "600"},
+            headers={"Retry-After": str(retry_after)},
         )
 
     # 2. Linked contacts

--- a/frontend/app/map/index.tsx
+++ b/frontend/app/map/index.tsx
@@ -84,6 +84,7 @@ export default function WeatherMapNativewind() {
   const [isSosSending, setIsSosSending] = useState(false);
   const [currentCoords, setCurrentCoords] = useState<{ latitude: number; longitude: number } | null>(null);
   const [hasPendingSOS, setHasPendingSOS] = useState(false);
+  const [linkedContactCount, setLinkedContactCount] = useState<number | null>(null);
 
   // Al montar y al volver al foco: verificar cola con control de antigüedad.
   // Items < 30 min → flush automático. Items > 30 min → pedir confirmación al usuario.
@@ -123,6 +124,22 @@ export default function WeatherMapNativewind() {
         } else {
           await flushSOSQueue();
           setHasPendingSOS(await hasPendingSOSItem());
+        }
+      })();
+    }, [])
+  );
+
+  // Al volver al foco: actualizar conteo de contactos vinculados para el badge del FAB
+  useFocusEffect(
+    useCallback(() => {
+      (async () => {
+        try {
+          const res = await authFetch(`${API_BASE_URL}/api/v1/sos-contacts`);
+          if (!res.ok) return;
+          const data: { link_status: string }[] = await res.json();
+          setLinkedContactCount(data.filter(c => c.link_status === 'linked').length);
+        } catch {
+          // best-effort — badge stays hidden on error
         }
       })();
     }, [])
@@ -460,7 +477,10 @@ export default function WeatherMapNativewind() {
       if (res.status === 429) {
         await enqueueSOS(lat, lon);
         setHasPendingSOS(true);
-        Toast.show({ type: "error", text1: "Límite alcanzado", text2: "El SOS se enviará automáticamente pronto." });
+        const retryAfterSec = parseInt(res.headers.get('Retry-After') ?? '600', 10);
+        const minutes = Math.ceil(retryAfterSec / 60);
+        const retryText = minutes <= 1 ? 'en 1 min.' : `en ${minutes} min.`;
+        Toast.show({ type: "error", text1: "Límite alcanzado", text2: `Podrás enviar otro SOS ${retryText}` });
         return;
       }
 
@@ -647,26 +667,45 @@ export default function WeatherMapNativewind() {
       </Pressable>
 
       {/* SOS FAB */}
-      <TouchableOpacity
-        onPress={handleSOSTrigger}
-        disabled={isSosSending}
-        style={{
-          position: 'absolute',
-          bottom: 56,
-          left: 16,
-          width: 48,
-          height: 48,
-          borderRadius: 14,
-          backgroundColor: isSosSending ? 'rgba(226,67,55,0.5)' : colors.brandRed,
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        {isSosSending
-          ? <ActivityIndicator size="small" color="#fff" />
-          : <MaterialCommunityIcons name="alarm-light-outline" size={24} color="#fff" />
-        }
-      </TouchableOpacity>
+      <View style={{ position: 'absolute', bottom: 56, left: 16 }}>
+        <TouchableOpacity
+          onPress={handleSOSTrigger}
+          disabled={isSosSending}
+          style={{
+            width: 48,
+            height: 48,
+            borderRadius: 14,
+            backgroundColor: isSosSending ? 'rgba(226,67,55,0.5)' : colors.brandRed,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          {isSosSending
+            ? <ActivityIndicator size="small" color="#fff" />
+            : <MaterialCommunityIcons name="alarm-light-outline" size={24} color="#fff" />
+          }
+        </TouchableOpacity>
+        {linkedContactCount !== null && (
+          <View style={{
+            position: 'absolute',
+            top: -6,
+            right: -6,
+            minWidth: 18,
+            height: 18,
+            borderRadius: 9,
+            backgroundColor: linkedContactCount === 0 ? colors.brandOrange : colors.brandGreen,
+            alignItems: 'center',
+            justifyContent: 'center',
+            paddingHorizontal: 4,
+            borderWidth: 1.5,
+            borderColor: '#fff',
+          }}>
+            <Text style={{ color: '#fff', fontSize: 10, fontFamily: fonts.poppinsSemiBold }}>
+              {linkedContactCount === 0 ? '!' : linkedContactCount > 9 ? '9+' : String(linkedContactCount)}
+            </Text>
+          </View>
+        )}
+      </View>
 
       {/* SOS pendiente de envío */}
       {hasPendingSOS && (


### PR DESCRIPTION
## Resumen

Esta PR mejora la experiencia del flujo SOS mediante dos cambios:

* Badge de contactos vinculados sobre el botón SOS.
* Mensajes de rate limit con tiempo restante real.

## Funcionalidad

### SOS Contact Badge

El FAB SOS ahora muestra un badge con la cantidad de contactos vinculados.

Comportamiento:

* `!` (naranja) cuando no existen contactos vinculados.
* Número (verde) cuando existen contactos vinculados.
* `9+` para cantidades mayores a nueve.
* Invisible mientras la información se encuentra cargando.

La información se obtiene usando el endpoint existente:

`GET /api/v1/sos-contacts`

y se actualiza al volver a la pantalla del mapa.

### Rate Limit UX

El backend ahora calcula el tiempo restante real del rate limit SOS utilizando el evento más antiguo dentro de la ventana activa.

El frontend consume el header `Retry-After` y muestra mensajes como:

> Podrás enviar otro SOS en 8 min.

en lugar del mensaje genérico anterior.

## Archivos modificados

* backend/app/features/sos_trigger/service.py
* frontend/app/map/index.tsx

## QA recomendado

### Badge

* Abrir mapa sin contactos vinculados.
* Verificar badge naranja con `!`.
* Vincular un contacto.
* Volver al mapa.
* Verificar badge verde con contador.

### Rate Limit

* Enviar SOS hasta alcanzar el límite.
* Verificar respuesta 429.
* Verificar que el tiempo mostrado coincide con el tiempo restante real.

## Validación

* TypeScript sin errores en archivos modificados.
* Tests backend pasando.
* Sin dependencias nuevas.
* Sin cambios de schema.
