### PR TITLE
Feat/12 alertas rig — notif test por dispositivo, inject ciclón falso…

### DIFF
--- a/backend/app/features/alerts/service.py
+++ b/backend/app/features/alerts/service.py
@@ -1,6 +1,61 @@
 import json
+import logging
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+
+def _smn_headline_to_level(headline: str) -> int:
+    """Derive SIAT level (1-5) from SMN headline keywords."""
+    hl = headline.upper()
+    if any(k in hl for k in ("ROJO", "EXTREM", "EXCEPCIONAL", "CATEGORÍA 4", "CATEGORÍA 5")):
+        return 5
+    if any(k in hl for k in ("NARANJA", "SEVER", "GRAVE", "HURACÁN", "HURACAN")):
+        return 4
+    if any(k in hl for k in ("AMARILLO", "MODERADO", "FUERTE", "INTENSO", "INTENSA", "TORMENTA TROPICAL")):
+        return 3
+    return 2  # VERDE — default para boletín informativo
+
+
+async def persist_smn_bulletin_if_new(db: AsyncSession, bulletin: dict) -> bool:
+    """
+    Insert an SMN bulletin into the alerts table if it hasn't been persisted yet.
+    Returns True when a new row was inserted, False when it already existed.
+    SMN alerts have no specific lat/lon (national scope).
+    """
+    aviso_num = bulletin.get("aviso_num")
+    if aviso_num:
+        title = f"SMN Aviso #{aviso_num}"
+        existing = await db.execute(
+            text("SELECT id FROM alerts WHERE title = :title AND timestamp > NOW() - INTERVAL '26 hours'"),
+            {"title": title},
+        )
+    else:
+        headline = bulletin.get("headline") or ""
+        title = f"SMN: {headline[:240]}"
+        existing = await db.execute(
+            text("SELECT id FROM alerts WHERE title = :title AND timestamp > NOW() - INTERVAL '4 hours'"),
+            {"title": title},
+        )
+
+    if existing.mappings().first():
+        logger.debug("SMN bulletin already persisted: '%s'", title)
+        return False
+
+    level = _smn_headline_to_level(bulletin.get("headline") or "")
+    short = (bulletin.get("summary") or bulletin.get("headline") or "Boletín del SMN/CONAGUA")[:500]
+
+    await db.execute(
+        text("""
+            INSERT INTO alerts (level, score, title, short, lat, lon, factors, recommendations)
+            VALUES (:level, 0, :title, :short, NULL, NULL, '[]', '[]')
+        """),
+        {"level": level, "title": title, "short": short},
+    )
+    await db.commit()
+    logger.info("SMN bulletin persisted: level=%d title='%s'", level, title)
+    return True
 
 
 async def get_alerts(db: AsyncSession, limit: int, offset: int):

--- a/backend/app/features/alerts/tests/test_router.py
+++ b/backend/app/features/alerts/tests/test_router.py
@@ -106,6 +106,87 @@ def test_alerts_active_smn_failure_does_not_break():
 # GET /api/v1/alerts/weather/mx
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# persist_smn_bulletin_if_new — service-level tests (no HTTP)
+# ---------------------------------------------------------------------------
+
+_SVC_ALERTS = "app.features.alerts.service"
+
+
+def _make_bulletin(aviso_num=42, headline="FRENTE FRÍO NÚMERO 15", summary="Lluvias moderadas."):
+    return {"aviso_num": aviso_num, "headline": headline, "summary": summary, "source": "SMN/CONAGUA"}
+
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+
+
+@pytest.mark.asyncio
+async def test_persist_smn_new_bulletin_returns_true():
+    """Boletín nuevo → se inserta y retorna True."""
+    from app.features.alerts.service import persist_smn_bulletin_if_new
+
+    db = MagicMock()
+    db.commit = AsyncMock()
+    # Primera consulta (dedup) devuelve vacío; la segunda es el INSERT
+    db.execute = AsyncMock(side_effect=[
+        MagicMock(**{"mappings.return_value.first.return_value": None}),  # dedup miss
+        MagicMock(),  # INSERT
+    ])
+
+    result = await persist_smn_bulletin_if_new(db, _make_bulletin())
+
+    assert result is True
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_persist_smn_existing_bulletin_returns_false():
+    """Boletín ya registrado → no inserta y retorna False."""
+    from app.features.alerts.service import persist_smn_bulletin_if_new
+
+    db = MagicMock()
+    db.commit = AsyncMock()
+    db.execute = AsyncMock(return_value=MagicMock(
+        **{"mappings.return_value.first.return_value": {"id": "existing-uuid"}}
+    ))
+
+    result = await persist_smn_bulletin_if_new(db, _make_bulletin())
+
+    assert result is False
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_persist_smn_no_aviso_num_uses_headline_dedup():
+    """Sin aviso_num → title usa el headline como clave de dedup."""
+    from app.features.alerts.service import persist_smn_bulletin_if_new
+
+    bulletin = {"aviso_num": None, "headline": "CANAL DE BAJA PRESIÓN", "summary": "Nublados."}
+    db = MagicMock()
+    db.commit = AsyncMock()
+    db.execute = AsyncMock(side_effect=[
+        MagicMock(**{"mappings.return_value.first.return_value": None}),
+        MagicMock(),
+    ])
+
+    result = await persist_smn_bulletin_if_new(db, bulletin)
+    assert result is True
+    # Verify the INSERT was called (second execute call)
+    assert db.execute.await_count == 2
+
+
+def test_smn_headline_to_level_keywords():
+    """Keywords de severidad mapean al nivel correcto."""
+    from app.features.alerts.service import _smn_headline_to_level
+
+    assert _smn_headline_to_level("CONDICIONES EXTREMAS EN EL NORTE") == 5
+    assert _smn_headline_to_level("LLUVIA SEVERA PREVISTA") == 4
+    assert _smn_headline_to_level("TORMENTA TROPICAL ALBERTO") == 3
+    assert _smn_headline_to_level("FRENTE FRÍO NÚMERO 15") == 2  # default VERDE
+    assert _smn_headline_to_level("") == 2
+
+
 def test_weather_mx_partial_failure_returns_200():
     """If one OpenWeather point raises an exception, remaining points are returned (no 502)."""
     good_data = {

--- a/backend/app/features/notifications/router.py
+++ b/backend/app/features/notifications/router.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import get_db
 from app.core.auth import get_current_user
-from app.features.notifications.service import push_token, send_all_notifications
+from app.features.notifications.service import push_token, send_all_notifications, send_targeted_notification
 from app.features.notifications.schemas import (
     NotificationSend, NotificationResponse, PushTokenCreate,
     NotificationTestType, NotificationTestRequest,
@@ -18,6 +18,11 @@ _TEST_PAYLOADS: dict[str, dict] = {
         "title": "Alerta SIAT-CT Verde [PRUEBA]",
         "body": "Ciclón de prueba | Distancia: ~200 km | ETA: ~36h",
         "data": {"siat_level": "2", "siat_color": "VERDE"},
+    },
+    "hurricane_l3": {
+        "title": "Alerta SIAT-CT Amarillo [PRUEBA]",
+        "body": "Ciclón de prueba | Distancia: ~120 km | ETA: ~18h",
+        "data": {"siat_level": "3", "siat_color": "AMARILLO"},
     },
     "hurricane_l4": {
         "title": "Alerta SIAT-CT Naranja [PRUEBA]",
@@ -88,6 +93,11 @@ async def send_test_notification(
 
     payload = _TEST_PAYLOADS[body.type]
     try:
+        if body.only_me:
+            db_user = await get_user_by_firebase_uid(db, current_user.get("uid"))
+            if db_user is None:
+                raise HTTPException(status_code=404, detail="User profile not found. Call POST /api/v1/users/me first.")
+            return await send_targeted_notification(db, db_user["id"], payload["title"], payload["body"], payload["data"])
         return await send_all_notifications(db, payload["title"], payload["body"], payload["data"])
     except HTTPException:
         raise

--- a/backend/app/features/notifications/schemas.py
+++ b/backend/app/features/notifications/schemas.py
@@ -17,6 +17,7 @@ class PushTokenCreate(BaseModel):
 
 class NotificationTestType(str, Enum):
     hurricane_l2 = "hurricane_l2"
+    hurricane_l3 = "hurricane_l3"
     hurricane_l4 = "hurricane_l4"
     sos_test     = "sos_test"
     generic      = "generic"
@@ -24,4 +25,5 @@ class NotificationTestType(str, Enum):
 
 class NotificationTestRequest(BaseModel):
     type: NotificationTestType
+    only_me: bool = False  # True → push solo al dispositivo del usuario autenticado
 

--- a/backend/app/features/notifications/service.py
+++ b/backend/app/features/notifications/service.py
@@ -57,6 +57,39 @@ async def get_tokens_for_users(db: AsyncSession, user_ids: list[int]) -> dict[in
 
 
 
+async def send_targeted_notification(
+    db: AsyncSession, user_id: int, title: str, body: str, data: dict[str, str]
+):
+    """Send a push notification only to the tokens belonging to a specific user."""
+    from fastapi import HTTPException  # local import avoids circular on module load
+
+    token_map = await get_tokens_for_users(db, [user_id])
+    tokens = token_map.get(user_id, [])
+    if not tokens:
+        raise HTTPException(status_code=404, detail="No tokens registered for this user")
+
+    message = messaging.MulticastMessage(
+        notification=messaging.Notification(title=title, body=body),
+        data=data or {},
+        tokens=tokens,
+    )
+    try:
+        response = await _send_multicast_with_retry(message)
+    except Exception as exc:
+        logger.error("send_targeted_notification Firebase failed after retries: %s", exc, exc_info=True)
+        raise
+
+    invalid_tokens = [tokens[i] for i, r in enumerate(response.responses) if not r.success]
+    if invalid_tokens:
+        await db.execute(
+            text("DELETE FROM device_tokens WHERE token = ANY(:tokens)"),
+            {"tokens": invalid_tokens},
+        )
+        await db.commit()
+
+    return {"success_count": response.success_count, "failure_count": response.failure_count}
+
+
 async def send_all_notifications(db: AsyncSession, title:str, body:str, data:dict[str, str]):
     # Query to db to get all tokens
     result = await db.execute(text("SELECT token FROM device_tokens"))

--- a/backend/app/features/notifications/tests/test_router.py
+++ b/backend/app/features/notifications/tests/test_router.py
@@ -138,6 +138,76 @@ def test_test_notif_invalid_type():
     assert r.status_code == 422
 
 
+def test_test_notif_only_me_success():
+    """only_me=True → llama send_targeted_notification, no send_all_notifications."""
+    with patch.object(settings, "NOTIFICATION_TEST_ADMIN_EMAILS", ADMIN_EMAIL):
+        with _mock_auth_email(ADMIN_EMAIL):
+            with patch(
+                "app.features.notifications.router.get_user_by_firebase_uid",
+                new_callable=AsyncMock,
+                return_value=FAKE_DB_USER,
+            ):
+                with patch(
+                    "app.features.notifications.router.send_targeted_notification",
+                    new_callable=AsyncMock,
+                    return_value={"success_count": 1, "failure_count": 0},
+                ) as mock_targeted:
+                    with patch(
+                        "app.features.notifications.router.send_all_notifications",
+                        new_callable=AsyncMock,
+                    ) as mock_all:
+                        r = client.post(
+                            "/api/v1/notifications/test",
+                            json={"type": "generic", "only_me": True},
+                            headers=AUTH_HEADERS,
+                        )
+    assert r.status_code == 200
+    assert r.json()["success_count"] == 1
+    mock_targeted.assert_awaited_once()
+    mock_all.assert_not_awaited()
+
+
+def test_test_notif_only_me_user_not_found():
+    """only_me=True pero el perfil no existe en DB → 404."""
+    with patch.object(settings, "NOTIFICATION_TEST_ADMIN_EMAILS", ADMIN_EMAIL):
+        with _mock_auth_email(ADMIN_EMAIL):
+            with patch(
+                "app.features.notifications.router.get_user_by_firebase_uid",
+                new_callable=AsyncMock,
+                return_value=None,
+            ):
+                r = client.post(
+                    "/api/v1/notifications/test",
+                    json={"type": "generic", "only_me": True},
+                    headers=AUTH_HEADERS,
+                )
+    assert r.status_code == 404
+
+
+def test_test_notif_broadcast_when_only_me_false():
+    """only_me=False (default) → llama send_all_notifications, no send_targeted_notification."""
+    with patch.object(settings, "NOTIFICATION_TEST_ADMIN_EMAILS", ADMIN_EMAIL):
+        with _mock_auth_email(ADMIN_EMAIL):
+            with patch(
+                "app.features.notifications.router.send_all_notifications",
+                new_callable=AsyncMock,
+                return_value={"success_count": 5, "failure_count": 0},
+            ) as mock_all:
+                with patch(
+                    "app.features.notifications.router.send_targeted_notification",
+                    new_callable=AsyncMock,
+                ) as mock_targeted:
+                    r = client.post(
+                        "/api/v1/notifications/test",
+                        json={"type": "hurricane_l2"},
+                        headers=AUTH_HEADERS,
+                    )
+    assert r.status_code == 200
+    assert r.json()["success_count"] == 5
+    mock_all.assert_awaited_once()
+    mock_targeted.assert_not_awaited()
+
+
 def test_send_all_firebase_failure_returns_503():
     """Si Firebase falla en send_all_notifications, el endpoint retorna 503 en lugar de 500."""
     with patch(

--- a/backend/app/features/siat/router.py
+++ b/backend/app/features/siat/router.py
@@ -1,9 +1,19 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.auth import get_current_user
+from app.core.config import settings
 from app.core.database import get_db
-from app.features.siat.schemas import AffectedUsersResponse, RunCycleResponse, UserSiatStatus
-from app.features.siat.service import get_affected_users, get_user_siat_status, run_cycle
+from app.features.siat.schemas import (
+    AffectedUsersResponse, FakeCycloneRequest, InjectCycloneResponse,
+    InjectSMNAlertRequest, InjectSMNAlertResponse, ResetStateResponse,
+    RunCycleResponse, UserSiatStatus,
+)
+from app.features.siat.service import (
+    get_affected_users, get_user_siat_status, inject_and_run_cycle,
+    inject_smn_test_alert, reset_user_siat_state, run_cycle,
+)
+from app.features.users.service import get_user_by_firebase_uid
 from app.middleware.api_key_auth import verify_api_key
 
 router = APIRouter()
@@ -21,6 +31,75 @@ async def siat_run_cycle(db: AsyncSession = Depends(get_db)):
     Protected by X-API-Key header.
     """
     return await run_cycle(db)
+
+
+@router.post("/api/v1/siat/inject-cyclone", response_model=InjectCycloneResponse)
+async def siat_inject_cyclone(
+    body: FakeCycloneRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
+):
+    """
+    Insert a fake cyclone and immediately run a full SIAT cycle end-to-end.
+    Dev/staging only — requires Firebase auth + admin email allowlist.
+    """
+    admin_emails = [
+        e.strip().lower()
+        for e in settings.NOTIFICATION_TEST_ADMIN_EMAILS.split(",")
+        if e.strip()
+    ]
+    user_email = (current_user.get("email") or "").lower()
+    if not admin_emails or user_email not in admin_emails:
+        raise HTTPException(status_code=403, detail="Not authorized.")
+
+    db_user = await get_user_by_firebase_uid(db, current_user.get("uid"))
+    if db_user is None:
+        raise HTTPException(status_code=404, detail="User profile not found. Call POST /api/v1/users/me first.")
+    if db_user.get("lat") is None or db_user.get("lon") is None:
+        raise HTTPException(
+            status_code=422,
+            detail="No tienes ubicación registrada. Ve a Configuración → Ubicación, guarda tu posición, y vuelve a intentarlo.",
+        )
+
+    return await inject_and_run_cycle(db, body)
+
+
+@router.post("/api/v1/siat/reset-state", response_model=ResetStateResponse)
+async def siat_reset_state(
+    db: AsyncSession = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
+):
+    """
+    Clear the SIAT alert state for the authenticated user.
+    Allows re-testing level escalation from scratch without changing preset.
+    Any authenticated user can reset their own state.
+    """
+    db_user = await get_user_by_firebase_uid(db, current_user.get("uid"))
+    if db_user is None:
+        raise HTTPException(status_code=404, detail="User profile not found.")
+    await reset_user_siat_state(db, db_user["id"])
+    return {"message": "Estado SIAT reiniciado. La siguiente inyección evaluará desde cero.", "user_id": db_user["id"]}
+
+
+@router.post("/api/v1/siat/inject-smn-alert", response_model=InjectSMNAlertResponse)
+async def siat_inject_smn_alert(
+    body: InjectSMNAlertRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
+):
+    """
+    Insert a national test alert and immediately process it via the SMN geocercado path.
+    Dev/staging only — requires Firebase auth + admin email allowlist.
+    """
+    admin_emails = [
+        e.strip().lower()
+        for e in settings.NOTIFICATION_TEST_ADMIN_EMAILS.split(",")
+        if e.strip()
+    ]
+    user_email = (current_user.get("email") or "").lower()
+    if not admin_emails or user_email not in admin_emails:
+        raise HTTPException(status_code=403, detail="Not authorized.")
+    return await inject_smn_test_alert(db, body.level, body.title, body.short)
 
 
 @router.get(

--- a/backend/app/features/siat/schemas.py
+++ b/backend/app/features/siat/schemas.py
@@ -1,5 +1,15 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from datetime import datetime
+from typing import Optional
+
+
+class FakeCycloneRequest(BaseModel):
+    name: str = "FALSO-1"
+    lat: float
+    lon: float
+    wind_kmh: float = Field(default=120.0, gt=0)
+    movement_speed_kmh: float = Field(default=20.0, ge=0)
+    movement_direction: str = "NW"
 
 
 class UserSiatStatus(BaseModel):
@@ -26,6 +36,28 @@ class RunCycleResponse(BaseModel):
     users_evaluated: int
     notifications_sent: int
     assessments: list[AssessmentResult]
+
+
+class InjectCycloneResponse(RunCycleResponse):
+    cyclone_event_id: int
+    cyclone_name: str
+
+
+class InjectSMNAlertRequest(BaseModel):
+    level: int = Field(default=3, ge=1, le=5)
+    title: str = "SMN: Alerta Meteorológica de Prueba [TEST]"
+    short: str = "Alerta de prueba generada por el equipo BluEye. No es una alerta real."
+
+
+class InjectSMNAlertResponse(BaseModel):
+    alert_id: str
+    users_evaluated: int
+    notifications_sent: int
+
+
+class ResetStateResponse(BaseModel):
+    message: str
+    user_id: int
 
 
 class AffectedUser(BaseModel):

--- a/backend/app/features/siat/service.py
+++ b/backend/app/features/siat/service.py
@@ -300,12 +300,11 @@ _SMN_RADIUS_KM = 500.0
 
 
 async def _get_pending_smn_alerts(db: AsyncSession) -> list:
+    # Includes national alerts (lat/lon NULL) — these are handled without radius filtering
     result = await db.execute(text("""
         SELECT id, title, short, level, lat, lon
         FROM alerts
-        WHERE lat IS NOT NULL
-          AND lon IS NOT NULL
-          AND notified_at IS NULL
+        WHERE notified_at IS NULL
           AND timestamp > NOW() - INTERVAL '35 minutes'
         ORDER BY timestamp DESC
     """))
@@ -322,11 +321,13 @@ async def _mark_alert_notified(db: AsyncSession, alert_id) -> None:
 async def _push_smn_for_alert(
     db: AsyncSession, alert: dict, users: list
 ) -> int:
+    is_national = alert["lat"] is None or alert["lon"] is None
     affected_user_ids = []
     for user in users:
-        dist = haversine_km(alert["lat"], alert["lon"], user["lat"], user["lon"])
-        if dist > _SMN_RADIUS_KM:
-            continue
+        if not is_national:
+            dist = haversine_km(alert["lat"], alert["lon"], user["lat"], user["lon"])
+            if dist > _SMN_RADIUS_KM:
+                continue
         prefs = await get_preferences(db, user["id"])
         if prefs["siat_enabled"] and alert["level"] >= prefs["min_siat_level"]:
             if is_within_quiet_hours(prefs) and alert["level"] < _QUIET_HOURS_OVERRIDE_LEVEL:
@@ -399,11 +400,62 @@ async def _notify_smn_alerts(db: AsyncSession, users: list) -> int:
 # Main orchestrator
 # ---------------------------------------------------------------------------
 
-async def run_cycle(db: AsyncSession) -> dict:
+async def reset_user_siat_state(db: AsyncSession, user_id: int) -> None:
+    """Delete all SIAT state for a user so the next injection evaluates from scratch."""
+    await db.execute(
+        text("DELETE FROM user_alert_states WHERE user_id = :uid"),
+        {"uid": user_id},
+    )
+    await db.commit()
+
+
+async def inject_smn_test_alert(
+    db: AsyncSession, level: int, title: str, short: str
+) -> dict:
+    """Insert a national test alert and immediately process it via the SMN notify path."""
+    result = await db.execute(
+        text("""
+            INSERT INTO alerts (level, score, title, short, lat, lon, factors, recommendations)
+            VALUES (:level, 0, :title, :short, NULL, NULL, '[]', '[]')
+            RETURNING id
+        """),
+        {"level": level, "title": title, "short": short},
+    )
+    alert_id = str(result.mappings().first()["id"])
+    await db.commit()
+
+    users = await _get_users_with_location(db)
+    notifications_sent = await _notify_smn_alerts(db, users)
+    return {"alert_id": alert_id, "users_evaluated": len(users), "notifications_sent": notifications_sent}
+
+
+async def inject_and_run_cycle(db: AsyncSession, req) -> dict:
+    """Insert a fake cyclone into cyclone_events and immediately run a full SIAT cycle."""
+    fake_cyclone: dict = {
+        "source": "FAKE",
+        "name": req.name,
+        "status": "HU",
+        "lat": req.lat,
+        "lon": req.lon,
+        "wind_kmh": req.wind_kmh,
+        "pressure": None,
+        "movement_direction": req.movement_direction,
+        "movement_speed_kmh": req.movement_speed_kmh,
+        "advisory_time": datetime.now(timezone.utc),
+        "raw_payload": {},
+    }
+    cyclone_event_id = await _save_cyclone(db, fake_cyclone)
+    result = await run_cycle(db, extra_cyclones=[fake_cyclone])
+    return {**result, "cyclone_event_id": cyclone_event_id, "cyclone_name": req.name}
+
+
+async def run_cycle(db: AsyncSession, extra_cyclones: list[dict] | None = None) -> dict:
     logger.info("SIAT run-cycle started")
 
     users = await _get_users_with_location(db)
     cyclones = await fetch_active_cyclones()
+    if extra_cyclones:
+        cyclones = cyclones + extra_cyclones
 
     logger.info("SIAT run-cycle: %d cyclone(s), %d user(s) with location", len(cyclones), len(users))
 

--- a/backend/app/features/siat/tests/test_router.py
+++ b/backend/app/features/siat/tests/test_router.py
@@ -9,6 +9,13 @@ client = TestClient(app)
 
 TEST_API_KEY = "test-siat-api-key"
 API_KEY_HEADERS = {"X-Api-Key": TEST_API_KEY}
+AUTH_HEADERS = {"Authorization": "Bearer faketoken"}
+ADMIN_EMAIL = "admin@blueye.mx"
+NON_ADMIN_EMAIL = "user@blueye.mx"
+
+
+def _mock_auth_email(email: str):
+    return patch("app.core.auth.auth.verify_id_token", return_value={"uid": "test-uid", "email": email})
 
 
 @pytest.fixture(autouse=True)
@@ -571,6 +578,226 @@ async def test_smn_quiet_hours_suppresses_push():
 
     assert total == 0
     mock_mark.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/siat/inject-cyclone — router tests
+# ---------------------------------------------------------------------------
+
+_INJECT_RESULT = {
+    "cyclones_found": 1,
+    "users_evaluated": 1,
+    "notifications_sent": 1,
+    "assessments": [],
+    "cyclone_event_id": 42,
+    "cyclone_name": "FALSO-1",
+}
+
+_FAKE_CYCLONE_BODY = {"name": "FALSO-1", "lat": 21.0, "lon": -98.0}
+
+
+def test_inject_cyclone_success():
+    """Admin user con ubicación → 200 con cyclone_event_id y cyclone_name."""
+    with patch.object(settings, "NOTIFICATION_TEST_ADMIN_EMAILS", ADMIN_EMAIL):
+        with _mock_auth_email(ADMIN_EMAIL):
+            with patch(f"{_ROUTER}.get_user_by_firebase_uid", new_callable=AsyncMock, return_value=_FAKE_DB_USER_WITH_LOC):
+                with patch(f"{_ROUTER}.inject_and_run_cycle", new_callable=AsyncMock, return_value=_INJECT_RESULT):
+                    r = client.post(
+                        "/api/v1/siat/inject-cyclone",
+                        json=_FAKE_CYCLONE_BODY,
+                        headers=AUTH_HEADERS,
+                    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["cyclone_event_id"] == 42
+    assert body["cyclone_name"] == "FALSO-1"
+    assert body["cyclones_found"] == 1
+
+
+def test_inject_cyclone_non_admin_403():
+    """Usuario no admin → 403."""
+    with patch.object(settings, "NOTIFICATION_TEST_ADMIN_EMAILS", ADMIN_EMAIL):
+        with _mock_auth_email(NON_ADMIN_EMAIL):
+            r = client.post(
+                "/api/v1/siat/inject-cyclone",
+                json=_FAKE_CYCLONE_BODY,
+                headers=AUTH_HEADERS,
+            )
+    assert r.status_code == 403
+
+
+def test_inject_cyclone_no_auth_422():
+    """Sin Authorization header → 422 (FastAPI header validation)."""
+    r = client.post("/api/v1/siat/inject-cyclone", json=_FAKE_CYCLONE_BODY)
+    assert r.status_code == 422
+
+
+def test_inject_cyclone_missing_lat_lon_422():
+    """Body sin lat/lon → 422 (Pydantic validation)."""
+    with patch.object(settings, "NOTIFICATION_TEST_ADMIN_EMAILS", ADMIN_EMAIL):
+        with _mock_auth_email(ADMIN_EMAIL):
+            r = client.post(
+                "/api/v1/siat/inject-cyclone",
+                json={"name": "FALSO-1"},
+                headers=AUTH_HEADERS,
+            )
+    assert r.status_code == 422
+
+
+_FAKE_DB_USER_WITH_LOC = {"id": 1, "firebase_uid": "test-uid", "lat": 19.43, "lon": -99.13}
+_FAKE_DB_USER_NO_LOC   = {"id": 1, "firebase_uid": "test-uid", "lat": None, "lon": None}
+
+
+def test_inject_cyclone_user_no_location_422():
+    """Usuario sin lat/lon en DB → 422 con mensaje explícito."""
+    with patch.object(settings, "NOTIFICATION_TEST_ADMIN_EMAILS", ADMIN_EMAIL):
+        with _mock_auth_email(ADMIN_EMAIL):
+            with patch(f"{_ROUTER}.get_user_by_firebase_uid", new_callable=AsyncMock, return_value=_FAKE_DB_USER_NO_LOC):
+                r = client.post(
+                    "/api/v1/siat/inject-cyclone",
+                    json=_FAKE_CYCLONE_BODY,
+                    headers=AUTH_HEADERS,
+                )
+    assert r.status_code == 422
+    assert "ubicación" in r.json()["detail"].lower()
+
+
+def test_inject_cyclone_with_location_calls_service():
+    """Usuario con ubicación → delega a inject_and_run_cycle."""
+    with patch.object(settings, "NOTIFICATION_TEST_ADMIN_EMAILS", ADMIN_EMAIL):
+        with _mock_auth_email(ADMIN_EMAIL):
+            with patch(f"{_ROUTER}.get_user_by_firebase_uid", new_callable=AsyncMock, return_value=_FAKE_DB_USER_WITH_LOC):
+                with patch(f"{_ROUTER}.inject_and_run_cycle", new_callable=AsyncMock, return_value=_INJECT_RESULT) as mock_inject:
+                    r = client.post(
+                        "/api/v1/siat/inject-cyclone",
+                        json=_FAKE_CYCLONE_BODY,
+                        headers=AUTH_HEADERS,
+                    )
+    assert r.status_code == 200
+    mock_inject.assert_awaited_once()
+
+
+def test_reset_state_success():
+    """Usuario autenticado → 200 y mensaje de confirmación."""
+    with _mock_auth_email(ADMIN_EMAIL):
+        with patch(f"{_ROUTER}.get_user_by_firebase_uid", new_callable=AsyncMock, return_value=_FAKE_DB_USER_WITH_LOC):
+            with patch(f"{_ROUTER}.reset_user_siat_state", new_callable=AsyncMock, return_value=None):
+                r = client.post("/api/v1/siat/reset-state", headers=AUTH_HEADERS)
+    assert r.status_code == 200
+    assert r.json()["user_id"] == 1
+
+
+def test_reset_state_no_profile_404():
+    """Usuario sin perfil en DB → 404."""
+    with _mock_auth_email(ADMIN_EMAIL):
+        with patch(f"{_ROUTER}.get_user_by_firebase_uid", new_callable=AsyncMock, return_value=None):
+            r = client.post("/api/v1/siat/reset-state", headers=AUTH_HEADERS)
+    assert r.status_code == 404
+
+
+def test_inject_smn_alert_success():
+    """Admin → 200 con alert_id y notifications_sent."""
+    smn_result = {"alert_id": "uuid-test-123", "users_evaluated": 2, "notifications_sent": 1}
+    with patch.object(settings, "NOTIFICATION_TEST_ADMIN_EMAILS", ADMIN_EMAIL):
+        with _mock_auth_email(ADMIN_EMAIL):
+            with patch(f"{_ROUTER}.inject_smn_test_alert", new_callable=AsyncMock, return_value=smn_result):
+                r = client.post(
+                    "/api/v1/siat/inject-smn-alert",
+                    json={"level": 3},
+                    headers=AUTH_HEADERS,
+                )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["alert_id"] == "uuid-test-123"
+    assert body["notifications_sent"] == 1
+
+
+def test_inject_smn_alert_non_admin_403():
+    """No admin → 403."""
+    with patch.object(settings, "NOTIFICATION_TEST_ADMIN_EMAILS", ADMIN_EMAIL):
+        with _mock_auth_email(NON_ADMIN_EMAIL):
+            r = client.post("/api/v1/siat/inject-smn-alert", json={"level": 3}, headers=AUTH_HEADERS)
+    assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# run_cycle() acepta extra_cyclones — service-level test
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_run_cycle_with_extra_cyclones():
+    """Extra cyclones pasados a run_cycle se evalúan aunque NHC no devuelva ninguno."""
+    from app.features.siat.service import run_cycle
+
+    fake_cyclone = {
+        "source": "FAKE",
+        "name": "FALSO-1",
+        "status": "HU",
+        "lat": 21.0,
+        "lon": -98.0,
+        "wind_kmh": 160.0,
+        "movement_speed_kmh": 20.0,
+    }
+    prefs = {"siat_enabled": True, "min_siat_level": 2, "map_events_enabled": True}
+    db = MagicMock()
+    db.commit = AsyncMock()
+
+    with patch(f"{_SVC}.fetch_active_cyclones", new_callable=AsyncMock, return_value=[]), \
+         patch(f"{_SVC}._get_users_with_location", new_callable=AsyncMock, return_value=[_FAKE_USER]), \
+         patch(f"{_SVC}._save_cyclone", new_callable=AsyncMock, return_value=99), \
+         patch(f"{_SVC}.evaluate_user", return_value=_ASSESSMENT_LEVEL_2), \
+         patch(f"{_SVC}._get_user_state", new_callable=AsyncMock, return_value={"current_level": 1}), \
+         patch(f"{_SVC}._save_assessment", new_callable=AsyncMock), \
+         patch(f"{_SVC}._upsert_user_state", new_callable=AsyncMock), \
+         patch(f"{_SVC}.get_preferences", new_callable=AsyncMock, return_value=prefs), \
+         patch(f"{_SVC}.get_tokens_for_users", new_callable=AsyncMock, return_value={1: ["token-abc"]}), \
+         patch(f"{_SVC}._push_per_user", new_callable=AsyncMock, return_value=1), \
+         patch(f"{_SVC}._mark_notified", new_callable=AsyncMock), \
+         patch(f"{_SVC}._notify_smn_alerts", new_callable=AsyncMock, return_value=0):
+        result = await run_cycle(db, extra_cyclones=[fake_cyclone])
+
+    assert result["cyclones_found"] == 1   # NHC=0, extra=1
+    assert len(result["assessments"]) == 1
+    assert result["notifications_sent"] == 1
+
+
+@pytest.mark.asyncio
+async def test_smn_national_alert_no_coords_notifies_all_eligible_users():
+    """Alerta nacional (lat/lon NULL) → sin filtro de distancia → todos los usuarios elegibles reciben push."""
+    from app.features.siat.service import _notify_smn_alerts
+
+    national_alert = {
+        "id": "alert-national-1",
+        "title": "SMN Aviso #300",
+        "short": "Lluvias intensas en todo el país",
+        "level": 3,
+        "lat": None,
+        "lon": None,
+    }
+    prefs = {"siat_enabled": True, "min_siat_level": 2, "map_events_enabled": True}
+    db = MagicMock()
+
+    with patch(f"{_SVC}._get_pending_smn_alerts", new_callable=AsyncMock, return_value=[national_alert]), \
+         patch(f"{_SVC}.get_preferences", new_callable=AsyncMock, return_value=prefs), \
+         patch(f"{_SVC}.get_tokens_for_users", new_callable=AsyncMock, return_value={1: ["token-abc"]}), \
+         patch(f"{_SVC}._mark_alert_notified", new_callable=AsyncMock) as mock_mark, \
+         patch(f"{_SVC}.messaging") as mock_messaging:
+
+        fake_response = MagicMock()
+        fake_response.success_count = 1
+        fake_response.failure_count = 0
+        fake_response.responses = [MagicMock(success=True)]
+        mock_messaging.send_each_for_multicast.return_value = fake_response
+        mock_messaging.MulticastMessage = MagicMock()
+        mock_messaging.Notification = MagicMock()
+        mock_messaging.AndroidConfig = MagicMock()
+        mock_messaging.APNSConfig = MagicMock()
+
+        # _FAKE_USER_FAR is > 500 km away — but national alert must still reach them
+        total = await _notify_smn_alerts(db, [_FAKE_USER_FAR])
+
+    assert total == 1
+    mock_mark.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,8 @@ from app.features.sos_contacts.router import router as sos_contacts_router
 from app.features.sos_invite.router import router as sos_invite_router
 from app.features.sos_trigger.router import router as sos_trigger_router
 from app.features.siat.service import ensure_siat_tables, run_cycle
+from app.features.alerts.providers.smn import fetch_latest_bulletin
+from app.features.alerts.service import persist_smn_bulletin_if_new
 import app.core.firebase
 import asyncio
 import logging
@@ -158,6 +160,14 @@ async def _siat_background_loop():
     while True:
         try:
             async with AsyncSessionLocal() as db:
+                bulletin = await fetch_latest_bulletin()
+                if bulletin:
+                    inserted = await persist_smn_bulletin_if_new(db, bulletin)
+                    if inserted:
+                        logger.info(
+                            "SMN: new bulletin persisted — '%s'",
+                            (bulletin.get("headline") or "")[:60],
+                        )
                 result = await run_cycle(db)
                 logger.info(
                     "SIAT background cycle: cyclones=%d users=%d notif=%d",

--- a/frontend/app/NotificationTestScreen.tsx
+++ b/frontend/app/NotificationTestScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, ActivityIndicator, ScrollView } from 'react-native';
+import { View, Text, TouchableOpacity, ActivityIndicator, ScrollView, Switch, Alert } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { toast } from 'sonner-native';
@@ -9,7 +9,7 @@ import { API_BASE_URL } from '../utils/config';
 
 type MCIName = React.ComponentProps<typeof MaterialCommunityIcons>['name'];
 
-type NotificationTestType = 'hurricane_l2' | 'hurricane_l4' | 'sos_test' | 'generic';
+type NotificationTestType = 'hurricane_l2' | 'hurricane_l3' | 'hurricane_l4' | 'sos_test' | 'generic';
 
 type TestButton = {
   label: string;
@@ -19,30 +19,153 @@ type TestButton = {
 };
 
 const BUTTONS: TestButton[] = [
-  { label: 'Huracán Nivel 2 — Verde',          icon: 'weather-hurricane',  color: colors.brandGreen,  type: 'hurricane_l2' },
-  { label: 'Huracán Nivel 4 — Naranja (fullscreen)', icon: 'alert-octagram', color: colors.brandOrange, type: 'hurricane_l4' },
-  { label: 'SOS de prueba',                    icon: 'alarm-light-outline', color: colors.brandRed,    type: 'sos_test' },
-  { label: 'Push genérico',                   icon: 'bell-outline',        color: colors.brandBlue,   type: 'generic' },
+  { label: 'Huracán Nivel 2 — Verde',               icon: 'weather-hurricane',  color: colors.brandGreen,   type: 'hurricane_l2' },
+  { label: 'Huracán Nivel 3 — Amarillo',             icon: 'weather-hurricane',  color: colors.brandYellow,  type: 'hurricane_l3' },
+  { label: 'Huracán Nivel 4 — Naranja (fullscreen)', icon: 'alert-octagram',     color: colors.brandOrange,  type: 'hurricane_l4' },
+  { label: 'SOS de prueba',                         icon: 'alarm-light-outline', color: colors.brandRed,     type: 'sos_test' },
+  { label: 'Push genérico',                         icon: 'bell-outline',        color: colors.brandBlue,    type: 'generic' },
+];
+
+type FakeCyclonePreset = {
+  label: string;
+  sublabel: string;
+  color: string;
+  body: { name: string; lat: number; lon: number; wind_kmh: number; movement_speed_kmh: number };
+};
+
+// Posiciones en el Golfo de México, calibradas para usuarios en CDMX (~19.4°N, -99.1°W)
+const CYCLONE_PRESETS: FakeCyclonePreset[] = [
+  {
+    label: 'Nivel 2 — Verde',
+    sublabel: '~510 km · ETA ~51h',
+    color: colors.brandGreen,
+    body: { name: 'FALSO-VERDE', lat: 23.0, lon: -96.0, wind_kmh: 130, movement_speed_kmh: 10 },
+  },
+  {
+    label: 'Nivel 4 — Naranja',
+    sublabel: '~200 km · ETA ~10h',
+    color: colors.brandOrange,
+    body: { name: 'FALSO-NARANJA', lat: 21.0, lon: -98.0, wind_kmh: 160, movement_speed_kmh: 20 },
+  },
+  {
+    label: 'Nivel 5 — Rojo',
+    sublabel: '~87 km · ETA ~2.9h',
+    color: colors.brandRed,
+    body: { name: 'FALSO-ROJO', lat: 20.0, lon: -98.5, wind_kmh: 200, movement_speed_kmh: 30 },
+  },
 ];
 
 export default function NotificationTestScreen() {
   const [loadingIndex, setLoadingIndex] = useState<number | null>(null);
+  const [onlyMe, setOnlyMe] = useState(true);
+  const [cycloneLoadingIndex, setCycloneLoadingIndex] = useState<number | null>(null);
 
-  const sendTest = async (index: number) => {
-    if (loadingIndex !== null) return;
-    setLoadingIndex(index);
+  const [resetLoading, setResetLoading] = useState(false);
+  const [smnLoading, setSmnLoading] = useState(false);
+
+  const confirmBroadcast = (): Promise<boolean> =>
+    new Promise(resolve =>
+      Alert.alert(
+        '¿Enviar a todos?',
+        'Esto mandará la notificación a TODOS los dispositivos registrados en esta base de datos.',
+        [
+          { text: 'Cancelar', style: 'cancel', onPress: () => resolve(false) },
+          { text: 'Enviar', style: 'destructive', onPress: () => resolve(true) },
+        ],
+      ),
+    );
+
+  const injectCyclone = async (index: number) => {
+    if (cycloneLoadingIndex !== null) return;
+    setCycloneLoadingIndex(index);
     try {
-      const res = await authFetch(`${API_BASE_URL}/api/v1/notifications/test`, {
+      const preset = CYCLONE_PRESETS[index];
+      const res = await authFetch(`${API_BASE_URL}/api/v1/siat/inject-cyclone`, {
         method: 'POST',
-        body: JSON.stringify({ type: BUTTONS[index].type }),
+        body: JSON.stringify(preset.body),
       });
       if (res.status === 403) {
-        toast.error('No autorizado', { description: 'Tu cuenta no tiene acceso a esta herramienta.' });
+        toast.error('Sin acceso', { description: 'Pide que agreguen tu email a NOTIFICATION_TEST_ADMIN_EMAILS en backend/.env' });
+        return;
+      }
+      if (res.status === 422) {
+        const err = await res.json().catch(() => ({}));
+        toast.error('Sin ubicación registrada', { description: err.detail || 'Configura tu ubicación en el perfil antes de inyectar.' });
         return;
       }
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
-      toast.success('Enviado', { description: `${data.success_count} dispositivo(s)` });
+      const firstAssessment = data.assessments?.[0];
+      const detail = firstAssessment
+        ? `${data.users_evaluated} eval. · Nivel ${firstAssessment.siat_level} ${firstAssessment.siat_color} · ${firstAssessment.distance_km?.toFixed(0)} km`
+        : `${data.users_evaluated} evaluado(s)`;
+      const notifDesc = data.notifications_sent > 0
+        ? `Push enviado · ${detail}`
+        : `Sin push · ${detail} · (revisa quiet hours o nivel mínimo)`;
+      toast.success(`Ciclón inyectado · ${preset.label}`, { description: notifDesc });
+    } catch (e) {
+      toast.error('Error al inyectar ciclón', { description: String(e) });
+    } finally {
+      setCycloneLoadingIndex(null);
+    }
+  };
+
+  const resetSiatState = async () => {
+    if (resetLoading) return;
+    setResetLoading(true);
+    try {
+      const res = await authFetch(`${API_BASE_URL}/api/v1/siat/reset-state`, { method: 'POST' });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      toast.success('Estado SIAT reiniciado', { description: 'La siguiente inyección evaluará desde nivel 0.' });
+    } catch (e) {
+      toast.error('Error al reiniciar', { description: String(e) });
+    } finally {
+      setResetLoading(false);
+    }
+  };
+
+  const injectSmnAlert = async () => {
+    if (smnLoading) return;
+    setSmnLoading(true);
+    try {
+      const res = await authFetch(`${API_BASE_URL}/api/v1/siat/inject-smn-alert`, {
+        method: 'POST',
+        body: JSON.stringify({ level: 3, title: 'SMN: Alerta Meteorológica de Prueba [TEST]', short: 'Prueba de alerta nacional SMN/CONAGUA generada por el equipo BluEye.' }),
+      });
+      if (res.status === 403) {
+        toast.error('Sin acceso', { description: 'Pide que agreguen tu email a NOTIFICATION_TEST_ADMIN_EMAILS en backend/.env' });
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      const desc = data.notifications_sent > 0
+        ? `Push enviado a ${data.notifications_sent} dispositivo(s) · ${data.users_evaluated} usuario(s) evaluados`
+        : `${data.users_evaluated} usuario(s) evaluados · sin push (revisa prefs)`;
+      toast.success('Alerta SMN inyectada', { description: desc });
+    } catch (e) {
+      toast.error('Error al inyectar alerta SMN', { description: String(e) });
+    } finally {
+      setSmnLoading(false);
+    }
+  };
+
+  const sendTest = async (index: number) => {
+    if (loadingIndex !== null) return;
+    if (!onlyMe && !(await confirmBroadcast())) return;
+    setLoadingIndex(index);
+    try {
+      const res = await authFetch(`${API_BASE_URL}/api/v1/notifications/test`, {
+        method: 'POST',
+        body: JSON.stringify({ type: BUTTONS[index].type, only_me: onlyMe }),
+      });
+      if (res.status === 403) {
+        toast.error('Sin acceso', { description: 'Pide que agreguen tu email a NOTIFICATION_TEST_ADMIN_EMAILS en backend/.env' });
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      const desc = onlyMe ? 'Solo tu dispositivo' : `${data.success_count} dispositivo(s)`;
+      toast.success('Enviado', { description: desc });
     } catch (e) {
       toast.error('Error al enviar', { description: String(e) });
     } finally {
@@ -59,6 +182,25 @@ export default function NotificationTestScreen() {
         <Text className="text-sm font-poppins text-white/50 mb-6">
           Herramienta interna — solo visible en staging/dev
         </Text>
+
+        {/* Destino de la notificación */}
+        <View
+          className="flex-row items-center justify-between mb-6 rounded-2xl px-5 py-4"
+          style={{ backgroundColor: 'rgba(255,255,255,0.06)', borderWidth: 1, borderColor: 'rgba(255,255,255,0.12)' }}
+        >
+          <View className="flex-1 mr-4">
+            <Text className="text-sm font-poppins-semibold text-white">Solo mi dispositivo</Text>
+            <Text className="text-xs font-poppins text-white/50 mt-0.5">
+              {onlyMe ? 'Push solo a tus tokens registrados' : 'Broadcast a TODOS los dispositivos'}
+            </Text>
+          </View>
+          <Switch
+            value={onlyMe}
+            onValueChange={setOnlyMe}
+            trackColor={{ false: 'rgba(255,255,255,0.15)', true: colors.brandBlue }}
+            thumbColor="white"
+          />
+        </View>
 
         {BUTTONS.map((btn, index) => (
           <TouchableOpacity
@@ -86,6 +228,83 @@ export default function NotificationTestScreen() {
             )}
           </TouchableOpacity>
         ))}
+
+        {/* Sección: inyección de ciclón falso */}
+        <Text className="text-base font-poppins-semibold text-white mt-4 mb-1">
+          Motor SIAT — Ciclón Falso
+        </Text>
+        <Text className="text-xs font-poppins text-white/50 mb-4">
+          Inyecta un ciclón de prueba y corre el ciclo SIAT completo end-to-end.{'\n'}
+          Posiciones calibradas para usuarios en CDMX.
+        </Text>
+
+        {CYCLONE_PRESETS.map((preset, index) => (
+          <TouchableOpacity
+            key={preset.body.name}
+            onPress={() => injectCyclone(index)}
+            disabled={cycloneLoadingIndex !== null}
+            className="flex-row items-center mb-4 rounded-2xl px-5 py-4"
+            style={{
+              backgroundColor: `${preset.color}22`,
+              borderWidth: 1,
+              borderColor: preset.color,
+              opacity: cycloneLoadingIndex !== null && cycloneLoadingIndex !== index ? 0.5 : 1,
+            }}
+          >
+            {cycloneLoadingIndex === index ? (
+              <ActivityIndicator size="small" color={preset.color} style={{ marginRight: 12 }} />
+            ) : (
+              <MaterialCommunityIcons name="weather-hurricane" size={22} color={preset.color} style={{ marginRight: 12 }} />
+            )}
+            <View className="flex-1">
+              <Text className="font-poppins-semibold text-sm text-white">{preset.label}</Text>
+              <Text className="font-poppins text-xs text-white/50">{preset.sublabel}</Text>
+            </View>
+            {cycloneLoadingIndex !== null && cycloneLoadingIndex !== index && (
+              <Text className="text-xs font-poppins text-white/30">espera...</Text>
+            )}
+          </TouchableOpacity>
+        ))}
+
+        {/* Reset estado SIAT */}
+        <TouchableOpacity
+          onPress={resetSiatState}
+          disabled={resetLoading}
+          className="flex-row items-center mb-4 rounded-2xl px-5 py-4"
+          style={{ backgroundColor: 'rgba(255,255,255,0.06)', borderWidth: 1, borderColor: 'rgba(255,255,255,0.2)' }}
+        >
+          {resetLoading
+            ? <ActivityIndicator size="small" color="white" style={{ marginRight: 12 }} />
+            : <MaterialCommunityIcons name="refresh" size={22} color="white" style={{ marginRight: 12 }} />}
+          <View className="flex-1">
+            <Text className="font-poppins-semibold text-sm text-white">Limpiar estado SIAT</Text>
+            <Text className="font-poppins text-xs text-white/50">Permite volver a disparar escalación desde el mismo nivel</Text>
+          </View>
+        </TouchableOpacity>
+
+        {/* Sección: alerta SMN nacional */}
+        <Text className="text-base font-poppins-semibold text-white mt-4 mb-1">
+          Ruta SMN/CONAGUA
+        </Text>
+        <Text className="text-xs font-poppins text-white/50 mb-4">
+          Inyecta una alerta nacional (sin coords) y la procesa vía geocercado.{'\n'}
+          Nivel 3 — AMARILLO por defecto. Llega a todos los usuarios elegibles.
+        </Text>
+
+        <TouchableOpacity
+          onPress={injectSmnAlert}
+          disabled={smnLoading}
+          className="flex-row items-center mb-8 rounded-2xl px-5 py-4"
+          style={{ backgroundColor: `${colors.brandYellow}22`, borderWidth: 1, borderColor: colors.brandYellow }}
+        >
+          {smnLoading
+            ? <ActivityIndicator size="small" color={colors.brandYellow} style={{ marginRight: 12 }} />
+            : <MaterialCommunityIcons name="weather-cloudy-alert" size={22} color={colors.brandYellow} style={{ marginRight: 12 }} />}
+          <View className="flex-1">
+            <Text className="font-poppins-semibold text-sm text-white">Alerta SMN Nacional — Amarillo</Text>
+            <Text className="font-poppins text-xs text-white/50">Nivel 3 · Sin geocoordenadas · Todos los usuarios</Text>
+          </View>
+        </TouchableOpacity>
       </ScrollView>
     </SafeAreaView>
   );


### PR DESCRIPTION
## Contexto

El equipo no tenía forma de probar el sistema de alertas sin esperar un huracán real.
Esta rama implementa una herramienta de QA interna que permite disparar y recibir
una notificación de prueba en < 2 minutos, cubriendo las tres rutas de código principales:
push directo, motor SIAT, y alertas SMN/CONAGUA.

---


## Contexto

El equipo no tenía forma de probar el sistema de alertas sin
esperar un huracá
Esta rama implementa una herramienta de QA interna que permite
disparar y recibi
una notificación de prueba en < 2 minutos, cubriendo las tres
rutas de código p
push directo, motor SIAT, y alertas SMN/CONAGUA.

---

## Cambios

### Fase 1 — Test por dispositivo
- `POST /api/v1/npo `only_me`(default `true`).
  Cuando está activo, el push va solo a los tokens del usuario
autenticado.
  Antes siempre hacía broadcast a todos los dispositivos.
- Confirmación exr el broadcast.
- Level 3 **AMARILLO** agregado al quick test (era el único nivel del escala que faltaba).

### Fase 2 — Inyección de ciclón falso end-to-end
- `POST /api/v1/siat/inject-cyclone` (Firebase + admin whitelist):
  inserta un ciclclone_events` ycorre el ciclo
  SIAT completo dación de usuariosy push real.
- `run_cycle()` aiclo de fondo nose modifica.
- Devuelve **422 tiene `lat/lon`registrado
  (antes fallaba silenciosamente con `notifications_sent: 0`).
- 3 presets en UI(~510 km), NARANJA (~200 km), ROJO (~87 km).
- Toast de resultado muestra nivel calculado, color y distancia.

### Fase 3 — SMN/
- `persist_smn_bulletin_if_new()`: cada 30 min el background
loop hace fetch d
  boletín SMN y lo inserta en la tabla `alerts` si es nuevo
(dedup por `aviso
- `_notify_smn_alerts`: eliminado el filtro `lat IS NOT NULL` — las alertas
  nacionales (sintodos los usuarios elegibles.
- `POST /api/v1/siat/inject-smn-alert`: inyecta una alerta nacional de prueba
  y dispara el path SMN directamente, sin hacer fetch al NHC.
- `POST /api/v1/sr_alert_states`del usuario
  para poder re-pde preset.

---

## Tests

**150 tests, todos verdes** (+16 desde la base de 134).
Cobertura nueva: `only_me` targeted vs broadcast, inject con/sin ubicación,
reset state, inject SMN, alertas nacionales sin filtro de radio,
dedup SMN.

---

## Precondiciones

| Requisito | Cómo cumplirlo |
|---|---|
| Email en whitelist | Agregar a `NOTIFICATION_TEST_ADMIN_EMAILS` en `backend/.env` staging |
| Token registrad iniciar sesión en la app |
| Ubicación en DB | Requerida solo para inject-cyclone; el endpoint devuelve 422 si falta |

---

## Pantalla

`Settings → Dev:  en staging/devbuilds)