### PR TITLE
feat: auto-sync GPS location to backend on map open and onboarding

### DIFF
--- a/frontend/app/map/index.tsx
+++ b/frontend/app/map/index.tsx
@@ -18,6 +18,7 @@ import {
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import MapView, { UrlTile, PROVIDER_GOOGLE, Marker } from "react-native-maps";
 import * as Location from "expo-location";
+import { syncLocationToBackend } from "../../utils/locationSync";
 import { toast } from "sonner-native";
 import {
   canReportFromLocation,
@@ -199,6 +200,7 @@ export default function WeatherMapNativewind() {
         setUserLocation({ latitude: coords.latitude, longitude: coords.longitude });
         setCurrentCoords({ latitude: coords.latitude, longitude: coords.longitude });
         mapRef.current?.animateToRegion(userRegion, 1000);
+        syncLocationToBackend(coords.latitude, coords.longitude);
       } catch (error) {
         console.warn("⚠️ Could not get location (timeout or error), using default region:", error.message);
       }

--- a/frontend/app/onboarding/_screens/Step1Screen.tsx
+++ b/frontend/app/onboarding/_screens/Step1Screen.tsx
@@ -10,6 +10,7 @@ import { useOnboarding } from '../_context/OnboardingContext';
 import { validateStep1 } from '../_validation';
 import { MEXICO_STATES } from '../_types';
 import { track } from '../../../utils/analytics';
+import { syncLocationToBackend } from '../../../utils/locationSync';
 import { colors } from '../../../utils/theme';
 
 export const Step1Screen: React.FC = () => {
@@ -77,6 +78,7 @@ export const Step1Screen: React.FC = () => {
 
         updateMultipleFields(updates);
 
+        syncLocationToBackend(location.coords.latitude, location.coords.longitude);
         track('onboarding_location_used', {
           state: address.region,
           hasPostalCode: !!address.postalCode,

--- a/frontend/utils/locationSync.ts
+++ b/frontend/utils/locationSync.ts
@@ -1,0 +1,57 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { authFetch } from './api';
+import { API_BASE_URL } from './config';
+
+const LAST_SYNC_KEY = '@BluEye:location_last_sync';
+const LAST_COORDS_KEY = '@BluEye:location_last_coords';
+const SYNC_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+
+function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6371;
+  const dLat = (lat2 - lat1) * Math.PI / 180;
+  const dLon = (lon2 - lon1) * Math.PI / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+/**
+ * Silently syncs the user's GPS coordinates to the backend.
+ * Skips if the position hasn't changed by more than 1 km AND less than 1 hour has passed.
+ * Never throws — designed to run fire-and-forget alongside other location logic.
+ */
+export async function syncLocationToBackend(lat: number, lon: number): Promise<void> {
+  try {
+    const now = Date.now();
+
+    const [lastSyncStr, lastCoordsStr] = await Promise.all([
+      AsyncStorage.getItem(LAST_SYNC_KEY),
+      AsyncStorage.getItem(LAST_COORDS_KEY),
+    ]);
+
+    const intervalElapsed = !lastSyncStr || (now - parseInt(lastSyncStr)) > SYNC_INTERVAL_MS;
+
+    let significantMove = true;
+    if (lastCoordsStr) {
+      const { lat: pLat, lon: pLon } = JSON.parse(lastCoordsStr);
+      significantMove = haversineKm(lat, lon, pLat, pLon) > 1.0;
+    }
+
+    if (!significantMove && !intervalElapsed) return;
+
+    const res = await authFetch(`${API_BASE_URL}/api/v1/users/me/location`, {
+      method: 'PATCH',
+      body: JSON.stringify({ lat, lon }),
+    });
+
+    if (res.ok) {
+      await Promise.all([
+        AsyncStorage.setItem(LAST_SYNC_KEY, String(now)),
+        AsyncStorage.setItem(LAST_COORDS_KEY, JSON.stringify({ lat, lon })),
+      ]);
+    }
+  } catch {
+    // Silent — never interrupts the caller
+  }
+}


### PR DESCRIPTION
## Summary
- New `frontend/utils/locationSync.ts` with `syncLocationToBackend(lat, lon)`: syncs GPS coordinates silently via `PATCH /api/v1/users/me/location`. Rate-limited to once per hour OR when the user moves >1 km (haversine). Never throws — completely transparent to the caller.
- Called from `app/map/index.tsx` when the map obtains the user's location on focus.
- Called from `app/onboarding/_screens/Step1Screen.tsx` after the "Usar mi ubicación" button resolves.
- **Why:** The SIAT cyclone engine skips users with no lat/lon in their profile. Without this, production users would never receive cyclone push alerts.

## Test plan
- [ ] Open map → check backend `users` table: `lat`/`lon` updated for the user
- [ ] Open map again within 1h without moving — no redundant PATCH (check network tab / logs)
- [ ] Complete onboarding step 1 with location button → `lat`/`lon` saved to backend
- [ ] Inject fake cyclone in NotificationTestScreen → user receives push (was "0 users evaluated" before)