### PR TITLE
feat: add DEV_BYPASS_NOTIF_TEST_AUTH env-var to skip email whitelist …

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -22,6 +22,9 @@ class Settings(BaseSettings):
 
     # Dev-only bypasses
     DEV_BYPASS_MAP_EVENTS_AUTH: bool = False
+    # When true, any authenticated Firebase user can call the notification test endpoints.
+    # Set to true in Railway staging. Never set in production.
+    DEV_BYPASS_NOTIF_TEST_AUTH: bool = False
 
     # Notification test tool — comma-separated emails allowed to call POST /api/v1/notifications/test.
     # Empty string disables the endpoint for everyone (production default).

--- a/backend/app/features/notifications/router.py
+++ b/backend/app/features/notifications/router.py
@@ -79,17 +79,17 @@ async def send_test_notification(
     current_user: dict = Depends(get_current_user),
 ):
     """Send a test notification to all devices. Requires Firebase auth + admin email allowlist."""
-    admin_emails = [
-        e.strip().lower()
-        for e in settings.NOTIFICATION_TEST_ADMIN_EMAILS.split(",")
-        if e.strip()
-    ]
-    if not admin_emails:
-        raise HTTPException(status_code=403, detail="Test notifications not configured.")
-
-    user_email = (current_user.get("email") or "").lower()
-    if user_email not in admin_emails:
-        raise HTTPException(status_code=403, detail="Not authorized to send test notifications.")
+    if not settings.DEV_BYPASS_NOTIF_TEST_AUTH:
+        admin_emails = [
+            e.strip().lower()
+            for e in settings.NOTIFICATION_TEST_ADMIN_EMAILS.split(",")
+            if e.strip()
+        ]
+        if not admin_emails:
+            raise HTTPException(status_code=403, detail="Test notifications not configured.")
+        user_email = (current_user.get("email") or "").lower()
+        if user_email not in admin_emails:
+            raise HTTPException(status_code=403, detail="Not authorized to send test notifications.")
 
     payload = _TEST_PAYLOADS[body.type]
     try:

--- a/backend/app/features/siat/router.py
+++ b/backend/app/features/siat/router.py
@@ -43,14 +43,15 @@ async def siat_inject_cyclone(
     Insert a fake cyclone and immediately run a full SIAT cycle end-to-end.
     Dev/staging only — requires Firebase auth + admin email allowlist.
     """
-    admin_emails = [
-        e.strip().lower()
-        for e in settings.NOTIFICATION_TEST_ADMIN_EMAILS.split(",")
-        if e.strip()
-    ]
-    user_email = (current_user.get("email") or "").lower()
-    if not admin_emails or user_email not in admin_emails:
-        raise HTTPException(status_code=403, detail="Not authorized.")
+    if not settings.DEV_BYPASS_NOTIF_TEST_AUTH:
+        admin_emails = [
+            e.strip().lower()
+            for e in settings.NOTIFICATION_TEST_ADMIN_EMAILS.split(",")
+            if e.strip()
+        ]
+        user_email = (current_user.get("email") or "").lower()
+        if not admin_emails or user_email not in admin_emails:
+            raise HTTPException(status_code=403, detail="Not authorized.")
 
     db_user = await get_user_by_firebase_uid(db, current_user.get("uid"))
     if db_user is None:
@@ -91,14 +92,15 @@ async def siat_inject_smn_alert(
     Insert a national test alert and immediately process it via the SMN geocercado path.
     Dev/staging only — requires Firebase auth + admin email allowlist.
     """
-    admin_emails = [
-        e.strip().lower()
-        for e in settings.NOTIFICATION_TEST_ADMIN_EMAILS.split(",")
-        if e.strip()
-    ]
-    user_email = (current_user.get("email") or "").lower()
-    if not admin_emails or user_email not in admin_emails:
-        raise HTTPException(status_code=403, detail="Not authorized.")
+    if not settings.DEV_BYPASS_NOTIF_TEST_AUTH:
+        admin_emails = [
+            e.strip().lower()
+            for e in settings.NOTIFICATION_TEST_ADMIN_EMAILS.split(",")
+            if e.strip()
+        ]
+        user_email = (current_user.get("email") or "").lower()
+        if not admin_emails or user_email not in admin_emails:
+            raise HTTPException(status_code=403, detail="Not authorized.")
     return await inject_smn_test_alert(db, body.level, body.title, body.short)
 
 


### PR DESCRIPTION
Body:
## Summary
- Any authenticated Firebase user can now use the notification test endpoints
  on staging without needing their email in `NOTIFICATION_TEST_ADMIN_EMAILS`.
- Affected endpoints: `POST /api/v1/notifications/test`, `POST /api/v1/siat/inject-cyclone`,
  `POST /api/v1/siat/inject-smn-alert`.
- Production behavior unchanged — `DEV_BYPASS_NOTIF_TEST_AUTH` defaults to `false`.

## Activation
In Railway staging → Variables → add:
`DEV_BYPASS_NOTIF_TEST_AUTH=true`

## Test plan
- [ ] With bypass active: cualquier usuario autenticado puede usar los botones sin 403
- [ ] Sin la variable (o con `false`): whitelist sigue funcionando igual

Una vez mergeado, el último paso es ir a Railway staging → Variables → agregar DEV_BYPASS_NOTIF_TEST_AUTH=true y redeploy. Después de eso cualquier miembro del equipo con el build de staging puede usarlo sin pedirte nada.
