### PR TITLE
feat: persist SMN pdf_url + QA observability logs

### DIFF
--- a/backend/app/features/alerts/schemas.py
+++ b/backend/app/features/alerts/schemas.py
@@ -22,6 +22,7 @@ class AlertDetail(BaseModel):
     lon: float | None = None
     factors: list
     recommendations: list
+    pdf_url: str | None = None
 
 
 class AlertCreate(BaseModel):

--- a/backend/app/features/alerts/service.py
+++ b/backend/app/features/alerts/service.py
@@ -46,12 +46,13 @@ async def persist_smn_bulletin_if_new(db: AsyncSession, bulletin: dict) -> bool:
     level = _smn_headline_to_level(bulletin.get("headline") or "")
     short = (bulletin.get("summary") or bulletin.get("headline") or "Boletín del SMN/CONAGUA")[:500]
 
+    pdf_url = bulletin.get("pdf_url")
     await db.execute(
         text("""
-            INSERT INTO alerts (level, score, title, short, lat, lon, factors, recommendations)
-            VALUES (:level, 0, :title, :short, NULL, NULL, '[]', '[]')
+            INSERT INTO alerts (level, score, title, short, lat, lon, factors, recommendations, pdf_url)
+            VALUES (:level, 0, :title, :short, NULL, NULL, '[]', '[]', :pdf_url)
         """),
-        {"level": level, "title": title, "short": short},
+        {"level": level, "title": title, "short": short, "pdf_url": pdf_url},
     )
     await db.commit()
     logger.info("SMN bulletin persisted: level=%d title='%s'", level, title)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -66,6 +66,9 @@ async def ensure_core_tables(engine: AsyncEngine) -> None:
                 updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
             )
         """))
+        await conn.execute(text(
+            "ALTER TABLE alerts ADD COLUMN IF NOT EXISTS pdf_url TEXT"
+        ))
         await conn.execute(text('CREATE EXTENSION IF NOT EXISTS "pgcrypto"'))
         await conn.execute(text("""
             CREATE TABLE IF NOT EXISTS notification_preferences (

--- a/frontend/app/AlarmScreen.jsx
+++ b/frontend/app/AlarmScreen.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Modal, View, Text, TouchableOpacity } from "react-native";
 import { Link, useRouter, useLocalSearchParams } from "expo-router";
 import { colorForLevel } from "./alerts/_components/AlertCard";
@@ -5,6 +6,11 @@ import { colorForLevel } from "./alerts/_components/AlertCard";
 export default function AlarmScreen() {
   const { alertId, category, title, message } = useLocalSearchParams();
   const router = useRouter();
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    console.log('[QA_NAV] AlarmScreen mounted | alertId:', alertId ?? 'none', '| category:', category, '| title:', title);
+  }, []);
 
   const alertData = {
     id:       alertId  || null,
@@ -72,6 +78,7 @@ export default function AlarmScreen() {
               <TouchableOpacity
                 className="flex-1 ml-2 py-3 rounded-lg items-center"
                 style={{ backgroundColor: buttonColor }}
+                onPress={() => console.log('[QA_NAV] AlarmScreen → más info | alertId:', alertData.id ?? 'none', '| href:', alertData.id ? `/alerts/${alertData.id}` : "/alerts")}
               >
                 <Text className="font-bold" style={{ color: baseColor }}>Más información</Text>
               </TouchableOpacity>

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -174,6 +174,7 @@ export default Sentry.wrap(function Layout() {
     const tapSub = addNotificationResponseListener(async (rawData) => {
       const data = rawData as NotificationData
       const { id, isFullScreen, isSos, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data)
+      console.log('[QA_NOTIF] tap | alertId:', id ?? 'none', '| fullScreen:', isFullScreen, '| sos:', isSos)
       if (!id && !isFullScreen && !isSos) return
 
       await initAnalytics();
@@ -190,8 +191,10 @@ export default Sentry.wrap(function Layout() {
         return;
       }
       if (isFullScreen) {
+        console.log('[QA_NAV] tap → AlarmScreen | alertId:', id ?? 'none', '| category:', params.category)
         router.push({ pathname: "AlarmScreen", params });
       } else if (id) {
+        console.log('[QA_NAV] tap → alert detail | alertId:', id)
         router.push({ pathname: "/alerts/[id]", params: { id } });
       }
     });
@@ -201,8 +204,10 @@ export default Sentry.wrap(function Layout() {
       const rawData = notification.request.content.data as NotificationData
       const content = notification.request.content
       const { isFullScreen, isSos, senderName, params } = resolveNotifPayload(rawData, content)
+      console.log('[QA_NOTIF] received foreground | fullScreen:', isFullScreen, '| sos:', isSos, '| category:', params.category)
       if (isFullScreen && !alarmActiveRef.current) {
         alarmActiveRef.current = true
+        console.log('[QA_NAV] received → AlarmScreen | category:', params.category, '| alertId:', params.alertId ?? 'none')
         router.push({ pathname: "AlarmScreen", params })
         // Liberar el guard después de un debounce para cubrir multi-push
         setTimeout(() => { alarmActiveRef.current = false }, 5000)

--- a/frontend/app/alerts/[id].tsx
+++ b/frontend/app/alerts/[id].tsx
@@ -30,6 +30,7 @@ interface AlertData {
   score?: number;
   recommendations?: string[];
   factors?: string[];
+  pdf_url?: string;
 }
 
 function SectionPill({ title, color }: { title: string; color: string }) {
@@ -58,12 +59,17 @@ export default function AlertDetailsScreen() {
   const [aiLoading, setAiLoading] = useState(false);
 
   const handleOpenBoletin = async () => {
-    const url = "https://preparados.gob.mx/SIAT-CT/";
+    const url = alert?.pdf_url ?? "https://preparados.gob.mx/SIAT-CT/";
+    console.log('[QA_LINK] boletin tap | alertId:', id, '| alertTitle:', alert?.title, '| url:', url);
     try {
       const canOpen = await Linking.canOpenURL(url);
-      if (canOpen) await Linking.openURL(url);
+      console.log('[QA_LINK] canOpenURL:', canOpen);
+      if (canOpen) {
+        await Linking.openURL(url);
+        console.log('[QA_LINK] openURL called OK');
+      }
     } catch (err) {
-      console.error("Error opening URL:", err);
+      console.error('[QA_LINK] openURL error:', err);
     }
   };
 
@@ -79,7 +85,10 @@ export default function AlertDetailsScreen() {
           throw Object.assign(new Error("Error"), { status: res.status });
         }
         const data = await res.json();
-        if (live) setAlert(data);
+        if (live) {
+          console.log('[QA_ALERTS] detail loaded | id:', id, '| level:', data.level, '| title:', data.title);
+          setAlert(data);
+        }
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e)
         const isAuthError = msg === 'Not authenticated'

--- a/frontend/app/alerts/index.tsx
+++ b/frontend/app/alerts/index.tsx
@@ -64,12 +64,13 @@ export default function AlertsListScreen() {
         renderItem={({ item }) => (
           <AlertCard
             alert={item}
-            onPress={() =>
+            onPress={() => {
+              console.log('[QA_ALERTS] list tap | id:', item.id, '| level:', item.level, '| title:', item.title);
               router.push({
                 pathname: "/alerts/[id]",
                 params: { id: item.id },
-              })
-            }
+              });
+            }}
           />
         )}
       />


### PR DESCRIPTION
## Summary

- **Backend:** agrega columna \`pdf_url TEXT\` a la tabla \`alerts\` (ALTER TABLE IF NOT EXISTS en startup). \`persist_smn_bulletin_if_new()\` ahora guarda el PDF URL que el scraper SMN ya extraía pero descartaba. \`AlertDetail\` lo expone en el response.
- **Frontend (\`alerts/[id]\`):** \`handleOpenBoletin\` usa \`alert.pdf_url\` si existe; si no, cae al fallback \`https://preparados.gob.mx/SIAT-CT/\`. SMN Aviso futuros abrirán el PDF real del boletín.
- **QA logs:** añade prefijos \`[QA_NOTIF]\`, \`[QA_NAV]\`, \`[QA_ALERTS]\`, \`[QA_LINK]\` en \`_layout.tsx\`, \`AlarmScreen\`, lista de alertas y detalle — cubre el flujo completo notificación → tap → AlarmScreen → lista → detalle → boletín.

## Test plan

- [ ] Mergear y dejar que Railway redepliegue (el ALTER TABLE corre en startup)
- [ ] Esperar el próximo ciclo del background loop (~30 min) para que ingiera un aviso SMN nuevo con pdf_url
- [ ] Abrir "Dev: Notificaciones" → tocar "Huracán Nivel 4" → verificar logs [QA_NOTIF] y [QA_NAV] en logcat
- [ ] En AlarmScreen → tocar "Más información" → verificar [QA_NAV] AlarmScreen más info
- [ ] En lista → tocar "SMN Aviso #NNN" → verificar [QA_ALERTS] list tap
- [ ] En detalle → verificar [QA_ALERTS] detail loaded con id, level, title
- [ ] Tocar "Ver boletín oficial" → verificar [QA_LINK] boletin tap | url: muestra el PDF URL (para avisos nuevos) o el fallback (para los existentes sin pdf_url)
- [ ] Confirmar que Chrome abre la URL correcta