### PR TITLE
fix: restore notification title in AlarmScreen on background tap

### DIFF
--- a/backend/app/features/notifications/router.py
+++ b/backend/app/features/notifications/router.py
@@ -17,28 +17,45 @@ _TEST_PAYLOADS: dict[str, dict] = {
     "hurricane_l2": {
         "title": "Alerta SIAT-CT Verde [PRUEBA]",
         "body": "Ciclón de prueba | Distancia: ~200 km | ETA: ~36h",
-        "data": {"siat_level": "2", "siat_color": "VERDE"},
+        "data": {
+            "siat_level": "2", "siat_color": "VERDE",
+            "alertTitle": "Alerta SIAT-CT Verde [PRUEBA]",
+            "alertMessage": "Ciclón de prueba | Distancia: ~200 km | ETA: ~36h",
+        },
     },
     "hurricane_l3": {
         "title": "Alerta SIAT-CT Amarillo [PRUEBA]",
         "body": "Ciclón de prueba | Distancia: ~120 km | ETA: ~18h",
-        "data": {"siat_level": "3", "siat_color": "AMARILLO"},
+        "data": {
+            "siat_level": "3", "siat_color": "AMARILLO",
+            "alertTitle": "Alerta SIAT-CT Amarillo [PRUEBA]",
+            "alertMessage": "Ciclón de prueba | Distancia: ~120 km | ETA: ~18h",
+        },
     },
     "hurricane_l4": {
         "title": "Alerta SIAT-CT Naranja [PRUEBA]",
         "body": "Ciclón de prueba | Distancia: ~50 km | ETA: ~8h",
-        "data": {"siat_level": "4", "siat_color": "NARANJA", "fullScreen": "true"},
+        "data": {
+            "siat_level": "4", "siat_color": "NARANJA", "fullScreen": "true",
+            "alertTitle": "Alerta SIAT-CT Naranja [PRUEBA]",
+            "alertMessage": "Ciclón de prueba | Distancia: ~50 km | ETA: ~8h",
+        },
     },
     "sos_test": {
         "title": "SOS — Equipo BluEye [PRUEBA]",
         "body": "Necesita ayuda urgente. Toca para ver su ubicación.",
-        "data": {"category": "sos", "sender_name": "Test BluEye",
-                 "lat": "19.43264", "lon": "-99.13318"},
+        "data": {
+            "category": "sos", "sender_name": "Test BluEye",
+            "lat": "19.43264", "lon": "-99.13318",
+        },
     },
     "generic": {
         "title": "Notificación de prueba [PRUEBA]",
         "body": "Esta es una notificación de prueba del equipo BluEye.",
-        "data": {},
+        "data": {
+            "alertTitle": "Notificación de prueba [PRUEBA]",
+            "alertMessage": "Esta es una notificación de prueba del equipo BluEye.",
+        },
     },
 }
 

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -171,9 +171,9 @@ export default Sentry.wrap(function Layout() {
     setForegroundNotificationHandler();
 
     // Tap en notificación (background → foreground, o foreground tap)
-    const tapSub = addNotificationResponseListener(async (rawData) => {
+    const tapSub = addNotificationResponseListener(async (rawData, content) => {
       const data = rawData as NotificationData
-      const { id, isFullScreen, isSos, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data)
+      const { id, isFullScreen, isSos, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data, content)
       console.log('[QA_NOTIF] tap | alertId:', id ?? 'none', '| fullScreen:', isFullScreen, '| sos:', isSos)
       if (!id && !isFullScreen && !isSos) return
 
@@ -244,8 +244,9 @@ export default Sentry.wrap(function Layout() {
 
       const data = initial.notification.request.content.data as NotificationData | undefined
       if (!data) return
+      const { title: coldTitle, body: coldBody } = initial.notification.request.content
 
-      const { id, isFullScreen, isSos, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data)
+      const { id, isFullScreen, isSos, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data, { title: coldTitle, body: coldBody })
       if (!id && !isFullScreen && !isSos) return
 
       await initAnalytics();

--- a/frontend/utils/pushNotifications.ts
+++ b/frontend/utils/pushNotifications.ts
@@ -122,9 +122,14 @@ export function setForegroundNotificationHandler() {
 }
 
 // Devuelve el unsubscribe para limpiarlo en unuseEffect
-export function addNotificationResponseListener(onTap: (data: Record<string, unknown>) => void) {
+export function addNotificationResponseListener(
+  onTap: (
+    data: Record<string, unknown>,
+    content: { title?: string | null; body?: string | null },
+  ) => void,
+) {
   return Notifications.addNotificationResponseReceivedListener((response) => {
-    const data = response.notification.request.content.data;
-    onTap(data); // envía los datos al callback que definas en el layout
+    const { data, title, body } = response.notification.request.content;
+    onTap(data, { title, body });
   });
 }


### PR DESCRIPTION
## Summary
- Root cause: Android discards `notification.title` from FCM content when the app is backgrounded — `response.notification.request.content.title` is `null` on tap, so `resolveNotifPayload` fell back to "Alerta de emergencia".
- Backend: mirror `title`/`body` into `data.alertTitle`/`alertMessage` on all test payloads so `resolveNotifPayload` reads them from `data` regardless of foreground/background state.
- Frontend: pass notification `content` (`title`, `body`) to `resolveNotifPayload` in both the tapSub and the cold-start handler; `addNotificationResponseListener` wrapper now forwards `content` alongside `data`.

## Files changed
- `backend/app/features/notifications/router.py` — `alertTitle`/`alertMessage` in all `_TEST_PAYLOADS`
- `frontend/utils/pushNotifications.ts` — `addNotificationResponseListener` forwards `content`
- `frontend/app/_layout.tsx` — `tapSub` y cold-start handler pasan `content` a `resolveNotifPayload`

## Test plan
- [ ] Enviar `hurricane_l4` (PRUEBA), bajar la app al background, tapear la notificación
- [ ] Verificar que AlarmScreen muestra "Alerta SIAT-CT Naranja [PRUEBA]" en lugar de "Alerta de emergencia"
- [ ] Repetir con `hurricane_l2` y `hurricane_l3`
- [ ] Verificar que el cold-start (matar la app, tapear la notificación) también funciona