### PR TITLE
fix: backfill pdf_url for existing SMN bulletins + QA log for Ver en mapa

### DIFF
--- a/backend/app/features/alerts/service.py
+++ b/backend/app/features/alerts/service.py
@@ -39,7 +39,16 @@ async def persist_smn_bulletin_if_new(db: AsyncSession, bulletin: dict) -> bool:
             {"title": title},
         )
 
-    if existing.mappings().first():
+    existing_row = existing.mappings().first()
+    if existing_row:
+        pdf_url = bulletin.get("pdf_url")
+        if pdf_url:
+            await db.execute(
+                text("UPDATE alerts SET pdf_url = :pdf_url WHERE id = :id AND pdf_url IS NULL"),
+                {"pdf_url": pdf_url, "id": existing_row["id"]},
+            )
+            await db.commit()
+            logger.debug("SMN bulletin pdf_url backfilled: '%s'", title)
         logger.debug("SMN bulletin already persisted: '%s'", title)
         return False
 

--- a/frontend/app/alerts/[id].tsx
+++ b/frontend/app/alerts/[id].tsx
@@ -259,6 +259,7 @@ export default function AlertDetailsScreen() {
             style={[styles.ctaButton, { backgroundColor: colors.brandBlue }]}
             activeOpacity={0.7}
             onPress={() => {
+              console.log('[QA_NAV] alert detail → mapa | alertId:', alert.id, '| level:', alert.level);
               track("details_map_tap", { alertId: String(alert.id), level: Number(alert.level), score: Number(alert.score ?? 0) });
               router.push("/(tabs)/MapScreen");
             }}


### PR DESCRIPTION
## Summary
- When el SIAT loop re-scrapea un boletín SMN que ya existe en DB pero tiene `pdf_url = NULL` (insertado antes de que se agregara la columna), ahora hace UPDATE en lugar de ignorarlo.
- Agrega `[QA_NAV]` console log al botón "Ver en mapa" en el detalle de alerta, para tener visibilidad en logcat durante sesiones de QA.

## Root cause
SMN Aviso #324 se insertó antes del fix de PR #180 (que agregó la columna `pdf_url`). La fila quedó con `pdf_url = NULL` aunque el scraper sí tiene el PDF. El SIAT loop volvía a scrapear cada 30 min pero al encontrar la fila existente simplemente retornaba `False` sin backfillear.

## Files changed
- `backend/app/features/alerts/service.py` — `persist_smn_bulletin_if_new` ahora hace UPDATE si `pdf_url IS NULL`
- `frontend/app/alerts/[id].tsx` — `[QA_NAV]` log en "Ver en mapa"

## Test plan
- [ ] Verificar en Railway logs que el próximo ciclo SIAT (cada 30 min) actualiza SMN Aviso #324 con el pdf_url real
- [ ] Abrir detalle de SMN Aviso #324 → "Ver boletín oficial" debe abrir el PDF de smn.conagua.gob.mx
- [ ] Tocar "Ver en mapa" → logcat debe mostrar `[QA_NAV] alert detail → mapa`