### PR TITLE
fix: navigate to alerts list when notification tap has no alertId

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -175,7 +175,6 @@ export default Sentry.wrap(function Layout() {
       const data = rawData as NotificationData
       const { id, isFullScreen, isSos, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data, content)
       console.log('[QA_NOTIF] tap | alertId:', id ?? 'none', '| fullScreen:', isFullScreen, '| sos:', isSos)
-      if (!id && !isFullScreen && !isSos) return
 
       await initAnalytics();
       track("push_open", {
@@ -196,6 +195,9 @@ export default Sentry.wrap(function Layout() {
       } else if (id) {
         console.log('[QA_NAV] tap → alert detail | alertId:', id)
         router.push({ pathname: "/alerts/[id]", params: { id } });
+      } else {
+        console.log('[QA_NAV] tap → alerts list (no alertId)')
+        router.push("/alerts");
       }
     });
 


### PR DESCRIPTION
## Summary
L2/L3 test notifications (and any real alert notification without `alertId`) were silently ignored on tap — the `tapSub` returned early because `!id && !isFullScreen && !isSos`.

Now falls through to `router.push('/alerts')` so tapping any alert notification always opens something useful.

## Test plan
- [ ] Dev Tools → "Huracán L2 Verde" → background → tap banner → debe abrir listado de alertas
- [ ] Dev Tools → "Huracán L3 Amarillo" → mismo flujo
- [ ] L4 Naranja sigue abriendo AlarmScreen (no regresión)