### PR TITLE
feat: center map on alert location when navigating from alert detail

### DIFF
--- a/frontend/app/(tabs)/MapScreen.tsx
+++ b/frontend/app/(tabs)/MapScreen.tsx
@@ -1,12 +1,30 @@
 import "../../global.css";
 import { StatusBar } from "expo-status-bar";
+import { useLocalSearchParams } from "expo-router";
 import Main from "../map";
 
-const MapScreen = () => (
-  <>
-    <StatusBar style="light" translucent={false} />
-    <Main />
-  </>
-);
+const MapScreen = () => {
+  const { alertLat, alertLon, alertTitle, alertLevel } = useLocalSearchParams<{
+    alertLat?: string;
+    alertLon?: string;
+    alertTitle?: string;
+    alertLevel?: string;
+  }>();
+
+  const focusLat = alertLat ? parseFloat(alertLat) : undefined;
+  const focusLon = alertLon ? parseFloat(alertLon) : undefined;
+
+  return (
+    <>
+      <StatusBar style="light" translucent={false} />
+      <Main
+        focusLat={focusLat}
+        focusLon={focusLon}
+        focusTitle={alertTitle}
+        focusLevel={alertLevel ? parseInt(alertLevel, 10) : undefined}
+      />
+    </>
+  );
+};
 
 export default MapScreen;

--- a/frontend/app/alerts/[id].tsx
+++ b/frontend/app/alerts/[id].tsx
@@ -31,6 +31,8 @@ interface AlertData {
   recommendations?: string[];
   factors?: string[];
   pdf_url?: string;
+  lat?: number | null;
+  lon?: number | null;
 }
 
 function SectionPill({ title, color }: { title: string; color: string }) {
@@ -259,9 +261,15 @@ export default function AlertDetailsScreen() {
             style={[styles.ctaButton, { backgroundColor: colors.brandBlue }]}
             activeOpacity={0.7}
             onPress={() => {
-              console.log('[QA_NAV] alert detail → mapa | alertId:', alert.id, '| level:', alert.level);
+              console.log('[QA_NAV] alert detail → mapa | alertId:', alert.id, '| level:', alert.level, '| hasCoords:', alert.lat != null);
               track("details_map_tap", { alertId: String(alert.id), level: Number(alert.level), score: Number(alert.score ?? 0) });
-              router.push("/(tabs)/MapScreen");
+              const params: Record<string, string> = {
+                alertTitle: alert.title,
+                alertLevel: String(alert.level),
+              };
+              if (alert.lat != null) params.alertLat = String(alert.lat);
+              if (alert.lon != null) params.alertLon = String(alert.lon);
+              router.push({ pathname: "/(tabs)/MapScreen", params });
             }}
           >
             <Text style={{ color: 'white', fontFamily: fonts.poppinsSemiBold }}>Ver en mapa</Text>

--- a/frontend/app/map/index.tsx
+++ b/frontend/app/map/index.tsx
@@ -16,7 +16,7 @@ import {
   Platform,
 } from "react-native";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
-import MapView, { UrlTile, PROVIDER_GOOGLE, Marker } from "react-native-maps";
+import MapView, { UrlTile, PROVIDER_GOOGLE, Marker, Callout } from "react-native-maps";
 import * as Location from "expo-location";
 import { syncLocationToBackend } from "../../utils/locationSync";
 import { toast } from "sonner-native";
@@ -46,6 +46,21 @@ const OWM_API_KEY = process.env.EXPO_PUBLIC_OPENWEATHER_API_KEY;
 
 type MCIName = React.ComponentProps<typeof MaterialCommunityIcons>['name']
 
+interface MapProps {
+  focusLat?: number;
+  focusLon?: number;
+  focusTitle?: string;
+  focusLevel?: number;
+}
+
+const LEVEL_COLORS: Record<number, string> = {
+  1: '#4CAF50',
+  2: '#4CAF50',
+  3: '#FFC107',
+  4: '#FF9800',
+  5: '#F44336',
+}
+
 const ZoneMarker = React.memo(function ZoneMarker({ zone, onPress }: { zone: Zone; onPress: () => void }) {
   // Custom-image markers must redraw their native bitmap once on load, then STOP.
   // While tracksViewChanges is true the hit area is unstable and Android drops taps,
@@ -72,7 +87,7 @@ const ZoneMarker = React.memo(function ZoneMarker({ zone, onPress }: { zone: Zon
   );
 });
 
-export default function WeatherMapNativewind() {
+export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, focusLevel }: MapProps = {}) {
   const [region, setRegion] = useState(DEFAULT_REGION);
   const [showWind, setShowWind] = useState(true);
   const [showPrecip, setShowPrecip] = useState(false);
@@ -166,6 +181,18 @@ export default function WeatherMapNativewind() {
     });
     return () => sub.remove();
   }, []);
+
+  useEffect(() => {
+    if (focusLat == null || focusLon == null) return;
+    const focusRegion = {
+      latitude: focusLat,
+      longitude: focusLon,
+      latitudeDelta: 3,
+      longitudeDelta: 3,
+    };
+    setRegion(focusRegion);
+    mapRef.current?.animateToRegion(focusRegion, 800);
+  }, [focusLat, focusLon]);
 
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout>;
@@ -580,6 +607,25 @@ export default function WeatherMapNativewind() {
         {showEvents && zones.map((zone) => (
           <ZoneMarker key={zone.id} zone={zone} onPress={() => handleCirclePress(zone)} />
         ))}
+
+        {focusLat != null && focusLon != null && (
+          <Marker coordinate={{ latitude: focusLat, longitude: focusLon }} anchor={{ x: 0.5, y: 0.5 }}>
+            <View style={{
+              backgroundColor: LEVEL_COLORS[focusLevel ?? 3],
+              borderRadius: 24,
+              padding: 8,
+              borderWidth: 2,
+              borderColor: 'white',
+            }}>
+              <MaterialCommunityIcons name="weather-hurricane" size={28} color="white" />
+            </View>
+            <Callout>
+              <View style={{ padding: 8, maxWidth: 200 }}>
+                <Text style={{ fontWeight: 'bold', fontSize: 13 }}>{focusTitle ?? 'Alerta'}</Text>
+              </View>
+            </Callout>
+          </Marker>
+        )}
       </MapView>
 
       {/* Layer selector */}


### PR DESCRIPTION
## Summary
- \"Ver en mapa\" desde el detalle de una alerta ahora centra el mapa en las coordenadas de la alerta y muestra un marker de huracán con el título como callout.
- Si la alerta no tiene coordenadas (ej. boletines SMN nacionales con lat/lon NULL), el mapa abre en estado genérico igual que antes.
- El marker usa un color por nivel: verde (1-2), amarillo (3), naranja (4), rojo (5).

## Files changed
- `frontend/app/alerts/[id].tsx` — pasa `alertLat`, `alertLon`, `alertTitle`, `alertLevel` a MapScreen; agrega `lat`/`lon` a la interfaz `AlertData`
- `frontend/app/(tabs)/MapScreen.tsx` — lee los params con `useLocalSearchParams` y los pasa a `<Main />`
- `frontend/app/map/index.tsx` — acepta props `focusLat/Lon/Title/Level`, anima al region de la alerta en mount, muestra `<Marker>` con ícono `weather-hurricane`

## Test plan
- [ ] Ver en mapa desde alerta SIAT real (con lat/lon) → mapa centrado en la alerta con marker
- [ ] Ver en mapa desde SMN Aviso #324 (sin lat/lon) → mapa abre en estado genérico sin crash
- [ ] Abrir mapa directo desde tabs → sin marker, comportamiento normal