### PR TITLE
fix: SIAT/SMN FCM payloads + create alerts record for cyclone escalations

### DIFF
--- a/backend/app/features/siat/service.py
+++ b/backend/app/features/siat/service.py
@@ -242,6 +242,31 @@ async def _mark_notified(db: AsyncSession, user_id: int, level: int) -> None:
     )
 
 
+async def _upsert_cyclone_alert(
+    db: AsyncSession, cyclone: dict, assessment: dict
+) -> str:
+    """Create an alerts record for a SIAT cyclone escalation. Returns the alert UUID."""
+    level = assessment["siat_level"]
+    color = assessment["siat_color"]
+    label = _COLOR_LABELS.get(color, color)
+    title = f"Ciclón {cyclone['name']} — SIAT-CT {label}"
+    short = (assessment.get("reason") or f"Ciclón a {assessment.get('distance_km', '?'):.0f} km")[:500]
+    result = await db.execute(
+        text("""
+            INSERT INTO alerts (level, score, title, short, lat, lon, factors, recommendations)
+            VALUES (:level, 0, :title, :short, :lat, :lon, '[]', '[]')
+            RETURNING id
+        """),
+        {
+            "level": level, "title": title, "short": short,
+            "lat": cyclone["lat"], "lon": cyclone["lon"],
+        },
+    )
+    alert_id = str(result.mappings().first()["id"])
+    logger.info("Cyclone alert created: id=%s level=%d title='%s'", alert_id, level, title)
+    return alert_id
+
+
 # ---------------------------------------------------------------------------
 # Push notification — per-user (not broadcast)
 # ---------------------------------------------------------------------------
@@ -262,16 +287,28 @@ async def _push_per_user(
             logger.debug("user_id=%d has no registered tokens, skipping push", user_id)
             continue
 
+        level = assessment["siat_level"]
         label = _COLOR_LABELS.get(assessment["siat_color"], assessment["siat_color"])
+        title = f"Alerta SIAT-CT {label}"
+        body = assessment["reason"]
+        alert_id = assessment.get("alert_id")
+
+        data: dict[str, str] = {
+            "siat_level": str(level),
+            "siat_color": assessment["siat_color"],
+            "alertTitle": title,
+            "alertMessage": body,
+        }
+        if alert_id:
+            data["alertId"] = alert_id
+        if level >= 4:
+            data["fullScreen"] = "true"
+
         msg = messaging.MulticastMessage(
-            notification=messaging.Notification(
-                title=f"Alerta SIAT-CT {label}",
-                body=assessment["reason"],
-            ),
-            data={
-                "siat_level": str(assessment["siat_level"]),
-                "siat_color": assessment["siat_color"],
-            },
+            notification=messaging.Notification(title=title, body=body),
+            data=data,
+            android=messaging.AndroidConfig(priority="high"),
+            apns=messaging.APNSConfig(headers={"apns-priority": "10"}),
             tokens=tokens,
         )
 
@@ -342,20 +379,20 @@ async def _push_smn_for_alert(
     if not all_tokens:
         return 0
 
+    smn_title = f"Nueva alerta — {alert['title']}"
+    smn_body = alert["short"] or ""
     msg = messaging.MulticastMessage(
-        notification=messaging.Notification(
-            title=f"Nueva alerta — {alert['title']}",
-            body=alert["short"],
-        ),
+        notification=messaging.Notification(title=smn_title, body=smn_body),
         data={
             "alert_id": str(alert["id"]),
+            "alertId": str(alert["id"]),
             "level": str(alert["level"]),
             "siat_level": str(alert["level"]),
+            "alertTitle": smn_title,
+            "alertMessage": smn_body,
         },
         android=messaging.AndroidConfig(priority="high"),
-        apns=messaging.APNSConfig(
-            headers={"apns-priority": "10"},
-        ),
+        apns=messaging.APNSConfig(headers={"apns-priority": "10"}),
         tokens=all_tokens,
     )
 
@@ -461,10 +498,12 @@ async def run_cycle(db: AsyncSession, extra_cyclones: list[dict] | None = None) 
 
     all_assessments: list[dict] = []
     escalations: dict[int, dict] = {}  # user_id → highest assessment this cycle
+    cyclone_map: dict[int, dict] = {}  # cyclone_id → cyclone data (for alert creation)
 
     for cyclone in (cyclones if users else []):
         try:
             cyclone_id = await _save_cyclone(db, cyclone)
+            cyclone_map[cyclone_id] = cyclone
             logger.info("Cyclone saved: id=%d name=%s status=%s", cyclone_id, cyclone["name"], cyclone["status"])
         except Exception as exc:
             logger.error("Failed to save cyclone %s: %s", cyclone.get("name"), exc, exc_info=True)
@@ -507,7 +546,7 @@ async def run_cycle(db: AsyncSession, extra_cyclones: list[dict] | None = None) 
                         else:
                             prev = escalations.get(user["id"])
                             if prev is None or new_level > prev["siat_level"]:
-                                escalations[user["id"]] = assessment
+                                escalations[user["id"]] = {**assessment, "cyclone_id": cyclone_id}
                                 logger.info(
                                     "Escalation queued: user_id=%d %s→%s (%s)",
                                     user["id"], old_level, new_level, assessment["siat_color"],
@@ -529,6 +568,16 @@ async def run_cycle(db: AsyncSession, extra_cyclones: list[dict] | None = None) 
 
     notifications_sent = 0
     if escalations:
+        # Create one alerts record per unique cyclone that triggered escalations
+        cyclone_alert_ids: dict[int, str] = {}
+        for assessment in escalations.values():
+            cid = assessment["cyclone_id"]
+            if cid not in cyclone_alert_ids:
+                cyclone = cyclone_map[cid]
+                cyclone_alert_ids[cid] = await _upsert_cyclone_alert(db, cyclone, assessment)
+        for assessment in escalations.values():
+            assessment["alert_id"] = cyclone_alert_ids.get(assessment["cyclone_id"])
+
         token_map = await get_tokens_for_users(db, list(escalations.keys()))
         notifications_sent = await _push_per_user(escalations, token_map)
         for user_id, assessment in escalations.items():

--- a/backend/app/features/siat/tests/test_router.py
+++ b/backend/app/features/siat/tests/test_router.py
@@ -304,6 +304,7 @@ def _base_run_cycle_patches(assessment, prefs, push_return=0):
         patch(f"{_SVC}._push_per_user", new_callable=AsyncMock, return_value=push_return),
         patch(f"{_SVC}._mark_notified", new_callable=AsyncMock, return_value=None),
         patch(f"{_SVC}._notify_smn_alerts", new_callable=AsyncMock, return_value=0),
+        patch(f"{_SVC}._upsert_cyclone_alert", new_callable=AsyncMock, return_value="test-alert-uuid"),
     ]
 
 
@@ -318,7 +319,7 @@ async def test_run_cycle_respects_siat_disabled():
 
     patches = _base_run_cycle_patches(_ASSESSMENT_LEVEL_3, prefs, push_return=0)
     with patches[0], patches[1], patches[2], patches[3], patches[4], \
-         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11]:
+         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11], patches[12]:
         result = await run_cycle(db)
 
     assert result["notifications_sent"] == 0
@@ -335,7 +336,7 @@ async def test_run_cycle_respects_min_siat_level():
 
     patches = _base_run_cycle_patches(_ASSESSMENT_LEVEL_2, prefs, push_return=0)
     with patches[0], patches[1], patches[2], patches[3], patches[4], \
-         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11]:
+         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11], patches[12]:
         result = await run_cycle(db)
 
     assert result["notifications_sent"] == 0
@@ -352,7 +353,7 @@ async def test_run_cycle_sends_push_when_prefs_allow():
 
     patches = _base_run_cycle_patches(_ASSESSMENT_LEVEL_2, prefs, push_return=1)
     with patches[0], patches[1], patches[2], patches[3], patches[4], \
-         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11]:
+         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11], patches[12]:
         result = await run_cycle(db)
 
     assert result["notifications_sent"] == 1
@@ -520,7 +521,7 @@ async def test_siat_quiet_hours_suppresses_push():
 
     patches = _base_run_cycle_patches(_ASSESSMENT_LEVEL_3, _QUIET_PREFS, push_return=0)
     with patches[0], patches[1], patches[2], patches[3], patches[4], \
-         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11], \
+         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11], patches[12], \
          patch(f"{_SVC}.is_within_quiet_hours", return_value=True):
         result = await run_cycle(db)
 
@@ -537,7 +538,7 @@ async def test_siat_quiet_hours_allows_push_outside_range():
 
     patches = _base_run_cycle_patches(_ASSESSMENT_LEVEL_3, _QUIET_PREFS, push_return=1)
     with patches[0], patches[1], patches[2], patches[3], patches[4], \
-         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11], \
+         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11], patches[12], \
          patch(f"{_SVC}.is_within_quiet_hours", return_value=False):
         result = await run_cycle(db)
 
@@ -554,7 +555,7 @@ async def test_siat_level5_overrides_quiet_hours():
 
     patches = _base_run_cycle_patches(_ASSESSMENT_LEVEL_5, _QUIET_PREFS, push_return=1)
     with patches[0], patches[1], patches[2], patches[3], patches[4], \
-         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11], \
+         patches[5], patches[6], patches[7], patches[8], patches[9], patches[10], patches[11], patches[12], \
          patch(f"{_SVC}.is_within_quiet_hours", return_value=True):
         result = await run_cycle(db)
 
@@ -753,7 +754,8 @@ async def test_run_cycle_with_extra_cyclones():
          patch(f"{_SVC}.get_tokens_for_users", new_callable=AsyncMock, return_value={1: ["token-abc"]}), \
          patch(f"{_SVC}._push_per_user", new_callable=AsyncMock, return_value=1), \
          patch(f"{_SVC}._mark_notified", new_callable=AsyncMock), \
-         patch(f"{_SVC}._notify_smn_alerts", new_callable=AsyncMock, return_value=0):
+         patch(f"{_SVC}._notify_smn_alerts", new_callable=AsyncMock, return_value=0), \
+         patch(f"{_SVC}._upsert_cyclone_alert", new_callable=AsyncMock, return_value="test-alert-uuid"):
         result = await run_cycle(db, extra_cyclones=[fake_cyclone])
 
     assert result["cyclones_found"] == 1   # NHC=0, extra=1


### PR DESCRIPTION
## Summary

Cuatro problemas corregidos en un PR:

### 1. SIAT crea un registro en `alerts` por cada escalación de ciclón
`run_cycle` ahora llama a `_upsert_cyclone_alert` antes de mandar los pushes. Crea **un registro por ciclón** que causó escalaciones, con las coords del ciclón (`lat`/`lon`). Esto permite:
- Ver la alerta en el listado de alertas
- Navegar al detalle desde la notificación
- Mostrar el marker en el mapa con "Ver en mapa"

### 2. SIAT FCM `data` completo
```python
data = {
    "siat_level": "4",
    "siat_color": "NARANJA",
    "alertTitle": "Alerta SIAT-CT Naranja",   # ← nuevo
    "alertMessage": "Ciclón INGRID | ...",      # ← nuevo
    "alertId": "<uuid>",                         # ← nuevo
    "fullScreen": "true",                        # ← nuevo (solo level >= 4)
}
```
Fixes "Alerta de emergencia" en background tap. L4/L5 ahora abrirán AlarmScreen.

### 3. SMN FCM `data` completo
```python
data = {
    "alert_id": "<uuid>",
    "alertId": "<uuid>",       # ← nuevo (alias para resolveNotifPayload)
    "alertTitle": "Nueva alerta — SMN Aviso #324",  # ← nuevo
    "alertMessage": "...",     # ← nuevo
    ...
}
```

### 4. Tests actualizados
`_base_run_cycle_patches` y `test_run_cycle_with_extra_cyclones` mockeado con `_upsert_cyclone_alert`. 150/150 passing.

## Test plan
- [ ] Dev Tools → "Nivel 2 Verde" (inject-cyclone) → alerta aparece en listado con coords del Golfo
- [ ] Tap en la notif desde background → AlarmScreen muestra título correcto (no "Alerta de emergencia")
- [ ] "Ver en mapa" desde la alerta SIAT → marker de huracán en las coords del ciclón
- [ ] Dev Tools → "Alerta SMN Nacional" → background tap → título correcto