### PR TITLE
fix: map stays on cyclone location when navigating from alert detail

### DIFF
--- a/frontend/app/map/index.tsx
+++ b/frontend/app/map/index.tsx
@@ -223,11 +223,13 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
           longitudeDelta: 0.1,
         };
 
-        setRegion(userRegion);
         setUserLocation({ latitude: coords.latitude, longitude: coords.longitude });
         setCurrentCoords({ latitude: coords.latitude, longitude: coords.longitude });
-        mapRef.current?.animateToRegion(userRegion, 1000);
         syncLocationToBackend(coords.latitude, coords.longitude);
+        if (focusLat == null || focusLon == null) {
+          setRegion(userRegion);
+          mapRef.current?.animateToRegion(userRegion, 1000);
+        }
       } catch (error) {
         console.warn("⚠️ Could not get location (timeout or error), using default region:", error.message);
       }
@@ -609,7 +611,7 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
         ))}
 
         {focusLat != null && focusLon != null && (
-          <Marker coordinate={{ latitude: focusLat, longitude: focusLon }} anchor={{ x: 0.5, y: 0.5 }}>
+          <Marker coordinate={{ latitude: focusLat, longitude: focusLon }} anchor={{ x: 0.5, y: 0.5 }} tracksViewChanges={false}>
             <View style={{
               backgroundColor: LEVEL_COLORS[focusLevel ?? 3],
               borderRadius: 24,


### PR DESCRIPTION
## Summary

- **Race condition**: when the map opened with `focusLat`/`focusLon` (from an alert), the GPS `useEffect` was finishing after the focus animation and calling `animateToRegion` on the user's location, panning away from the cyclone. Fix: skip `setRegion` + `animateToRegion` in the GPS effect when focus coords are present (user dot still renders via `setUserLocation`).
- **Clipped marker**: the hurricane `<Marker>` was missing `tracksViewChanges={false}`. On Android the native layer captured the bitmap before `MaterialCommunityIcons` finished painting, producing a partial/clipped marker. Fix: set `tracksViewChanges={false}` (icon is font-based, renders synchronously).

## Test plan

- [ ] Dev Tools → Motor SIAT → "Nivel 2 — Verde" → wait for notification → tap it → map opens **centered on cyclone** (~23°N, -96°W)
- [ ] Hurricane marker appears fully rendered (green circle with hurricane icon, no clipping)
- [ ] Recenter button still works (pans back to user location)
- [ ] Opening the Map tab normally (without alert params) still auto-centers on user location

🤖 Generated with [Claude Code](https://claude.com/claude-code)