### PR TITLE
feat: map frames both cyclone and user location when opened from alert

### DIFF
--- a/frontend/app/(tabs)/MapScreen.tsx
+++ b/frontend/app/(tabs)/MapScreen.tsx
@@ -14,6 +14,8 @@ const MapScreen = () => {
   const focusLat = alertLat ? parseFloat(alertLat) : undefined;
   const focusLon = alertLon ? parseFloat(alertLon) : undefined;
 
+  console.log('[QA_MAP] MapScreen params | alertLat:', alertLat, '| alertLon:', alertLon, '| focusLat:', focusLat, '| focusLon:', focusLon);
+
   return (
     <>
       <StatusBar style="light" translucent={false} />

--- a/frontend/app/map/index.tsx
+++ b/frontend/app/map/index.tsx
@@ -65,10 +65,14 @@ const HurricaneMarker = React.memo(function HurricaneMarker({
   lat, lon, title, level,
 }: { lat: number; lon: number; title?: string; level?: number }) {
   const [tracksViewChanges, setTracksViewChanges] = useState(true);
+  console.log('[QA_MAP] HurricaneMarker render | lat:', lat, '| lon:', lon, '| tracksViewChanges:', tracksViewChanges);
   return (
     <Marker coordinate={{ latitude: lat, longitude: lon }} anchor={{ x: 0.5, y: 0.5 }} tracksViewChanges={tracksViewChanges}>
       <View
-        onLayout={() => setTracksViewChanges(false)}
+        onLayout={() => {
+          console.log('[QA_MAP] HurricaneMarker onLayout → tracksViewChanges false');
+          setTracksViewChanges(false);
+        }}
         style={{ backgroundColor: LEVEL_COLORS[level ?? 3], borderRadius: 24, padding: 8, borderWidth: 2, borderColor: 'white' }}
       >
         <MaterialCommunityIcons name="weather-hurricane" size={28} color="white" />
@@ -205,6 +209,7 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
 
   useEffect(() => {
     if (focusLat == null || focusLon == null) return;
+    console.log('[QA_MAP] focus useEffect fired | focusLat:', focusLat, '| focusLon:', focusLon);
     const focusRegion = {
       latitude: focusLat,
       longitude: focusLon,
@@ -247,7 +252,16 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
         setUserLocation({ latitude: coords.latitude, longitude: coords.longitude });
         setCurrentCoords({ latitude: coords.latitude, longitude: coords.longitude });
         syncLocationToBackend(coords.latitude, coords.longitude);
-        if (focusLat == null || focusLon == null) {
+        if (focusLat != null && focusLon != null) {
+          console.log('[QA_MAP] GPS resolved with focus — fitToCoordinates | cyclone:', focusLat, focusLon, '| user:', coords.latitude, coords.longitude);
+          mapRef.current?.fitToCoordinates(
+            [
+              { latitude: focusLat, longitude: focusLon },
+              { latitude: coords.latitude, longitude: coords.longitude },
+            ],
+            { edgePadding: { top: 80, right: 60, bottom: 120, left: 60 }, animated: true }
+          );
+        } else {
           setRegion(userRegion);
           mapRef.current?.animateToRegion(userRegion, 1000);
         }


### PR DESCRIPTION
## Summary

When the user taps "Ver en mapa" from an alert detail, the map previously centered only on the cyclone — leaving the user with no spatial reference. This PR changes the behavior so both points are visible at once:

1. **Focus useEffect** (immediate): animates to cyclone location as soon as the map opens, before GPS resolves — so the user sees something right away.
2. **GPS useEffect** (once resolved): calls `fitToCoordinates([cyclone, user])` to adjust the camera so both the hurricane marker and the user's position fit in frame with padding.

This directly answers the user's real question: *"How close is this to me?"*

Also adds `[QA_MAP]` diagnostic logs to trace the full pipeline: MapScreen params → focus useEffect → GPS fitToCoordinates → HurricaneMarker render/onLayout.

## Test plan

- [ ] Dev Tools → Limpiar estado SIAT → Motor SIAT "Nivel 2 — Verde" → notificación → detalles → "Ver en mapa"
- [ ] Mapa abre centrado en ciclón (~23°N, -96°W), luego re-encuadra para mostrar ciclón + tu ubicación juntos
- [ ] Marker verde de huracán visible y completo
- [ ] Tu punto azul de ubicación visible en el mismo frame
- [ ] Logs `[QA_MAP]` confirman el flujo completo en logcat
- [ ] Abrir mapa directamente desde el tab (sin alerta) sigue centrando en tu ubicación normalmente