### PR TITLE
fix: upgrade react-native-maps 1.20.1→1.27.2, fix hurricane marker clipping

### DIFF
--- a/frontend/app/map/index.tsx
+++ b/frontend/app/map/index.tsx
@@ -16,7 +16,7 @@ import {
   Platform,
 } from "react-native";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
-import MapView, { UrlTile, PROVIDER_GOOGLE, Marker, Callout } from "react-native-maps";
+import MapView, { UrlTile, PROVIDER_GOOGLE, Marker } from "react-native-maps";
 import * as Location from "expo-location";
 import { syncLocationToBackend } from "../../utils/locationSync";
 import { toast } from "sonner-native";
@@ -65,23 +65,16 @@ const HurricaneMarker = React.memo(function HurricaneMarker({
   lat, lon, title, level,
 }: { lat: number; lon: number; title?: string; level?: number }) {
   const [tracksViewChanges, setTracksViewChanges] = useState(true);
-  console.log('[QA_MAP] HurricaneMarker render | lat:', lat, '| lon:', lon, '| tracksViewChanges:', tracksViewChanges);
+  console.log('[QA_MAP] HurricaneMarker render | lat:', lat, '| lon:', lon);
+  const color = LEVEL_COLORS[level ?? 3];
   return (
-    <Marker coordinate={{ latitude: lat, longitude: lon }} anchor={{ x: 0.5, y: 0.5 }} tracksViewChanges={tracksViewChanges}>
+    <Marker coordinate={{ latitude: lat, longitude: lon }} anchor={{ x: 0.5, y: 0.5 }} tracksViewChanges={tracksViewChanges} title={title}>
       <View
-        onLayout={() => {
-          console.log('[QA_MAP] HurricaneMarker onLayout → tracksViewChanges false');
-          setTracksViewChanges(false);
-        }}
-        style={{ backgroundColor: LEVEL_COLORS[level ?? 3], borderRadius: 24, padding: 8, borderWidth: 2, borderColor: 'white' }}
+        onLayout={() => setTimeout(() => setTracksViewChanges(false), 300)}
+        style={{ width: 48, height: 48, borderRadius: 24, backgroundColor: color, borderWidth: 2, borderColor: 'white', alignItems: 'center', justifyContent: 'center' }}
       >
         <MaterialCommunityIcons name="weather-hurricane" size={28} color="white" />
       </View>
-      <Callout>
-        <View style={{ padding: 8, maxWidth: 200 }}>
-          <Text style={{ fontWeight: 'bold', fontSize: 13 }}>{title ?? 'Alerta'}</Text>
-        </View>
-      </Callout>
     </Marker>
   );
 });
@@ -119,7 +112,7 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
   const [showClouds, setShowClouds] = useState(false);
   const [showEvents, setShowEvents] = useState(true);
   const [layerModalVisible, setLayerModalVisible] = useState(false);
-  const mapRef = useRef(null);
+  const mapRef = useRef<MapView>(null);
   const [userLocation, setUserLocation] = useState<{ latitude: number; longitude: number } | null>(null);
 
   const [zones, setZones] = useState<Zone[]>([]);
@@ -210,14 +203,13 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
   useEffect(() => {
     if (focusLat == null || focusLon == null) return;
     console.log('[QA_MAP] focus useEffect fired | focusLat:', focusLat, '| focusLon:', focusLon);
-    const focusRegion = {
+    // Don't update region state — recenter button must always go to user location
+    mapRef.current?.animateToRegion({
       latitude: focusLat,
       longitude: focusLon,
       latitudeDelta: 3,
       longitudeDelta: 3,
-    };
-    setRegion(focusRegion);
-    mapRef.current?.animateToRegion(focusRegion, 800);
+    }, 800);
   }, [focusLat, focusLon]);
 
   useEffect(() => {
@@ -252,6 +244,8 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
         setUserLocation({ latitude: coords.latitude, longitude: coords.longitude });
         setCurrentCoords({ latitude: coords.latitude, longitude: coords.longitude });
         syncLocationToBackend(coords.latitude, coords.longitude);
+        // Always update region to user location — recenter button depends on this
+        setRegion(userRegion);
         if (focusLat != null && focusLon != null) {
           console.log('[QA_MAP] GPS resolved with focus — fitToCoordinates | cyclone:', focusLat, focusLon, '| user:', coords.latitude, coords.longitude);
           mapRef.current?.fitToCoordinates(
@@ -262,7 +256,6 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
             { edgePadding: { top: 80, right: 60, bottom: 120, left: 60 }, animated: true }
           );
         } else {
-          setRegion(userRegion);
           mapRef.current?.animateToRegion(userRegion, 1000);
         }
       } catch (error) {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -50,7 +50,7 @@
         "react-native-executorch-expo-resource-fetcher": "^0.8.0",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-keyboard-controller": "1.18.5",
-        "react-native-maps": "1.20.1",
+        "react-native-maps": "1.27.2",
         "react-native-markdown-display": "^7.0.2",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
@@ -13868,19 +13868,19 @@
       }
     },
     "node_modules/react-native-maps": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.20.1.tgz",
-      "integrity": "sha512-NZI3B5Z6kxAb8gzb2Wxzu/+P2SlFIg1waHGIpQmazDSCRkNoHNY4g96g+xS0QPSaG/9xRBbDNnd2f2/OW6t6LQ==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.27.2.tgz",
+      "integrity": "sha512-VKr+xZ2RZGHHJlY6KhlafvGSmK0dq/tUu5uhfJ7K9rwN5pUdubdugzMKGDU/16lXmQSg7xbClKhRctj3Pm5F5g==",
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.13"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
-        "react": ">= 17.0.1",
-        "react-native": ">= 0.64.3",
+        "react": ">= 18.3.1",
+        "react-native": ">= 0.76.0",
         "react-native-web": ">= 0.11"
       },
       "peerDependenciesMeta": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,7 +52,7 @@
     "react-native-executorch-expo-resource-fetcher": "^0.8.0",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "1.18.5",
-    "react-native-maps": "1.20.1",
+    "react-native-maps": "1.27.2",
     "react-native-markdown-display": "^7.0.2",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",


### PR DESCRIPTION
## Problema

`react-native-maps` 1.20.1 tiene un bug con marcadores de vista personalizada bajo Fabric (New Architecture). En Android, el bitmap del marcador se capturaba antes de que el contenido terminara de renderizar, produciendo un marcador recortado o invisible. El error en logcat era `unstable api MapUIBlock`.

## Cambios

- **`package.json`**: `react-native-maps` 1.20.1 → 1.27.2 (incluye el fix de `MapUIBlock` para Fabric)
- **`map/index.tsx`**:
  - `HurricaneMarker` vuelve a usar `MaterialCommunityIcons` (el workaround SVG ya no es necesario)
  - `mapRef` tipado correctamente como `useRef<MapView>(null)` (era `never`)
  - `Callout` eliminado; se usa el prop nativo `title` en su lugar
  - `fitToCoordinates` al abrir desde una alerta: muestra ciclón + ubicación del usuario en el mismo encuadre
  - `animateToRegion` en focus effect sin `setRegion`, para que el botón de recentrar siempre vaya a la ubicación del usuario

## Cómo probar

1. `npx expo run:android` (rebuild nativo obligatorio por cambio de versión nativa)
2. Disparar una alerta SIAT: `POST /api/v1/siat/inject-cyclone`
3. Tocar la notificación → detalle de alerta → "Ver en mapa"
4. Verificar: marker del huracán visible y completo (sin recorte), mapa encuadra ciclón + tu ubicación
5. Verificar: botón de flecha (recentrar) lleva a tu ubicación, no al ciclón