### PR TITLE
fix: SMN scraper skips empty <strong> to find headline

### DIFF
--- a/backend/app/features/alerts/providers/smn.py
+++ b/backend/app/features/alerts/providers/smn.py
@@ -76,12 +76,16 @@ def _parse_bulletin(html: str) -> dict | None:
     if aviso_num is None:
         logger.debug("SMN parse: aviso_num selector not found")
 
-    # headline — content inside <strong> in the sintesis block
-    headline_match = re.search(
-        r"sintesis[^>]*>.*?<strong>(.*?)</strong>",
-        html, re.DOTALL
-    )
-    headline = _strip_tags(headline_match.group(1)) if headline_match else None
+    # headline — first non-empty <strong> inside the sintesis block
+    # The block can contain a leading empty <strong> </strong> before the real title.
+    sintesis_match = re.search(r"sintesis[^>]*>(.*?)</div>", html, re.DOTALL)
+    headline: str | None = None
+    if sintesis_match:
+        for m in re.finditer(r"<strong>(.*?)</strong>", sintesis_match.group(1), re.DOTALL):
+            candidate = _strip_tags(m.group(1))
+            if candidate:
+                headline = candidate
+                break
     if not headline:
         logger.warning(
             "SMN parse failed: headline not found — the 'sintesis/<strong>' "


### PR DESCRIPTION
## Problema

El bloque `sintesis` de la página del SMN tiene un `<strong> </strong>` vacío antes del título real. El regex anterior capturaba ese primer match y devolvía `None`, produciendo el warning en Railway:

```
SMN parse failed: headline not found — the 'sintesis/<strong>' structure may have changed.
```

## Causa

HTML actual del SMN:
```html
<p><strong> </strong></p>                          ← vacío (capturado antes)
<p><strong>LLUVIAS INTENSAS EN ZONAS...</strong></p> ← headline real
```

## Fix

En lugar de tomar el primer `<strong>` del bloque, ahora itera todos los matches y usa el primero que tenga contenido no vacío después de limpiar tags.

## Verificación

Probado contra el HTML real de la página — extrae correctamente:
`"LLUVIAS INTENSAS EN ZONAS DEL OCCIDENTE, ORIENTE Y SURESTE DEL PAÍS, INCLUIDA LA PENÍNSULA DE YUCATÁN"`