### PR TITLE
chore: improve QA log coverage for alert→map flow

### DIFF
--- a/frontend/app/alerts/[id].tsx
+++ b/frontend/app/alerts/[id].tsx
@@ -261,7 +261,7 @@ export default function AlertDetailsScreen() {
             style={[styles.ctaButton, { backgroundColor: colors.brandBlue }]}
             activeOpacity={0.7}
             onPress={() => {
-              console.log('[QA_NAV] alert detail → mapa | alertId:', alert.id, '| level:', alert.level, '| hasCoords:', alert.lat != null);
+              console.log('[QA_NAV] alert detail → mapa | alertId:', alert.id, '| level:', alert.level, '| lat:', alert.lat, '| lon:', alert.lon);
               track("details_map_tap", { alertId: String(alert.id), level: Number(alert.level), score: Number(alert.score ?? 0) });
               const params: Record<string, string> = {
                 alertTitle: alert.title,

--- a/frontend/app/map/index.tsx
+++ b/frontend/app/map/index.tsx
@@ -70,7 +70,10 @@ const HurricaneMarker = React.memo(function HurricaneMarker({
   return (
     <Marker coordinate={{ latitude: lat, longitude: lon }} anchor={{ x: 0.5, y: 0.5 }} tracksViewChanges={tracksViewChanges} title={title}>
       <View
-        onLayout={() => setTimeout(() => setTracksViewChanges(false), 300)}
+        onLayout={() => {
+          console.log('[QA_MAP] HurricaneMarker onLayout → tracksViewChanges false en 300ms');
+          setTimeout(() => setTracksViewChanges(false), 300);
+        }}
         style={{ width: 48, height: 48, borderRadius: 24, backgroundColor: color, borderWidth: 2, borderColor: 'white', alignItems: 'center', justifyContent: 'center' }}
       >
         <MaterialCommunityIcons name="weather-hurricane" size={28} color="white" />


### PR DESCRIPTION
## Cambios

- `[QA_NAV]` en alert detail: ahora muestra `lat` y `lon` reales en lugar del booleano `hasCoords`
- `[QA_MAP]` en HurricaneMarker: agrega log en `onLayout` para confirmar cuándo `tracksViewChanges` pasa a `false` y el bitmap queda fijo

## Por qué

Para poder leer el flujo completo alerta→mapa en logcat sin adivinar qué coords se pasan ni si el marker terminó de capturarse.