### PR TITLE
fix: correct SOS invite deep link scheme and expo-router screen name

### DIFF
--- a/backend/app/features/sos_invite/service.py
+++ b/backend/app/features/sos_invite/service.py
@@ -4,7 +4,7 @@ from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-DEEP_LINK_BASE = "blueeye://sos-invite"
+DEEP_LINK_BASE = "blueye://sos-invite"
 
 
 async def create_invite(

--- a/backend/app/features/sos_invite/tests/test_router.py
+++ b/backend/app/features/sos_invite/tests/test_router.py
@@ -14,7 +14,7 @@ FAKE_DB_USER = {"id": 42, "firebase_uid": "firebase-test-uid", "lat": None, "lon
                 "created_at": datetime.now(timezone.utc), "updated_at": datetime.now(timezone.utc)}
 
 _exp = datetime.now(timezone.utc) + timedelta(hours=72)
-INVITE_RESP   = {"share_url": "blueeye://sos-invite/abc123", "expires_at": _exp}
+INVITE_RESP   = {"share_url": "blueye://sos-invite/abc123", "expires_at": _exp}
 PREVIEW_RESP  = {"inviter_display_name": "Boro", "contact_name": "Mamá", "expires_at": _exp}
 ACCEPT_RESP   = {"inviter_display_name": "Boro", "contact_name": "Mamá"}
 
@@ -40,7 +40,7 @@ def test_create_invite_201():
          _mock_svc("app.features.sos_invite.router.create_invite", rv=INVITE_RESP):
         r = client.post("/api/v1/sos-contacts/1/invite", headers=AUTH_HEADERS)
     assert r.status_code == 201
-    assert r.json()["share_url"].startswith("blueeye://sos-invite/")
+    assert r.json()["share_url"].startswith("blueye://sos-invite/")
     assert "expires_at" in r.json()
 
 

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -352,7 +352,7 @@ export default Sentry.wrap(function Layout() {
                       options={{ headerShown: false }}
                     />
                     <Stack.Screen
-                      name="sos-invite"
+                      name="sos-invite/[token]"
                       options={{ headerShown: false }}
                     />
                     <Stack.Screen


### PR DESCRIPTION
## Bugs corregidos

**1. Scheme mismatch — deep link no abría la app**
El backend generaba `blueeye://sos-invite/{token}` pero `app.json` registra el scheme como `blueye`. Android no podía encontrar la app al tocar el link desde WhatsApp/SMS.
- `DEEP_LINK_BASE`: `blueeye://` → `blueye://`

**2. Stack.Screen mal nombrado — warning en expo-router**
`name="sos-invite"` no coincide con la ruta dinámica `app/sos-invite/[token].tsx`, generando el warning `No route named "sos-invite" exists in nested children` y bloqueando la navegación.
- `name="sos-invite"` → `name="sos-invite/[token]"`

## Tests
17/17 tests de sos_invite pasando.