### PR TITLE
Feat: SOS invite push notification

### DIFF
--- a/backend/app/features/sos_invite/schemas.py
+++ b/backend/app/features/sos_invite/schemas.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 class InviteCreateResponse(BaseModel):
     share_url: str
     expires_at: datetime
+    push_sent: bool = False
 
 
 class InvitePreviewResponse(BaseModel):

--- a/backend/app/features/sos_invite/service.py
+++ b/backend/app/features/sos_invite/service.py
@@ -1,8 +1,14 @@
+import logging
 import secrets
 
 from fastapi import HTTPException
+from firebase_admin import messaging
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.features.notifications.service import get_tokens_for_users, _send_multicast_with_retry
+
+logger = logging.getLogger(__name__)
 
 DEEP_LINK_BASE = "blueye://sos-invite"
 
@@ -14,7 +20,12 @@ async def create_invite(
     contact_id: int,
 ) -> dict:
     contact = await db.execute(
-        text("SELECT name, link_status, user_id FROM sos_contacts WHERE id = :id"),
+        text("""
+            SELECT sc.name, sc.link_status, sc.user_id, sc.phone, u.id AS invitee_user_id
+            FROM sos_contacts sc
+            LEFT JOIN users u ON u.phone = sc.phone
+            WHERE sc.id = :id
+        """),
         {"id": contact_id},
     )
     row = contact.mappings().first()
@@ -58,10 +69,61 @@ async def create_invite(
     await db.commit()
 
     inv = result.mappings().first()
+    invite_token = inv["token"]
+
+    push_sent = False
+    invitee_user_id = row["invitee_user_id"]
+    if invitee_user_id is not None:
+        push_sent = await _send_invite_push(
+            db,
+            invitee_user_id=int(invitee_user_id),
+            inviter_display_name=inviter_display_name or "Un usuario de BluEye",
+            contact_name=row["name"],
+            invite_token=invite_token,
+        )
+
     return {
-        "share_url": f"{DEEP_LINK_BASE}/{inv['token']}",
+        "share_url": f"{DEEP_LINK_BASE}/{invite_token}",
         "expires_at": inv["expires_at"],
+        "push_sent": push_sent,
     }
+
+
+async def _send_invite_push(
+    db: AsyncSession,
+    invitee_user_id: int,
+    inviter_display_name: str,
+    contact_name: str,
+    invite_token: str,
+) -> bool:
+    token_map = await get_tokens_for_users(db, [invitee_user_id])
+    tokens = token_map.get(invitee_user_id, [])
+    if not tokens:
+        return False
+
+    msg = messaging.MulticastMessage(
+        notification=messaging.Notification(
+            title=f"Invitación SOS de {inviter_display_name}",
+            body=f"Te invitan a ser contacto SOS de {inviter_display_name} en BluEye.",
+        ),
+        data={
+            "category":             "sos_invite",
+            "invite_token":         invite_token,
+            "inviter_display_name": inviter_display_name,
+            "contact_name":         contact_name,
+        },
+        tokens=tokens,
+    )
+    try:
+        response = await _send_multicast_with_retry(msg)
+        logger.info(
+            "SOS invite push → invitee_user_id=%d tokens=%d success=%d failure=%d",
+            invitee_user_id, len(tokens), response.success_count, response.failure_count,
+        )
+        return response.success_count > 0
+    except Exception as exc:
+        logger.error("SOS invite push failed invitee_user_id=%d: %s", invitee_user_id, exc)
+        return False
 
 
 async def get_invite_preview(db: AsyncSession, token: str) -> dict:

--- a/backend/app/features/sos_invite/tests/test_router.py
+++ b/backend/app/features/sos_invite/tests/test_router.py
@@ -14,7 +14,7 @@ FAKE_DB_USER = {"id": 42, "firebase_uid": "firebase-test-uid", "lat": None, "lon
                 "created_at": datetime.now(timezone.utc), "updated_at": datetime.now(timezone.utc)}
 
 _exp = datetime.now(timezone.utc) + timedelta(hours=72)
-INVITE_RESP   = {"share_url": "blueye://sos-invite/abc123", "expires_at": _exp}
+INVITE_RESP   = {"share_url": "blueye://sos-invite/abc123", "expires_at": _exp, "push_sent": False}
 PREVIEW_RESP  = {"inviter_display_name": "Boro", "contact_name": "Mamá", "expires_at": _exp}
 ACCEPT_RESP   = {"inviter_display_name": "Boro", "contact_name": "Mamá"}
 

--- a/backend/app/features/users/router.py
+++ b/backend/app/features/users/router.py
@@ -5,10 +5,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
 from app.core.auth import get_current_user
-from app.features.users.schemas import UserProfile, UserLocationUpdate
+from app.features.users.schemas import UserProfile, UserLocationUpdate, PhoneUpdate
 from app.features.users.service import (
     upsert_user,
     update_user_location,
+    update_user_phone,
     get_user_by_firebase_uid,
 )
 
@@ -33,6 +34,20 @@ async def get_my_profile(
 ):
     firebase_uid = user.get("uid")
     profile = await get_user_by_firebase_uid(db, firebase_uid)
+    if profile is None:
+        raise HTTPException(status_code=404, detail="Profile not found. Call POST /api/v1/users/me first.")
+    return profile
+
+
+@router.patch("/api/v1/users/me/phone", response_model=UserProfile)
+async def set_my_phone(
+    body: PhoneUpdate,
+    db: AsyncSession = Depends(get_db),
+    user=Depends(get_current_user),
+):
+    """Store the user's phone number so SOS invites can find them by phone."""
+    firebase_uid = user.get("uid")
+    profile = await update_user_phone(db, firebase_uid, body.phone)
     if profile is None:
         raise HTTPException(status_code=404, detail="Profile not found. Call POST /api/v1/users/me first.")
     return profile

--- a/backend/app/features/users/schemas.py
+++ b/backend/app/features/users/schemas.py
@@ -5,6 +5,7 @@ from datetime import datetime
 class UserProfile(BaseModel):
     id: int
     firebase_uid: str
+    phone: str | None
     lat: float | None
     lon: float | None
     created_at: datetime
@@ -14,3 +15,7 @@ class UserProfile(BaseModel):
 class UserLocationUpdate(BaseModel):
     lat: float
     lon: float
+
+
+class PhoneUpdate(BaseModel):
+    phone: str

--- a/backend/app/features/users/service.py
+++ b/backend/app/features/users/service.py
@@ -25,6 +25,19 @@ async def upsert_user(db: AsyncSession, firebase_uid: str) -> dict:
     return result.mappings().first()
 
 
+async def update_user_phone(db: AsyncSession, firebase_uid: str, phone: str) -> dict | None:
+    result = await db.execute(
+        text("""
+            UPDATE users SET phone = :phone, updated_at = NOW()
+            WHERE firebase_uid = :uid
+            RETURNING id, firebase_uid, phone, lat, lon, created_at, updated_at
+        """),
+        {"uid": firebase_uid, "phone": phone},
+    )
+    await db.commit()
+    return result.mappings().first()
+
+
 async def update_user_location(db: AsyncSession, firebase_uid: str, lat: float, lon: float) -> dict | None:
     result = await db.execute(
         text("""

--- a/backend/app/features/users/tests/test_router.py
+++ b/backend/app/features/users/tests/test_router.py
@@ -11,6 +11,7 @@ AUTH_HEADERS = {"Authorization": "Bearer faketoken"}
 FAKE_PROFILE = {
     "id": 1,
     "firebase_uid": "firebase-test-uid",
+    "phone": None,
     "lat": None,
     "lon": None,
     "created_at": datetime.now(timezone.utc),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -69,6 +69,9 @@ async def ensure_core_tables(engine: AsyncEngine) -> None:
         await conn.execute(text(
             "ALTER TABLE alerts ADD COLUMN IF NOT EXISTS pdf_url TEXT"
         ))
+        await conn.execute(text(
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS phone VARCHAR(30)"
+        ))
         await conn.execute(text('CREATE EXTENSION IF NOT EXISTS "pgcrypto"'))
         await conn.execute(text("""
             CREATE TABLE IF NOT EXISTS notification_preferences (

--- a/frontend/app/SOSContactsScreen.tsx
+++ b/frontend/app/SOSContactsScreen.tsx
@@ -4,6 +4,7 @@ import {
   View, Text, FlatList, Modal, TextInput, TouchableOpacity,
   Alert, ActivityIndicator, StyleSheet, KeyboardAvoidingView, Platform, Pressable, Share,
 } from "react-native";
+import { toast } from "sonner-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import ScreenHeader from "../components/ScreenHeader";
@@ -98,11 +99,17 @@ export default function SOSContactsScreen() {
     try {
       const res = await authFetch(`${API_BASE_URL}/api/v1/sos-contacts/${c.id}/invite`, { method: "POST" });
       if (!res.ok) throw new Error();
-      const { share_url } = await res.json();
+      const { share_url, push_sent } = await res.json();
       setContacts(prev => prev.map(x => x.id === c.id ? { ...x, link_status: "invite_sent" } : x));
-      await Share.share({
-        message: `Te invito a ser mi contacto SOS de emergencia en BluEye.\nToca aquí para aceptar: ${share_url}`,
-      });
+      if (push_sent) {
+        toast.success("Notificación enviada", {
+          description: `${c.name} recibirá una notificación para aceptar la invitación.`,
+        });
+      } else {
+        await Share.share({
+          message: `Te invito a ser mi contacto SOS de emergencia en BluEye.\nToca aquí para aceptar: ${share_url}`,
+        });
+      }
     } catch {
       Alert.alert("Error", "No se pudo generar la invitación. Intenta de nuevo.");
     }

--- a/frontend/app/SettingsScreen.tsx
+++ b/frontend/app/SettingsScreen.tsx
@@ -1,6 +1,6 @@
 import "../global.css";
 import { clearOnboardingData } from './onboarding/_services/onboardingService';
-import { Alert, Text, ScrollView, ActivityIndicator } from "react-native";
+import { Alert, Text, ScrollView, ActivityIndicator, TextInput, View, TouchableOpacity, StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
@@ -10,10 +10,41 @@ import { MODEL_FAILURE_LABEL } from "./ai/_services/modelTelemetry";
 import { useAuth } from "../features/auth/AuthContext";
 import ScreenHeader from "../components/ScreenHeader";
 import OptionCard from "../components/OptionCard";
+import { useState } from "react";
+import { authFetch } from "../utils/api";
+import { API_BASE_URL } from "../utils/config";
+import { colors, fonts } from "../utils/theme";
+import { toast } from "sonner-native";
+
 export default function SettingsScreen() {
   const router = useRouter();
   const { modelStatus, optIn, optOut, retryDownload, downloadProgress, modelFailure } = useModel();
   const { signOut, deleteAccount } = useAuth();
+  const [phone, setPhone] = useState("");
+  const [savingPhone, setSavingPhone] = useState(false);
+
+  const handleSavePhone = async () => {
+    const p = phone.trim();
+    if (!p || p.length < 5) {
+      Alert.alert("Teléfono inválido", "Ingresa un número con al menos 5 dígitos.");
+      return;
+    }
+    setSavingPhone(true);
+    try {
+      const res = await authFetch(`${API_BASE_URL}/api/v1/users/me/phone`, {
+        method: "PATCH",
+        body: JSON.stringify({ phone: p }),
+      });
+      if (!res.ok) throw new Error();
+      toast.success("Teléfono guardado", {
+        description: "Los contactos SOS podrán encontrarte por este número.",
+      });
+    } catch {
+      Alert.alert("Error", "No se pudo guardar el teléfono. Intenta de nuevo.");
+    } finally {
+      setSavingPhone(false);
+    }
+  };
 
   const handleDeleteAccount = () => {
     Alert.alert(
@@ -46,9 +77,6 @@ export default function SettingsScreen() {
       ]
     );
   };
-
-  const showComingSoon = () =>
-    Alert.alert("¡Próximamente!", "Esta opción estará disponible muy pronto.");
 
   const handleResetOnboarding = async () => {
     Alert.alert(
@@ -105,18 +133,39 @@ export default function SettingsScreen() {
           onPress={() => router.push('/NotificationPreferencesScreen')}
         />
 
-        {/* <OptionCard icon="account-outline" title="Cuenta" onPress={showComingSoon} /> */}
-
         <OptionCard icon="restore" title="Reiniciar Onboarding" onPress={handleResetOnboarding} />
 
-        {/* <OptionCard
-          icon="alert-outline"
-          title="Ver Alerta de Emergencia"
-          onPress={() => {
-            track('demo_alarm_view');
-            router.push('/AlarmScreen');
-          }}
-        /> */}
+        {/* Phone for SOS invite lookup */}
+        <View style={s.phoneCard}>
+          <View style={s.phoneHeader}>
+            <MaterialCommunityIcons name="phone-outline" size={22} color={colors.brandCyan} />
+            <Text style={s.phoneTitle}>Mi número de teléfono</Text>
+          </View>
+          <Text style={s.phoneSubtitle}>
+            Para recibir invitaciones SOS directamente en la app.
+          </Text>
+          <View style={s.phoneRow}>
+            <TextInput
+              style={s.phoneInput}
+              placeholder="+52 999 123 4567"
+              placeholderTextColor="rgba(255,255,255,0.3)"
+              value={phone}
+              onChangeText={setPhone}
+              keyboardType="phone-pad"
+              maxLength={30}
+              editable={!savingPhone}
+            />
+            <TouchableOpacity
+              style={[s.saveBtn, savingPhone && { opacity: 0.6 }]}
+              onPress={handleSavePhone}
+              disabled={savingPhone}
+            >
+              {savingPhone
+                ? <ActivityIndicator size="small" color="#030810" />
+                : <Text style={s.saveBtnText}>Guardar</Text>}
+            </TouchableOpacity>
+          </View>
+        </View>
 
         {/* AI offline model — one card per lifecycle status (single source of truth). */}
         {modelStatus === 'idle' && (
@@ -193,3 +242,60 @@ export default function SettingsScreen() {
     </SafeAreaView>
   );
 }
+
+const s = StyleSheet.create({
+  phoneCard: {
+    backgroundColor: "rgba(10,28,50,0.6)",
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.1)",
+    marginHorizontal: 16,
+    marginBottom: 12,
+    padding: 16,
+  },
+  phoneHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    marginBottom: 4,
+  },
+  phoneTitle: {
+    color: "white",
+    fontFamily: fonts.poppinsSemiBold,
+    fontSize: 15,
+  },
+  phoneSubtitle: {
+    color: "rgba(255,255,255,0.5)",
+    fontFamily: fonts.poppins,
+    fontSize: 12,
+    marginBottom: 12,
+  },
+  phoneRow: {
+    flexDirection: "row",
+    gap: 10,
+  },
+  phoneInput: {
+    flex: 1,
+    backgroundColor: "rgba(255,255,255,0.07)",
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.12)",
+    color: "white",
+    fontFamily: fonts.poppins,
+    fontSize: 15,
+    paddingHorizontal: 14,
+    paddingVertical: 11,
+  },
+  saveBtn: {
+    backgroundColor: colors.brandCyan,
+    borderRadius: 10,
+    paddingHorizontal: 18,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  saveBtnText: {
+    color: "#030810",
+    fontFamily: fonts.poppinsSemiBold,
+    fontSize: 14,
+  },
+});

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -70,6 +70,8 @@ interface NotificationData {
   sender_name?: string
   lat?: string
   lon?: string
+  invite_token?: string
+  inviter_display_name?: string
 }
 
 function resolveNotifPayload(
@@ -80,6 +82,7 @@ function resolveNotifPayload(
   const levelNum = Number(data.level ?? data.siat_level ?? data.alertLevel ?? 0)
   const isFullScreen = data.fullScreen === 'true' || levelNum >= 4
   const isSos = data.category === 'sos'
+  const isSosInvite = data.category === 'sos_invite'
   const sosLat = parseFloat(data.lat ?? '')
   const sosLon = parseFloat(data.lon ?? '')
   const sosHasCoords = Number.isFinite(sosLat) && Number.isFinite(sosLon)
@@ -88,6 +91,9 @@ function resolveNotifPayload(
     levelNum,
     isFullScreen,
     isSos,
+    isSosInvite,
+    inviteToken: data.invite_token,
+    inviterDisplayName: data.inviter_display_name ?? 'Un usuario',
     senderName: data.sender_name ?? 'Un contacto',
     sosLat,
     sosLon,
@@ -173,17 +179,22 @@ export default Sentry.wrap(function Layout() {
     // Tap en notificación (background → foreground, o foreground tap)
     const tapSub = addNotificationResponseListener(async (rawData, content) => {
       const data = rawData as NotificationData
-      const { id, isFullScreen, isSos, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data, content)
-      console.log('[QA_NOTIF] tap | alertId:', id ?? 'none', '| fullScreen:', isFullScreen, '| sos:', isSos)
+      const { id, isFullScreen, isSos, isSosInvite, inviteToken, inviterDisplayName, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data, content)
+      console.log('[QA_NOTIF] tap | alertId:', id ?? 'none', '| fullScreen:', isFullScreen, '| sos:', isSos, '| sosInvite:', isSosInvite)
 
       await initAnalytics();
       track("push_open", {
         alertId: id ? String(id) : undefined,
-        alertLevel: isSos ? undefined : (params.category ? Number(params.category) : undefined),
+        alertLevel: isSos || isSosInvite ? undefined : (params.category ? Number(params.category) : undefined),
         fullScreen: isFullScreen,
         origin: "listener",
       });
 
+      if (isSosInvite && inviteToken) {
+        console.log('[QA_NAV] tap → sos-invite | token:', inviteToken)
+        router.push({ pathname: "/sos-invite/[token]", params: { token: inviteToken } });
+        return;
+      }
       if (isSos) {
         const coordsText = sosHasCoords ? `\nUbicación: ${sosLat.toFixed(5)}, ${sosLon.toFixed(5)}` : '';
         Alert.alert('SOS recibido', `${senderName} necesita ayuda urgente.${coordsText}`);
@@ -205,14 +216,24 @@ export default Sentry.wrap(function Layout() {
     const receivedSub = Notifications.addNotificationReceivedListener((notification) => {
       const rawData = notification.request.content.data as NotificationData
       const content = notification.request.content
-      const { isFullScreen, isSos, senderName, params } = resolveNotifPayload(rawData, content)
-      console.log('[QA_NOTIF] received foreground | fullScreen:', isFullScreen, '| sos:', isSos, '| category:', params.category)
+      const { isFullScreen, isSos, isSosInvite, inviteToken, inviterDisplayName, senderName, params } = resolveNotifPayload(rawData, content)
+      console.log('[QA_NOTIF] received foreground | fullScreen:', isFullScreen, '| sos:', isSos, '| sosInvite:', isSosInvite, '| category:', params.category)
       if (isFullScreen && !alarmActiveRef.current) {
         alarmActiveRef.current = true
         console.log('[QA_NAV] received → AlarmScreen | category:', params.category, '| alertId:', params.alertId ?? 'none')
         router.push({ pathname: "AlarmScreen", params })
         // Liberar el guard después de un debounce para cubrir multi-push
         setTimeout(() => { alarmActiveRef.current = false }, 5000)
+        return;
+      }
+      if (isSosInvite && inviteToken) {
+        toast(`Invitación SOS de ${inviterDisplayName}`, {
+          description: 'Toca para aceptar la invitación.',
+          action: {
+            label: 'Ver',
+            onClick: () => router.push({ pathname: "/sos-invite/[token]", params: { token: inviteToken } }),
+          },
+        });
         return;
       }
       if (isSos) {
@@ -248,17 +269,22 @@ export default Sentry.wrap(function Layout() {
       if (!data) return
       const { title: coldTitle, body: coldBody } = initial.notification.request.content
 
-      const { id, isFullScreen, isSos, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data, { title: coldTitle, body: coldBody })
-      if (!id && !isFullScreen && !isSos) return
+      const { id, isFullScreen, isSos, isSosInvite, inviteToken, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data, { title: coldTitle, body: coldBody })
+      if (!id && !isFullScreen && !isSos && !isSosInvite) return
 
       await initAnalytics();
       track("push_open", {
         alertId: id ? String(id) : undefined,
-        alertLevel: isSos ? undefined : (params.category ? Number(params.category) : undefined),
+        alertLevel: isSos || isSosInvite ? undefined : (params.category ? Number(params.category) : undefined),
         fullScreen: isFullScreen,
         origin: "initial",
       });
 
+      if (isSosInvite && inviteToken) {
+        console.log('[QA_NAV] cold start → sos-invite | token:', inviteToken)
+        router.push({ pathname: "/sos-invite/[token]", params: { token: inviteToken } });
+        return;
+      }
       if (isSos) {
         const coordsText = sosHasCoords ? `\nUbicación: ${sosLat.toFixed(5)}, ${sosLon.toFixed(5)}` : '';
         Alert.alert('SOS recibido', `${senderName} necesita ayuda urgente.${coordsText}`);


### PR DESCRIPTION
## Qué hace

Cuando el contacto SOS invitado ya tiene la app instalada y guardó su número de teléfono, le llega una notificación push directamente en lugar de depender del link de WhatsApp.

## Cambios

**Backend:**
- `users` table: nuevo campo `phone VARCHAR(30)` (ALTER TABLE … ADD COLUMN IF NOT EXISTS — se aplica en el próximo boot de Railway)
- `PATCH /api/v1/users/me/phone` — endpoint para que cada usuario guarde su número
- `sos_invite/service.py`: al crear el invite, hace LEFT JOIN entre `users.phone` y `sos_contacts.phone`. Si hay match → envía FCM push con `category: "sos_invite"`, `invite_token`, `inviter_display_name`. Devuelve `push_sent: bool`

**Frontend:**
- `SettingsScreen`: campo de número de teléfono que llama al nuevo endpoint
- `_layout.tsx`: maneja `category === "sos_invite"` en tap/cold-start (→ navega a `sos-invite/[token]`) y en foreground (→ toast con botón "Ver")
- `SOSContactsScreen`: si `push_sent: true` → toast de éxito; si `push_sent: false` → share sheet de WhatsApp (fallback)

## Flujo

1. Usuario B guarda su teléfono en Ajustes → `PATCH /api/v1/users/me/phone`
2. Usuario A agrega a B como contacto SOS con ese número
3. A toca "Invitar" → backend detecta match → FCM push a B
4. B toca la notificación → app abre pantalla de aceptar invitación
5. Si B no tiene la app (sin token FCM) → cae al share sheet

## Tests

150/150 backend tests passing