### PR TITLE
Feat: phone in onboarding, profile screen, SOS bidirectionality

### DIFF
--- a/backend/app/features/sos_contacts/router.py
+++ b/backend/app/features/sos_contacts/router.py
@@ -4,10 +4,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.auth import get_current_user
 from app.core.database import get_db
 from app.features.users.service import get_user_by_firebase_uid
-from app.features.sos_contacts.schemas import SOSContactCreate, SOSContactResponse, SOSContactUpdate
+from app.features.sos_contacts.schemas import SOSContactCreate, SOSContactResponse, SOSContactUpdate, WhoHasMeItem
 from app.features.sos_contacts.service import (
     create_sos_contact,
     delete_sos_contact,
+    get_who_has_me,
     list_sos_contacts,
     update_sos_contact,
 )
@@ -39,6 +40,15 @@ async def post_sos_contact(
 ):
     user_id = await _get_user_id(db, user)
     return await create_sos_contact(db, user_id, body)
+
+
+@router.get("/api/v1/sos-contacts/who-has-me", response_model=list[WhoHasMeItem])
+async def get_who_has_me_route(
+    db: AsyncSession = Depends(get_db),
+    user=Depends(get_current_user),
+):
+    user_id = await _get_user_id(db, user)
+    return await get_who_has_me(db, user_id)
 
 
 @router.patch("/api/v1/sos-contacts/{contact_id}", response_model=SOSContactResponse)

--- a/backend/app/features/sos_contacts/schemas.py
+++ b/backend/app/features/sos_contacts/schemas.py
@@ -24,3 +24,10 @@ class SOSContactResponse(BaseModel):
     link_status: str
     created_at: datetime
     updated_at: datetime
+
+
+class WhoHasMeItem(BaseModel):
+    name: str
+    relationship: str | None
+    owner_display_name: str | None
+    created_at: datetime

--- a/backend/app/features/sos_contacts/service.py
+++ b/backend/app/features/sos_contacts/service.py
@@ -78,6 +78,21 @@ async def delete_sos_contact(db: AsyncSession, contact_id: int, user_id: int) ->
     await _raise_not_found_or_forbidden(db, contact_id, user_id)
 
 
+async def get_who_has_me(db: AsyncSession, user_id: int) -> list[dict]:
+    result = await db.execute(
+        text("""
+            SELECT sc.name, sc.relationship, sc.created_at,
+                   u.display_name AS owner_display_name
+            FROM sos_contacts sc
+            JOIN users u ON u.id = sc.user_id
+            WHERE sc.linked_user_id = :user_id AND sc.link_status = 'linked'
+            ORDER BY sc.created_at ASC
+        """),
+        {"user_id": user_id},
+    )
+    return [dict(row) for row in result.mappings().all()]
+
+
 async def _get_contact_owned_by(db: AsyncSession, contact_id: int, user_id: int) -> dict:
     result = await db.execute(
         text("""

--- a/backend/app/features/users/router.py
+++ b/backend/app/features/users/router.py
@@ -24,7 +24,7 @@ async def register_or_get_profile(
 ):
     """Create or update user profile from Firebase token. Idempotent."""
     firebase_uid = user.get("uid")
-    return await upsert_user(db, firebase_uid)
+    return await upsert_user(db, firebase_uid, display_name=user.get("name"), email=user.get("email"))
 
 
 @router.get("/api/v1/users/me", response_model=UserProfile)

--- a/backend/app/features/users/schemas.py
+++ b/backend/app/features/users/schemas.py
@@ -5,6 +5,8 @@ from datetime import datetime
 class UserProfile(BaseModel):
     id: int
     firebase_uid: str
+    display_name: str | None
+    email: str | None
     phone: str | None
     lat: float | None
     lon: float | None

--- a/backend/app/features/users/service.py
+++ b/backend/app/features/users/service.py
@@ -1,25 +1,35 @@
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+_ALL_FIELDS = "id, firebase_uid, display_name, email, phone, lat, lon, created_at, updated_at"
+
 
 async def get_user_by_firebase_uid(db: AsyncSession, firebase_uid: str) -> dict | None:
     result = await db.execute(
-        text("SELECT * FROM users WHERE firebase_uid = :uid LIMIT 1"),
+        text(f"SELECT {_ALL_FIELDS} FROM users WHERE firebase_uid = :uid LIMIT 1"),
         {"uid": firebase_uid},
     )
     return result.mappings().first()
 
 
-async def upsert_user(db: AsyncSession, firebase_uid: str) -> dict:
-    """Create user profile if not exists, return the user row."""
+async def upsert_user(
+    db: AsyncSession,
+    firebase_uid: str,
+    display_name: str | None = None,
+    email: str | None = None,
+) -> dict:
+    """Create or update user profile from Firebase token. Idempotent."""
     result = await db.execute(
-        text("""
-            INSERT INTO users (firebase_uid)
-            VALUES (:uid)
-            ON CONFLICT (firebase_uid) DO UPDATE SET updated_at = NOW()
-            RETURNING id, firebase_uid, lat, lon, created_at, updated_at
+        text(f"""
+            INSERT INTO users (firebase_uid, display_name, email)
+            VALUES (:uid, :display_name, :email)
+            ON CONFLICT (firebase_uid) DO UPDATE
+                SET updated_at    = NOW(),
+                    display_name  = COALESCE(EXCLUDED.display_name, users.display_name),
+                    email         = COALESCE(EXCLUDED.email, users.email)
+            RETURNING {_ALL_FIELDS}
         """),
-        {"uid": firebase_uid},
+        {"uid": firebase_uid, "display_name": display_name, "email": email},
     )
     await db.commit()
     return result.mappings().first()
@@ -27,10 +37,10 @@ async def upsert_user(db: AsyncSession, firebase_uid: str) -> dict:
 
 async def update_user_phone(db: AsyncSession, firebase_uid: str, phone: str) -> dict | None:
     result = await db.execute(
-        text("""
+        text(f"""
             UPDATE users SET phone = :phone, updated_at = NOW()
             WHERE firebase_uid = :uid
-            RETURNING id, firebase_uid, phone, lat, lon, created_at, updated_at
+            RETURNING {_ALL_FIELDS}
         """),
         {"uid": firebase_uid, "phone": phone},
     )
@@ -40,10 +50,10 @@ async def update_user_phone(db: AsyncSession, firebase_uid: str, phone: str) -> 
 
 async def update_user_location(db: AsyncSession, firebase_uid: str, lat: float, lon: float) -> dict | None:
     result = await db.execute(
-        text("""
+        text(f"""
             UPDATE users SET lat = :lat, lon = :lon, updated_at = NOW()
             WHERE firebase_uid = :uid
-            RETURNING id, firebase_uid, lat, lon, created_at, updated_at
+            RETURNING {_ALL_FIELDS}
         """),
         {"uid": firebase_uid, "lat": lat, "lon": lon},
     )

--- a/backend/app/features/users/tests/test_router.py
+++ b/backend/app/features/users/tests/test_router.py
@@ -11,6 +11,8 @@ AUTH_HEADERS = {"Authorization": "Bearer faketoken"}
 FAKE_PROFILE = {
     "id": 1,
     "firebase_uid": "firebase-test-uid",
+    "display_name": None,
+    "email": None,
     "phone": None,
     "lat": None,
     "lon": None,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -72,6 +72,12 @@ async def ensure_core_tables(engine: AsyncEngine) -> None:
         await conn.execute(text(
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS phone VARCHAR(30)"
         ))
+        await conn.execute(text(
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS display_name VARCHAR(255)"
+        ))
+        await conn.execute(text(
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS email VARCHAR(255)"
+        ))
         await conn.execute(text('CREATE EXTENSION IF NOT EXISTS "pgcrypto"'))
         await conn.execute(text("""
             CREATE TABLE IF NOT EXISTS notification_preferences (

--- a/frontend/app/(tabs)/MoreScreen.tsx
+++ b/frontend/app/(tabs)/MoreScreen.tsx
@@ -18,6 +18,7 @@ type MenuItem = {
 
 export default function MoreScreen() {
   const items: MenuItem[] = [
+    { label: "Mi Perfil", icon: "account-circle-outline", route: "/profile" },
     { label: "Chat offline", icon: "access-point-network", route: "/local-chat" },
     { label: "Contactos SOS", icon: "account-heart-outline", route: "/SOSContactsScreen" },
     { label: "Feedback", icon: "message-reply-outline", route: "/FeedbackScreen" },

--- a/frontend/app/SOSContactsScreen.tsx
+++ b/frontend/app/SOSContactsScreen.tsx
@@ -23,6 +23,13 @@ interface SOSContact {
   created_at: string; updated_at: string;
 }
 
+interface WhoHasMeItem {
+  name: string;
+  relationship: string | null;
+  owner_display_name: string | null;
+  created_at: string;
+}
+
 export default function SOSContactsScreen() {
   const router = useRouter();
   const [contacts, setContacts]             = useState<SOSContact[]>([]);
@@ -36,6 +43,7 @@ export default function SOSContactsScreen() {
   const [relVal, setRelVal]                 = useState("");
   const [formError, setFormError]           = useState<string | null>(null);
   const [pendingInviteToken, setPendingInviteToken] = useState<string | null>(null);
+  const [whoHasMe, setWhoHasMe]             = useState<WhoHasMeItem[]>([]);
 
   useEffect(() => {
     let live = true;
@@ -45,6 +53,13 @@ export default function SOSContactsScreen() {
       .catch(() => { if (live) setFetchError(true); })
       .finally(() => { if (live) setLoading(false); });
     return () => { live = false; };
+  }, []);
+
+  useEffect(() => {
+    authFetch(`${API_BASE_URL}/api/v1/sos-contacts/who-has-me`)
+      .then(r => r.ok ? r.json() : Promise.reject())
+      .then((data: WhoHasMeItem[]) => setWhoHasMe(data))
+      .catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -147,6 +162,25 @@ export default function SOSContactsScreen() {
     </SafeAreaView>
   );
 
+  const whoHasMeSection = whoHasMe.length > 0 ? (
+    <View style={{ paddingBottom: 24, paddingHorizontal: 16 }}>
+      <Text style={s.sectionTitle}>Soy contacto SOS de</Text>
+      {whoHasMe.map((item, idx) => (
+        <View key={idx} style={s.whoRow}>
+          <MaterialCommunityIcons name="shield-account-outline" size={32} color={colors.brandCyan} />
+          <View style={{ flex: 1, marginLeft: 12 }}>
+            <Text style={s.contactName}>
+              {item.owner_display_name ?? item.name}
+            </Text>
+            {item.relationship
+              ? <Text style={s.contactRel}>{item.relationship}</Text>
+              : null}
+          </View>
+        </View>
+      ))}
+    </View>
+  ) : null;
+
   return (
     <SafeAreaView className="flex-1 bg-transparent" edges={["top", "bottom"]}>
       <ScreenHeader title="Contactos SOS" />
@@ -170,22 +204,33 @@ export default function SOSContactsScreen() {
       )}
 
       {contacts.length === 0 ? (
-        <View style={s.centered}><View style={s.card}>
-          <MaterialCommunityIcons name="account-heart-outline" size={48} color={colors.brandCyan} />
-          <Text style={[s.title, { marginTop: 12, marginBottom: 6 }]}>Sin contactos SOS</Text>
-          <Text style={[s.bodyText, { textAlign: "center", marginBottom: 20 }]}>
-            Agrega personas de confianza que recibirán tu alerta en caso de emergencia.
-          </Text>
-          <TouchableOpacity style={s.cyanButton} onPress={openCreate}>
-            <Text style={s.cyanButtonText}>Agregar contacto</Text>
-          </TouchableOpacity>
-        </View></View>
+        <FlatList
+          data={[]}
+          renderItem={null}
+          ListEmptyComponent={
+            <View style={[s.centered, { paddingTop: 40 }]}>
+              <View style={s.card}>
+                <MaterialCommunityIcons name="account-heart-outline" size={48} color={colors.brandCyan} />
+                <Text style={[s.title, { marginTop: 12, marginBottom: 6 }]}>Sin contactos SOS</Text>
+                <Text style={[s.bodyText, { textAlign: "center", marginBottom: 20 }]}>
+                  Agrega personas de confianza que recibirán tu alerta en caso de emergencia.
+                </Text>
+                <TouchableOpacity style={s.cyanButton} onPress={openCreate}>
+                  <Text style={s.cyanButtonText}>Agregar contacto</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          }
+          ListFooterComponent={whoHasMeSection}
+          contentContainerStyle={{ flexGrow: 1 }}
+        />
       ) : (
         <View style={{ flex: 1 }}>
           <FlatList
             data={contacts}
             keyExtractor={item => String(item.id)}
             contentContainerStyle={{ paddingTop: 16, paddingBottom: 100 }}
+            ListFooterComponent={whoHasMeSection}
             renderItem={({ item }) => (
               <View style={s.contactRow}>
                 <MaterialCommunityIcons name="account-circle-outline" size={36} color={colors.brandCyan} />
@@ -273,7 +318,7 @@ export default function SOSContactsScreen() {
 }
 
 const s = StyleSheet.create({
-  centered:     { flex: 1, justifyContent: "center", alignItems: "center", paddingHorizontal: 24 },
+  centered:     { justifyContent: "center", alignItems: "center", paddingHorizontal: 24 },
   card:         { backgroundColor: "rgba(10,28,50,0.6)", borderRadius: 16, borderWidth: 1,
                   borderColor: "rgba(255,255,255,0.1)", padding: 24, width: "100%", alignItems: "center" },
   title:        { color: "white", fontFamily: fonts.poppinsSemiBold, fontSize: 17 },
@@ -281,8 +326,13 @@ const s = StyleSheet.create({
   cyanButton:   { backgroundColor: colors.brandCyan, borderRadius: 12,
                   paddingVertical: 13, paddingHorizontal: 24, alignItems: "center" },
   cyanButtonText: { color: "#030810", fontFamily: fonts.poppinsSemiBold, fontSize: 15 },
+  sectionTitle: { color: "rgba(255,255,255,0.5)", fontFamily: fonts.poppins, fontSize: 12,
+                  letterSpacing: 0.8, textTransform: "uppercase", marginBottom: 8, marginTop: 16 },
   contactRow:   { backgroundColor: "rgba(10,28,50,0.6)", borderRadius: 14, borderWidth: 1,
                   borderColor: "rgba(255,255,255,0.08)", marginHorizontal: 16, marginBottom: 10,
+                  padding: 14, flexDirection: "row", alignItems: "center" },
+  whoRow:       { backgroundColor: "rgba(10,28,50,0.4)", borderRadius: 14, borderWidth: 1,
+                  borderColor: "rgba(255,255,255,0.06)", marginBottom: 10,
                   padding: 14, flexDirection: "row", alignItems: "center" },
   contactName:  { color: "white", fontFamily: fonts.poppinsSemiBold, fontSize: 15 },
   contactPhone: { color: "rgba(255,255,255,0.6)", fontFamily: fonts.poppins, fontSize: 13, marginTop: 2 },

--- a/frontend/app/SettingsScreen.tsx
+++ b/frontend/app/SettingsScreen.tsx
@@ -1,50 +1,19 @@
 import "../global.css";
 import { clearOnboardingData } from './onboarding/_services/onboardingService';
-import { Alert, Text, ScrollView, ActivityIndicator, TextInput, View, TouchableOpacity, StyleSheet } from "react-native";
+import { Alert, Text, ScrollView, ActivityIndicator } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
-import { track } from "../utils/analytics";
 import { useModel } from "./ai/_context/ModelContext";
 import { MODEL_FAILURE_LABEL } from "./ai/_services/modelTelemetry";
 import { useAuth } from "../features/auth/AuthContext";
 import ScreenHeader from "../components/ScreenHeader";
 import OptionCard from "../components/OptionCard";
-import { useState } from "react";
-import { authFetch } from "../utils/api";
-import { API_BASE_URL } from "../utils/config";
-import { colors, fonts } from "../utils/theme";
-import { toast } from "sonner-native";
 
 export default function SettingsScreen() {
   const router = useRouter();
   const { modelStatus, optIn, optOut, retryDownload, downloadProgress, modelFailure } = useModel();
   const { signOut, deleteAccount } = useAuth();
-  const [phone, setPhone] = useState("");
-  const [savingPhone, setSavingPhone] = useState(false);
-
-  const handleSavePhone = async () => {
-    const p = phone.trim();
-    if (!p || p.length < 5) {
-      Alert.alert("Teléfono inválido", "Ingresa un número con al menos 5 dígitos.");
-      return;
-    }
-    setSavingPhone(true);
-    try {
-      const res = await authFetch(`${API_BASE_URL}/api/v1/users/me/phone`, {
-        method: "PATCH",
-        body: JSON.stringify({ phone: p }),
-      });
-      if (!res.ok) throw new Error();
-      toast.success("Teléfono guardado", {
-        description: "Los contactos SOS podrán encontrarte por este número.",
-      });
-    } catch {
-      Alert.alert("Error", "No se pudo guardar el teléfono. Intenta de nuevo.");
-    } finally {
-      setSavingPhone(false);
-    }
-  };
 
   const handleDeleteAccount = () => {
     Alert.alert(
@@ -135,38 +104,6 @@ export default function SettingsScreen() {
 
         <OptionCard icon="restore" title="Reiniciar Onboarding" onPress={handleResetOnboarding} />
 
-        {/* Phone for SOS invite lookup */}
-        <View style={s.phoneCard}>
-          <View style={s.phoneHeader}>
-            <MaterialCommunityIcons name="phone-outline" size={22} color={colors.brandCyan} />
-            <Text style={s.phoneTitle}>Mi número de teléfono</Text>
-          </View>
-          <Text style={s.phoneSubtitle}>
-            Para recibir invitaciones SOS directamente en la app.
-          </Text>
-          <View style={s.phoneRow}>
-            <TextInput
-              style={s.phoneInput}
-              placeholder="+52 999 123 4567"
-              placeholderTextColor="rgba(255,255,255,0.3)"
-              value={phone}
-              onChangeText={setPhone}
-              keyboardType="phone-pad"
-              maxLength={30}
-              editable={!savingPhone}
-            />
-            <TouchableOpacity
-              style={[s.saveBtn, savingPhone && { opacity: 0.6 }]}
-              onPress={handleSavePhone}
-              disabled={savingPhone}
-            >
-              {savingPhone
-                ? <ActivityIndicator size="small" color="#030810" />
-                : <Text style={s.saveBtnText}>Guardar</Text>}
-            </TouchableOpacity>
-          </View>
-        </View>
-
         {/* AI offline model — one card per lifecycle status (single source of truth). */}
         {modelStatus === 'idle' && (
           <OptionCard icon="chip" title="Activar modo sin conexión" onPress={handleDownloadModel} />
@@ -243,59 +180,3 @@ export default function SettingsScreen() {
   );
 }
 
-const s = StyleSheet.create({
-  phoneCard: {
-    backgroundColor: "rgba(10,28,50,0.6)",
-    borderRadius: 16,
-    borderWidth: 1,
-    borderColor: "rgba(255,255,255,0.1)",
-    marginHorizontal: 16,
-    marginBottom: 12,
-    padding: 16,
-  },
-  phoneHeader: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 10,
-    marginBottom: 4,
-  },
-  phoneTitle: {
-    color: "white",
-    fontFamily: fonts.poppinsSemiBold,
-    fontSize: 15,
-  },
-  phoneSubtitle: {
-    color: "rgba(255,255,255,0.5)",
-    fontFamily: fonts.poppins,
-    fontSize: 12,
-    marginBottom: 12,
-  },
-  phoneRow: {
-    flexDirection: "row",
-    gap: 10,
-  },
-  phoneInput: {
-    flex: 1,
-    backgroundColor: "rgba(255,255,255,0.07)",
-    borderRadius: 10,
-    borderWidth: 1,
-    borderColor: "rgba(255,255,255,0.12)",
-    color: "white",
-    fontFamily: fonts.poppins,
-    fontSize: 15,
-    paddingHorizontal: 14,
-    paddingVertical: 11,
-  },
-  saveBtn: {
-    backgroundColor: colors.brandCyan,
-    borderRadius: 10,
-    paddingHorizontal: 18,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  saveBtnText: {
-    color: "#030810",
-    fontFamily: fonts.poppinsSemiBold,
-    fontSize: 14,
-  },
-});

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -410,6 +410,10 @@ export default Sentry.wrap(function Layout() {
                       name="subscription"
                       options={{ headerShown: false }}
                     />
+                    <Stack.Screen
+                      name="profile"
+                      options={{ headerShown: false }}
+                    />
                   </Stack>
                   <Toaster />
                   </LinearGradient>

--- a/frontend/app/onboarding/_context/OnboardingContext.tsx
+++ b/frontend/app/onboarding/_context/OnboardingContext.tsx
@@ -3,10 +3,13 @@ import { useRouter } from 'expo-router';
 import type { OnboardingData, OnboardingContextValue } from '../_types';
 import { saveOnboardingData } from '../_services/onboardingService';
 import { track } from '../../../utils/analytics';
+import { authFetch } from '../../../utils/api';
+import { API_BASE_URL } from '../../../utils/config';
 
 const initialData: OnboardingData = {
   firstName: '',
   lastName: '',
+  phone: '',
   address1: '',
   address2: '',
   zipCode: '',
@@ -33,6 +36,12 @@ export const OnboardingProvider: React.FC<{ children: ReactNode }> = ({ children
   const submitOnboarding = async () => {
     try {
       await saveOnboardingData(data);
+      if (data.phone?.trim()) {
+        authFetch(`${API_BASE_URL}/api/v1/users/me/phone`, {
+          method: 'PATCH',
+          body: JSON.stringify({ phone: data.phone.trim() }),
+        }).catch(() => {});
+      }
       track('onboarding_completed', {
         nervousness_level: data.nervousnessLevel,
         age_range: data.age,

--- a/frontend/app/onboarding/_screens/Step1Screen.tsx
+++ b/frontend/app/onboarding/_screens/Step1Screen.tsx
@@ -160,8 +160,19 @@ export const Step1Screen: React.FC = () => {
           </View>
         </View>
 
+        <FormInput
+          label="Teléfono (opcional)"
+          value={data.phone ?? ''}
+          onChangeText={(value) => updateField('phone', value)}
+          placeholder="+52 999 123 4567"
+          keyboardType="phone-pad"
+          autoComplete="tel"
+          textContentType="telephoneNumber"
+          maxLength={30}
+        />
+
         <Text className="text-xs text-white/60 mt-1">
-          Usaremos tu nombre para personalizar las alertas
+          Usaremos tu nombre para personalizar las alertas. El teléfono permite recibir invitaciones SOS.
         </Text>
       </View>
 

--- a/frontend/app/onboarding/_types.ts
+++ b/frontend/app/onboarding/_types.ts
@@ -6,6 +6,7 @@
 export interface OnboardingData {
     firstName: string;
     lastName: string;
+    phone?: string;
     address1: string;
     address2?: string;
     zipCode: string;

--- a/frontend/app/profile/index.tsx
+++ b/frontend/app/profile/index.tsx
@@ -1,0 +1,199 @@
+import "../../global.css";
+import { useState, useEffect } from "react";
+import {
+  View, Text, TextInput, TouchableOpacity, ActivityIndicator,
+  Alert, ScrollView, StyleSheet,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import ScreenHeader from "../../components/ScreenHeader";
+import { authFetch } from "../../utils/api";
+import { API_BASE_URL } from "../../utils/config";
+import { colors, fonts } from "../../utils/theme";
+import { toast } from "sonner-native";
+
+interface UserProfile {
+  display_name: string | null;
+  email: string | null;
+  phone: string | null;
+  created_at: string;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString('es-MX', { year: 'numeric', month: 'long', day: 'numeric' });
+}
+
+export default function ProfileScreen() {
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [phone, setPhone] = useState("");
+  const [savingPhone, setSavingPhone] = useState(false);
+
+  useEffect(() => {
+    authFetch(`${API_BASE_URL}/api/v1/users/me`)
+      .then(r => r.ok ? r.json() : Promise.reject())
+      .then((data: UserProfile) => {
+        setProfile(data);
+        setPhone(data.phone ?? "");
+      })
+      .catch(() => Alert.alert("Error", "No se pudo cargar el perfil."))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleSavePhone = async () => {
+    const p = phone.trim();
+    if (!p || p.length < 5) {
+      Alert.alert("Teléfono inválido", "Ingresa un número con al menos 5 dígitos.");
+      return;
+    }
+    setSavingPhone(true);
+    try {
+      const res = await authFetch(`${API_BASE_URL}/api/v1/users/me/phone`, {
+        method: "PATCH",
+        body: JSON.stringify({ phone: p }),
+      });
+      if (!res.ok) throw new Error();
+      setProfile(prev => prev ? { ...prev, phone: p } : prev);
+      toast.success("Teléfono guardado", {
+        description: "Los contactos SOS podrán encontrarte por este número.",
+      });
+    } catch {
+      Alert.alert("Error", "No se pudo guardar el teléfono. Intenta de nuevo.");
+    } finally {
+      setSavingPhone(false);
+    }
+  };
+
+  return (
+    <SafeAreaView className="flex-1 bg-transparent" edges={["top", "bottom"]}>
+      <ScreenHeader title="Mi Perfil" />
+
+      {loading ? (
+        <View style={s.centered}>
+          <ActivityIndicator size="large" color={colors.brandCyan} />
+        </View>
+      ) : (
+        <ScrollView className="flex-1 pt-6" showsVerticalScrollIndicator={false}>
+          <View style={s.card}>
+            <View style={s.avatarRow}>
+              <MaterialCommunityIcons name="account-circle" size={64} color={colors.brandCyan} />
+            </View>
+
+            <Field
+              icon="account-outline"
+              label="Nombre"
+              value={profile?.display_name ?? "—"}
+            />
+            <Field
+              icon="email-outline"
+              label="Correo"
+              value={profile?.email ?? "—"}
+            />
+            <Field
+              icon="calendar-outline"
+              label="Miembro desde"
+              value={profile?.created_at ? formatDate(profile.created_at) : "—"}
+            />
+          </View>
+
+          <View style={s.card}>
+            <View style={s.sectionHeader}>
+              <MaterialCommunityIcons name="phone-outline" size={20} color={colors.brandCyan} />
+              <Text style={s.sectionTitle}>Número de teléfono</Text>
+            </View>
+            <Text style={s.sectionSub}>
+              Para recibir invitaciones SOS directamente en la app.
+            </Text>
+            <View style={s.phoneRow}>
+              <TextInput
+                style={s.phoneInput}
+                placeholder="+52 999 123 4567"
+                placeholderTextColor="rgba(255,255,255,0.3)"
+                value={phone}
+                onChangeText={setPhone}
+                keyboardType="phone-pad"
+                maxLength={30}
+                editable={!savingPhone}
+              />
+              <TouchableOpacity
+                style={[s.saveBtn, savingPhone && { opacity: 0.6 }]}
+                onPress={handleSavePhone}
+                disabled={savingPhone}
+              >
+                {savingPhone
+                  ? <ActivityIndicator size="small" color="#030810" />
+                  : <Text style={s.saveBtnText}>Guardar</Text>}
+              </TouchableOpacity>
+            </View>
+          </View>
+        </ScrollView>
+      )}
+    </SafeAreaView>
+  );
+}
+
+function Field({ icon, label, value }: { icon: string; label: string; value: string }) {
+  return (
+    <View style={s.fieldRow}>
+      <MaterialCommunityIcons name={icon as any} size={18} color="rgba(255,255,255,0.45)" style={{ marginTop: 1 }} />
+      <View style={{ flex: 1, marginLeft: 12 }}>
+        <Text style={s.fieldLabel}>{label}</Text>
+        <Text style={s.fieldValue}>{value}</Text>
+      </View>
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  centered: { flex: 1, justifyContent: "center", alignItems: "center" },
+  card: {
+    backgroundColor: "rgba(10,28,50,0.6)",
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.1)",
+    marginHorizontal: 16,
+    marginBottom: 16,
+    padding: 20,
+  },
+  avatarRow: { alignItems: "center", marginBottom: 20 },
+  fieldRow: { flexDirection: "row", alignItems: "flex-start", marginBottom: 16 },
+  fieldLabel: {
+    color: "rgba(255,255,255,0.45)",
+    fontFamily: fonts.poppins,
+    fontSize: 11,
+    letterSpacing: 0.6,
+    textTransform: "uppercase",
+    marginBottom: 2,
+  },
+  fieldValue: { color: "white", fontFamily: fonts.poppinsSemiBold, fontSize: 15 },
+  sectionHeader: { flexDirection: "row", alignItems: "center", gap: 10, marginBottom: 4 },
+  sectionTitle: { color: "white", fontFamily: fonts.poppinsSemiBold, fontSize: 15 },
+  sectionSub: {
+    color: "rgba(255,255,255,0.5)",
+    fontFamily: fonts.poppins,
+    fontSize: 12,
+    marginBottom: 14,
+  },
+  phoneRow: { flexDirection: "row", gap: 10 },
+  phoneInput: {
+    flex: 1,
+    backgroundColor: "rgba(255,255,255,0.07)",
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.12)",
+    color: "white",
+    fontFamily: fonts.poppins,
+    fontSize: 15,
+    paddingHorizontal: 14,
+    paddingVertical: 11,
+  },
+  saveBtn: {
+    backgroundColor: colors.brandCyan,
+    borderRadius: 10,
+    paddingHorizontal: 18,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  saveBtnText: { color: "#030810", fontFamily: fonts.poppinsSemiBold, fontSize: 14 },
+});


### PR DESCRIPTION
## Summary

- **Teléfono en onboarding**: Step 1 ("Datos Personales") ahora incluye campo de teléfono opcional. Al finalizar el wizard, si el usuario ingresó un número, se envía `PATCH /api/v1/users/me/phone` automáticamente. El campo de teléfono se eliminó de Ajustes.
- **Pantalla Mi Perfil**: Nueva pantalla `/profile` accesible desde el tab Más. Muestra nombre (de Firebase), email, fecha de registro y teléfono editable. Backend ahora persiste `display_name` y `email` del token de Firebase en la tabla `users` vía `upsert_user`.
- **"Soy contacto SOS de"**: Nuevo endpoint `GET /api/v1/sos-contacts/who-has-me` devuelve los usuarios que tienen al usuario actual como contacto SOS vinculado (`link_status = 'linked'`). Se muestra como sección separada debajo de los propios contactos en SOSContactsScreen.

## Cambios backend

- `users` table: `ALTER TABLE ADD COLUMN IF NOT EXISTS display_name`, `email`
- `upsert_user`: ahora recibe y persiste `display_name` + `email` del token; usa `COALESCE` para no sobrescribir con NULL
- `GET /api/v1/sos-contacts/who-has-me`: definido antes de `/{contact_id}` para evitar conflicto de rutas
- Tests: `FAKE_PROFILE` actualizado con los campos nuevos — 150 tests pasan

## Test plan

- [ ] Deploy a Railway staging y verificar que el servidor arranca sin errores (ALTER TABLE idempotente)
- [ ] Instalar APK en dispositivo, hacer onboarding nuevo → verificar que el teléfono queda guardado en el perfil
- [ ] Abrir "Más" → "Mi Perfil" → verificar nombre, email, fecha y editar teléfono
- [ ] Abrir "Más" → "Ajustes" → confirmar que no aparece el campo de teléfono
- [ ] Abrir "Contactos SOS" → verificar sección "Soy contacto SOS de" (muestra contactos si el usuario es contacto vinculado de alguien)