### PR TITLE
fix: transparent background in profile layout

### DIFF
--- a/frontend/app/profile/_layout.tsx
+++ b/frontend/app/profile/_layout.tsx
@@ -1,0 +1,14 @@
+import { Stack } from "expo-router";
+
+export default function ProfileLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: "transparent" },
+      }}
+    >
+      <Stack.Screen name="index" />
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary

- `profile/_layout.tsx` no tenía `contentStyle: { backgroundColor: 'transparent' }`, lo que causaba que la pantalla Mi Perfil mostrara fondo blanco en lugar del gradiente oscuro de la app.
- Se alineó el patrón con `alerts/`, `educational/` y `local-chat/`, que ya tienen esta propiedad.

## Test plan

- [ ] Más → Mi Perfil muestra el gradiente oscuro igual que Ajustes y Notificaciones
- [ ] Verificado en Samsung SM-N950F y Xiaomi 23117RA68G