### PR TITLE
fix: add missing reciprocate endpoint to sos-contacts router

### DIFF
--- a/backend/app/features/sos_contacts/router.py
+++ b/backend/app/features/sos_contacts/router.py
@@ -6,6 +6,7 @@ from app.core.database import get_db
 from app.features.users.service import get_user_by_firebase_uid
 from app.features.sos_contacts.schemas import SOSContactCreate, SOSContactResponse, SOSContactUpdate, WhoHasMeItem
 from app.features.sos_contacts.service import (
+    add_reciprocal_contact,
     create_sos_contact,
     delete_sos_contact,
     get_who_has_me,
@@ -49,6 +50,16 @@ async def get_who_has_me_route(
 ):
     user_id = await _get_user_id(db, user)
     return await get_who_has_me(db, user_id)
+
+
+@router.post("/api/v1/sos-contacts/reciprocate/{owner_user_id}", response_model=SOSContactResponse, status_code=status.HTTP_201_CREATED)
+async def reciprocate_contact(
+    owner_user_id: int,
+    db: AsyncSession = Depends(get_db),
+    user=Depends(get_current_user),
+):
+    user_id = await _get_user_id(db, user)
+    return await add_reciprocal_contact(db, user_id, owner_user_id)
 
 
 @router.patch("/api/v1/sos-contacts/{contact_id}", response_model=SOSContactResponse)


### PR DESCRIPTION
## Summary

- `POST /api/v1/sos-contacts/reciprocate/{owner_user_id}` estaba implementado en `service.py` pero nunca se registró en `router.py`
- Agrega el import de `add_reciprocal_contact` y la ruta antes de `/{contact_id}` para evitar conflictos de path

## Test plan

- [ ] `POST /api/v1/sos-contacts/reciprocate/{id}` devuelve 201 con el contacto creado
- [ ] Devuelve 409 si ya es contacto