### PR TITLE
fix: restore sos-contacts backend changes lost in squash merge

### DIFF
--- a/backend/app/features/notifications/service.py
+++ b/backend/app/features/notifications/service.py
@@ -90,6 +90,28 @@ async def send_targeted_notification(
     return {"success_count": response.success_count, "failure_count": response.failure_count}
 
 
+async def send_contacts_refresh_push(db: AsyncSession, user_ids: list[int]) -> None:
+    """Send a silent push so the recipients' contacts screen refreshes instantly."""
+    token_map = await get_tokens_for_users(db, user_ids)
+    tokens = [t for uid in user_ids for t in token_map.get(uid, [])]
+    if not tokens:
+        return
+    msg = messaging.MulticastMessage(
+        notification=messaging.Notification(title=" ", body=" "),
+        data={"type": "contacts_refresh"},
+        android=messaging.AndroidConfig(priority="high"),
+        tokens=tokens,
+    )
+    try:
+        response = await _send_multicast_with_retry(msg)
+        logger.info(
+            "contacts_refresh push → user_ids=%s tokens=%d success=%d",
+            user_ids, len(tokens), response.success_count,
+        )
+    except Exception as exc:
+        logger.error("contacts_refresh push failed: %s", exc)
+
+
 async def send_all_notifications(db: AsyncSession, title:str, body:str, data:dict[str, str]):
     # Query to db to get all tokens
     result = await db.execute(text("SELECT token FROM device_tokens"))

--- a/backend/app/features/sos_contacts/schemas.py
+++ b/backend/app/features/sos_contacts/schemas.py
@@ -27,7 +27,10 @@ class SOSContactResponse(BaseModel):
 
 
 class WhoHasMeItem(BaseModel):
+    owner_user_id: int
     name: str
     relationship: str | None
     owner_display_name: str | None
+    owner_phone: str | None
+    already_my_contact: bool
     created_at: datetime

--- a/backend/app/features/sos_contacts/service.py
+++ b/backend/app/features/sos_contacts/service.py
@@ -3,6 +3,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.features.sos_contacts.schemas import SOSContactCreate, SOSContactUpdate
+from app.features.notifications.service import send_contacts_refresh_push
 
 
 async def list_sos_contacts(db: AsyncSession, user_id: int) -> list[dict]:
@@ -69,11 +70,14 @@ async def update_sos_contact(db: AsyncSession, contact_id: int, user_id: int, pa
 
 async def delete_sos_contact(db: AsyncSession, contact_id: int, user_id: int) -> None:
     result = await db.execute(
-        text("DELETE FROM sos_contacts WHERE id = :id AND user_id = :user_id RETURNING id"),
+        text("DELETE FROM sos_contacts WHERE id = :id AND user_id = :user_id RETURNING id, linked_user_id, link_status"),
         {"id": contact_id, "user_id": user_id},
     )
     await db.commit()
-    if result.fetchone():
+    row = result.mappings().first()
+    if row:
+        if row["link_status"] == "linked" and row["linked_user_id"]:
+            await send_contacts_refresh_push(db, [int(row["linked_user_id"])])
         return
     await _raise_not_found_or_forbidden(db, contact_id, user_id)
 
@@ -82,7 +86,13 @@ async def get_who_has_me(db: AsyncSession, user_id: int) -> list[dict]:
     result = await db.execute(
         text("""
             SELECT sc.name, sc.relationship, sc.created_at,
-                   u.display_name AS owner_display_name
+                   u.id AS owner_user_id,
+                   u.display_name AS owner_display_name,
+                   u.phone AS owner_phone,
+                   EXISTS (
+                       SELECT 1 FROM sos_contacts ec
+                       WHERE ec.user_id = :user_id AND ec.linked_user_id = u.id
+                   ) AS already_my_contact
             FROM sos_contacts sc
             JOIN users u ON u.id = sc.user_id
             WHERE sc.linked_user_id = :user_id AND sc.link_status = 'linked'
@@ -91,6 +101,44 @@ async def get_who_has_me(db: AsyncSession, user_id: int) -> list[dict]:
         {"user_id": user_id},
     )
     return [dict(row) for row in result.mappings().all()]
+
+
+async def add_reciprocal_contact(db: AsyncSession, current_user_id: int, owner_user_id: int) -> dict:
+    if current_user_id == owner_user_id:
+        raise HTTPException(status_code=400, detail="Cannot add yourself as a contact")
+
+    exists = await db.execute(
+        text("SELECT id FROM sos_contacts WHERE user_id = :uid AND linked_user_id = :linked"),
+        {"uid": current_user_id, "linked": owner_user_id},
+    )
+    if exists.mappings().first():
+        raise HTTPException(status_code=409, detail="Already have this user as a contact")
+
+    owner = await db.execute(
+        text("SELECT display_name, phone FROM users WHERE id = :id"),
+        {"id": owner_user_id},
+    )
+    owner_row = owner.mappings().first()
+    if not owner_row:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    result = await db.execute(
+        text("""
+            INSERT INTO sos_contacts (user_id, name, phone, link_status, linked_user_id)
+            VALUES (:user_id, :name, :phone, 'linked', :linked_user_id)
+            RETURNING id, user_id, name, phone, relationship, linked_user_id, link_status, created_at, updated_at
+        """),
+        {
+            "user_id": current_user_id,
+            "name": owner_row["display_name"] or "Contacto SOS",
+            "phone": owner_row["phone"] or "",
+            "linked_user_id": owner_user_id,
+        },
+    )
+    await db.commit()
+    contact = dict(result.mappings().first())
+    await send_contacts_refresh_push(db, [owner_user_id])
+    return contact
 
 
 async def _get_contact_owned_by(db: AsyncSession, contact_id: int, user_id: int) -> dict:

--- a/backend/app/features/sos_invite/service.py
+++ b/backend/app/features/sos_invite/service.py
@@ -6,7 +6,7 @@ from firebase_admin import messaging
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.features.notifications.service import get_tokens_for_users, _send_multicast_with_retry
+from app.features.notifications.service import get_tokens_for_users, _send_multicast_with_retry, send_contacts_refresh_push
 
 logger = logging.getLogger(__name__)
 
@@ -187,6 +187,9 @@ async def accept_invite(db: AsyncSession, token: str, caller_user_id: int) -> di
         {"user_id": caller_user_id, "token": token},
     )
     await db.commit()
+
+    # Notify both sides so their contacts screen refreshes instantly
+    await send_contacts_refresh_push(db, [int(row["inviter_id"]), caller_user_id])
 
     return {
         "inviter_display_name": row["inviter_display_name"] or "Un usuario de BluEye",


### PR DESCRIPTION
## Summary

El squash merge del PR #198 perdió cambios en 4 archivos de backend. Este PR los restaura:

- `sos_contacts/service.py`: restaura `add_reciprocal_contact`, `get_who_has_me` extendido con `owner_user_id/phone/already_my_contact`, y `delete_sos_contact` con RETURNING + push
- `sos_contacts/schemas.py`: restaura campos `owner_user_id`, `owner_phone`, `already_my_contact` en `WhoHasMeItem`
- `notifications/service.py`: restaura `send_contacts_refresh_push()`
- `sos_invite/service.py`: restaura llamada a `send_contacts_refresh_push` en `accept_invite`

## Test plan

- [ ] Backend arranca sin crash
- [ ] `GET /api/v1/sos-contacts/who-has-me` devuelve `owner_user_id`, `owner_phone`, `already_my_contact`
- [ ] `POST /api/v1/sos-contacts/reciprocate/{id}` devuelve 201
- [ ] Aceptar invitación → push silencioso llega a ambos dispositivos