### PR TITLE
feat: reject invite notification + heads-up notification channel

### DIFF
--- a/backend/app/features/sos_invite/router.py
+++ b/backend/app/features/sos_invite/router.py
@@ -5,7 +5,7 @@ from app.core.auth import get_current_user
 from app.core.database import get_db
 from app.features.users.service import get_user_by_firebase_uid
 from app.features.sos_invite.schemas import InviteAcceptResponse, InviteCreateResponse, InvitePreviewResponse
-from app.features.sos_invite.service import accept_invite, create_invite, get_invite_preview
+from app.features.sos_invite.service import accept_invite, create_invite, get_invite_preview, reject_invite
 
 router = APIRouter()
 
@@ -51,3 +51,13 @@ async def accept_invitation(
 ):
     caller_id = await _resolve_user_id(db, user)
     return await accept_invite(db, token, caller_id)
+
+
+@router.post("/api/v1/sos-invitations/{token}/reject", status_code=204)
+async def reject_invitation(
+    token: str,
+    db: AsyncSession = Depends(get_db),
+    user=Depends(get_current_user),
+):
+    caller_id = await _resolve_user_id(db, user)
+    await reject_invite(db, token, caller_id)

--- a/backend/app/features/sos_invite/service.py
+++ b/backend/app/features/sos_invite/service.py
@@ -6,7 +6,7 @@ from firebase_admin import messaging
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.features.notifications.service import get_tokens_for_users, _send_multicast_with_retry, send_contacts_refresh_push
+from app.features.notifications.service import get_tokens_for_users, _send_multicast_with_retry, send_contacts_refresh_push, send_targeted_notification
 
 logger = logging.getLogger(__name__)
 
@@ -112,6 +112,13 @@ async def _send_invite_push(
             "inviter_display_name": inviter_display_name,
             "contact_name":         contact_name,
         },
+        android=messaging.AndroidConfig(
+            priority="high",
+            notification=messaging.AndroidNotification(
+                channel_id="sos_alerts",
+                notification_priority="PRIORITY_HIGH",
+            ),
+        ),
         tokens=tokens,
     )
     try:
@@ -195,3 +202,51 @@ async def accept_invite(db: AsyncSession, token: str, caller_user_id: int) -> di
         "inviter_display_name": row["inviter_display_name"] or "Un usuario de BluEye",
         "contact_name": row["contact_name"],
     }
+
+
+async def reject_invite(db: AsyncSession, token: str, caller_user_id: int) -> None:
+    result = await db.execute(
+        text("""
+            SELECT id, inviter_id, inviter_display_name, contact_id, contact_name,
+                   (expires_at > NOW()) AS is_valid,
+                   accepted_at, revoked_at
+            FROM sos_invitations WHERE token = :token
+        """),
+        {"token": token},
+    )
+    row = result.mappings().first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Invitation not found")
+    if not row["is_valid"] or row["revoked_at"] is not None:
+        raise HTTPException(status_code=410, detail="Invitation expired or revoked")
+    if row["accepted_at"] is not None:
+        raise HTTPException(status_code=409, detail="Invitation already accepted")
+    if int(row["inviter_id"]) == caller_user_id:
+        raise HTTPException(status_code=400, detail="Cannot reject your own invitation")
+
+    # Revert contact to unlinked so the inviter can re-send
+    await db.execute(
+        text("UPDATE sos_contacts SET link_status = 'unlinked' WHERE id = :id"),
+        {"id": row["contact_id"]},
+    )
+    # Invalidate the token (reuse revoked_at — same effect as expiry)
+    await db.execute(
+        text("UPDATE sos_invitations SET revoked_at = NOW() WHERE token = :token"),
+        {"token": token},
+    )
+    await db.commit()
+
+    # Notify the inviter: visible push + silent contacts refresh
+    inviter_id = int(row["inviter_id"])
+    contact_name = row["contact_name"] or "tu contacto"
+    try:
+        await send_targeted_notification(
+            db,
+            user_id=inviter_id,
+            title="Invitación SOS rechazada",
+            body=f"{contact_name} rechazó tu invitación SOS.",
+            data={"category": "sos_rejected"},
+        )
+    except Exception:
+        pass  # inviter may have no tokens; not critical
+    await send_contacts_refresh_push(db, [inviter_id])

--- a/frontend/app/sos-invite/[token].tsx
+++ b/frontend/app/sos-invite/[token].tsx
@@ -9,7 +9,7 @@ import { authFetch } from "../../utils/api";
 import { API_BASE_URL } from "../../utils/config";
 import { colors, fonts } from "../../utils/theme";
 
-type Stage = "loading" | "preview" | "accepting" | "success" | "error";
+type Stage = "loading" | "preview" | "accepting" | "rejecting" | "success" | "error";
 
 interface Preview {
   inviter_display_name: string;
@@ -60,6 +60,21 @@ export default function SosInviteScreen() {
       });
   }, [token]);
 
+  async function handleReject() {
+    if (!token) return;
+    console.log('[QA_SOS_INVITE] rejecting | token:', token);
+    setStage("rejecting");
+    try {
+      await authFetch(`${API_BASE_URL}/api/v1/sos-invitations/${token}/reject`, { method: "POST" });
+      console.log('[QA_SOS_INVITE] rejected OK');
+    } catch (e) {
+      console.warn('[QA_SOS_INVITE] reject error (non-critical):', e);
+    } finally {
+      await AsyncStorage.removeItem(PENDING_SOS_INVITE_KEY).catch(() => {});
+      router.back();
+    }
+  }
+
   async function handleAccept() {
     if (!token) return;
     console.log('[QA_SOS_INVITE] accepting | token:', token);
@@ -86,7 +101,7 @@ export default function SosInviteScreen() {
       <View style={s.centered}>
         <View style={s.card}>
 
-          {(stage === "loading" || stage === "accepting") && (
+          {(stage === "loading" || stage === "accepting" || stage === "rejecting") && (
             <ActivityIndicator size="large" color={colors.brandCyan} />
           )}
 
@@ -100,11 +115,7 @@ export default function SosInviteScreen() {
               </Text>
               <Text style={s.sub}>Contacto guardado: {preview.contact_name}</Text>
               <View style={s.row}>
-                <TouchableOpacity style={s.cancelBtn} onPress={() => {
-                  console.log('[QA_SOS_INVITE] user rejected invite | token:', token);
-                  AsyncStorage.removeItem(PENDING_SOS_INVITE_KEY).catch(() => {});
-                  router.back();
-                }}>
+                <TouchableOpacity style={s.cancelBtn} onPress={handleReject}>
                   <Text style={s.cancelTxt}>Rechazar</Text>
                 </TouchableOpacity>
                 <TouchableOpacity style={s.acceptBtn} onPress={handleAccept}>

--- a/frontend/utils/pushNotifications.ts
+++ b/frontend/utils/pushNotifications.ts
@@ -1,7 +1,7 @@
 // frontend/utils/pushNotifications.js
 import * as Notifications from "expo-notifications";
 import * as Device from "expo-device";
-import { Alert, DeviceEventEmitter } from "react-native";
+import { Alert, DeviceEventEmitter, Platform } from "react-native";
 import { toast } from "sonner-native";
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { track } from "./analytics";
@@ -66,11 +66,24 @@ export async function sendTokenToBackend(fcmToken: string): Promise<void> {
   }
 }
 
+export async function setupNotificationChannels() {
+  if (Platform.OS !== "android") return;
+  await Notifications.setNotificationChannelAsync("sos_alerts", {
+    name: "Alertas SOS",
+    importance: Notifications.AndroidImportance.HIGH,
+    vibrationPattern: [0, 250, 250, 250],
+    enableVibrate: true,
+    showBadge: true,
+  });
+}
+
 export async function registerForPushNotificationsAsync() {
   if (!Device.isDevice) {
     console.log("Push solo funciona en dispositivo físico");
     return null;
   }
+
+  await setupNotificationChannels();
 
   // 1) Permisos
   const { status: existingStatus } = await Notifications.getPermissionsAsync();


### PR DESCRIPTION
## Summary

- **Rechazo de invitación**: `POST /api/v1/sos-invitations/{token}/reject` revierte el contacto a `unlinked`, invalida el token, y envía push visible al invitador ("X rechazó tu invitación SOS") + silent contacts_refresh para que su pantalla actualice al instante
- **Heads-up notifications**: agrega `AndroidConfig(priority=high, channel_id=sos_alerts, notification_priority=PRIORITY_HIGH)` al push de invitación. En el frontend, `setupNotificationChannels()` crea el canal `sos_alerts` con `IMPORTANCE_HIGH` antes de registrar el token FCM
- El botón "Rechazar" en `sos-invite` ahora llama al endpoint antes de navegar hacia atrás (no bloquea al usuario si falla)

## Test plan

- [ ] Xiaomi rechaza invitación → Samsung recibe notificación heads-up "X rechazó tu invitación SOS"
- [ ] Samsung: el contacto vuelve a estado `unlinked` (ícono de compartir visible)
- [ ] Nueva invitación del Samsung llega al Xiaomi como heads-up banner (no solo en cajón)
- [ ] Token usado para rechazar ya no puede aceptarse (devuelve 410)