### PR TITLE
fix: remove unsupported notification_priority from AndroidNotification

### DIFF
--- a/backend/app/features/sos_invite/service.py
+++ b/backend/app/features/sos_invite/service.py
@@ -116,7 +116,6 @@ async def _send_invite_push(
             priority="high",
             notification=messaging.AndroidNotification(
                 channel_id="sos_alerts",
-                notification_priority="PRIORITY_HIGH",
             ),
         ),
         tokens=tokens,


### PR DESCRIPTION
Removes notification_priority kwarg that doesn't exist in the installed firebase-admin version, causing 500 on invite send. The sos_alerts channel importance (set in frontend) handles display priority.