### PR TITLE
fix: deduplicate SOS toasts and handle sos_rejected notifications

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -12,7 +12,7 @@ import { LinearGradient } from "expo-linear-gradient";
 import { gradients } from "../utils/theme";
 import React, { useEffect } from "react";
 import { useFonts } from "expo-font";
-import { Alert, AppState, Platform, StatusBar as RNStatusBar } from "react-native";
+import { Alert, AppState, DeviceEventEmitter, Platform, StatusBar as RNStatusBar } from "react-native";
 import { StatusBar } from "expo-status-bar";
 import {
   registerForPushNotificationsAsync,
@@ -84,6 +84,7 @@ function resolveNotifPayload(
   const isFullScreen = data.fullScreen === 'true' || levelNum >= 4
   const isSos = data.category === 'sos'
   const isSosInvite = data.category === 'sos_invite'
+  const isSosRejected = data.category === 'sos_rejected'
   const sosLat = parseFloat(data.lat ?? '')
   const sosLon = parseFloat(data.lon ?? '')
   const sosHasCoords = Number.isFinite(sosLat) && Number.isFinite(sosLon)
@@ -93,6 +94,7 @@ function resolveNotifPayload(
     isFullScreen,
     isSos,
     isSosInvite,
+    isSosRejected,
     inviteToken: data.invite_token,
     inviterDisplayName: data.inviter_display_name ?? 'Un usuario',
     senderName: data.sender_name ?? 'Un contacto',
@@ -180,8 +182,8 @@ export default Sentry.wrap(function Layout() {
     // Tap en notificación (background → foreground, o foreground tap)
     const tapSub = addNotificationResponseListener(async (rawData, content) => {
       const data = rawData as NotificationData
-      const { id, isFullScreen, isSos, isSosInvite, inviteToken, inviterDisplayName, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data, content)
-      console.log('[QA_NOTIF] tap | alertId:', id ?? 'none', '| fullScreen:', isFullScreen, '| sos:', isSos, '| sosInvite:', isSosInvite)
+      const { id, isFullScreen, isSos, isSosInvite, isSosRejected, inviteToken, inviterDisplayName, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data, content)
+      console.log('[QA_NOTIF] tap | alertId:', id ?? 'none', '| fullScreen:', isFullScreen, '| sos:', isSos, '| sosInvite:', isSosInvite, '| sosRejected:', isSosRejected)
 
       await initAnalytics();
       track("push_open", {
@@ -202,6 +204,11 @@ export default Sentry.wrap(function Layout() {
         Alert.alert('SOS recibido', `${senderName} necesita ayuda urgente.${coordsText}`);
         return;
       }
+      if (isSosRejected) {
+        console.log('[QA_NAV] tap → SOSContactsScreen (rejected)')
+        router.push('/SOSContactsScreen');
+        return;
+      }
       if (isFullScreen) {
         console.log('[QA_NAV] tap → AlarmScreen | alertId:', id ?? 'none', '| category:', params.category)
         router.push({ pathname: "AlarmScreen", params });
@@ -218,8 +225,8 @@ export default Sentry.wrap(function Layout() {
     const receivedSub = Notifications.addNotificationReceivedListener((notification) => {
       const rawData = notification.request.content.data as NotificationData
       const content = notification.request.content
-      const { isFullScreen, isSos, isSosInvite, inviteToken, inviterDisplayName, senderName, params } = resolveNotifPayload(rawData, content)
-      console.log('[QA_NOTIF] received foreground | fullScreen:', isFullScreen, '| sos:', isSos, '| sosInvite:', isSosInvite, '| category:', params.category)
+      const { isFullScreen, isSos, isSosInvite, isSosRejected, inviteToken, inviterDisplayName, senderName, params } = resolveNotifPayload(rawData, content)
+      console.log('[QA_NOTIF] received foreground | fullScreen:', isFullScreen, '| sos:', isSos, '| sosInvite:', isSosInvite, '| sosRejected:', isSosRejected, '| category:', params.category)
       if (isFullScreen && !alarmActiveRef.current) {
         alarmActiveRef.current = true
         console.log('[QA_NAV] received → AlarmScreen | category:', params.category, '| alertId:', params.alertId ?? 'none')
@@ -244,6 +251,14 @@ export default Sentry.wrap(function Layout() {
         toast.error(`SOS — ${senderName}`, {
           description: 'Necesita ayuda urgente. Revisa tu pantalla.',
         });
+        return;
+      }
+      if (isSosRejected) {
+        console.log('[QA_SOS_INVITE] foreground received | sos_rejected')
+        toast(content.title ?? 'Invitación SOS rechazada', {
+          description: content.body ?? undefined,
+        });
+        DeviceEventEmitter.emit('contacts:refresh');
       }
     });
 
@@ -273,8 +288,9 @@ export default Sentry.wrap(function Layout() {
       if (!data) return
       const { title: coldTitle, body: coldBody } = initial.notification.request.content
 
-      const { id, isFullScreen, isSos, isSosInvite, inviteToken, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data, { title: coldTitle, body: coldBody })
-      if (!id && !isFullScreen && !isSos && !isSosInvite) return
+      const { id, isFullScreen, isSos, isSosInvite, isSosRejected, inviteToken, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data, { title: coldTitle, body: coldBody })
+      console.log('[QA_NAV] cold start | category:', data.category ?? 'none', '| type:', (data as Record<string,unknown>).type ?? 'none', '| isSosInvite:', isSosInvite, '| isSos:', isSos, '| isSosRejected:', isSosRejected, '| id:', id ?? 'none')
+      if (!id && !isFullScreen && !isSos && !isSosInvite && !isSosRejected) return
 
       await initAnalytics();
       track("push_open", {
@@ -293,6 +309,11 @@ export default Sentry.wrap(function Layout() {
       if (isSos) {
         const coordsText = sosHasCoords ? `\nUbicación: ${sosLat.toFixed(5)}, ${sosLon.toFixed(5)}` : '';
         Alert.alert('SOS recibido', `${senderName} necesita ayuda urgente.${coordsText}`);
+        return;
+      }
+      if (isSosRejected) {
+        console.log('[QA_NAV] cold start → SOSContactsScreen (rejected)')
+        router.push('/SOSContactsScreen');
         return;
       }
       if (isFullScreen) {

--- a/frontend/utils/pushNotifications.ts
+++ b/frontend/utils/pushNotifications.ts
@@ -134,6 +134,11 @@ export function setForegroundNotificationHandler() {
       return;
     }
 
+    if (data?.category === "sos_invite" || data?.category === "sos_rejected") {
+      console.log('[QA_NOTIF] skip toast for', data.category, '— handled by _layout.tsx');
+      return;
+    }
+
     console.log('[QA_NOTIF] foreground toast | title:', title ?? 'none', '| alertId:', data?.alertId ?? 'none');
     toast(title ?? '', { description: body ?? undefined });
     track("push_received_foreground", {


### PR DESCRIPTION
## Qué cambia

**Problema 1 — Toast duplicado en SOS invite**
`pushNotifications.ts` y `_layout.tsx` tenían listeners independientes. Para `sos_invite`, `_layout.tsx` mostraba el toast correcto con botón "Ver" y `pushNotifications.ts` mostraba un segundo toast genérico. Ahora `pushNotifications.ts` hace early-return para `sos_invite` y `sos_rejected`.

**Problema 2 — `sos_rejected` no manejado**
Cuando el invitador recibía la notificación de rechazo, nada ocurría:
- En foreground: ahora se muestra toast con el mensaje del backend + se emite `contacts:refresh` (actualiza la UI al instante)
- Al tocar la notificación (background/foreground): navega a SOSContactsScreen
- Cold start: el guard `if (!id && !isFullScreen && !isSos && !isSosInvite)` bloqueaba silenciosamente las notificaciones de rechazo — corregido agregando `&& !isSosRejected`

**Problema 3 — Log de cold start**
Se agrega `[QA_NAV] cold start | category: ... | isSosInvite: ... | isSos: ... | isSosRejected: ... | id: ...` para saber exactamente qué tipo de notificación abrió la app desde killed state.

## Archivos modificados

- `frontend/app/_layout.tsx` — `resolveNotifPayload` + `tapSub` + `receivedSub` + cold-start handler + import `DeviceEventEmitter`
- `frontend/utils/pushNotifications.ts` — skip `sos_invite`/`sos_rejected` en listener de foreground

## Cómo probar

1. **Duplicate toast**: enviar invite SOS con app abierta → debe aparecer UN solo toast con botón "Ver"
2. **Reject foreground**: Samsung envía invite a Xiaomi; Xiaomi lo rechaza con app abierta en Samsung → toast "X rechazó tu invitación SOS" + lista de contactos se actualiza al instante
3. **Reject tap**: Samsung con app cerrada → abrir notificación de rechazo → lleva a SOSContactsScreen
4. **Cold start log**: matar app, tocar cualquier notificación → buscar `[QA_NAV] cold start` en logs