### PR TITLE
feat: visible banner notification when contact adds you back (reciprocal)

### DIFF
--- a/backend/app/features/notifications/service.py
+++ b/backend/app/features/notifications/service.py
@@ -58,7 +58,12 @@ async def get_tokens_for_users(db: AsyncSession, user_ids: list[int]) -> dict[in
 
 
 async def send_targeted_notification(
-    db: AsyncSession, user_id: int, title: str, body: str, data: dict[str, str]
+    db: AsyncSession,
+    user_id: int,
+    title: str,
+    body: str,
+    data: dict[str, str],
+    android_channel_id: str | None = None,
 ):
     """Send a push notification only to the tokens belonging to a specific user."""
     from fastapi import HTTPException  # local import avoids circular on module load
@@ -68,9 +73,14 @@ async def send_targeted_notification(
     if not tokens:
         raise HTTPException(status_code=404, detail="No tokens registered for this user")
 
+    android_config = messaging.AndroidConfig(
+        priority="high",
+        notification=messaging.AndroidNotification(channel_id=android_channel_id) if android_channel_id else None,
+    )
     message = messaging.MulticastMessage(
         notification=messaging.Notification(title=title, body=body),
         data=data or {},
+        android=android_config,
         tokens=tokens,
     )
     try:
@@ -99,7 +109,10 @@ async def send_contacts_refresh_push(db: AsyncSession, user_ids: list[int]) -> N
     msg = messaging.MulticastMessage(
         notification=messaging.Notification(title=" ", body=" "),
         data={"type": "contacts_refresh"},
-        android=messaging.AndroidConfig(priority="high"),
+        android=messaging.AndroidConfig(
+            priority="high",
+            notification=messaging.AndroidNotification(channel_id="contacts_refresh_silent"),
+        ),
         tokens=tokens,
     )
     try:

--- a/backend/app/features/sos_contacts/service.py
+++ b/backend/app/features/sos_contacts/service.py
@@ -3,7 +3,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.features.sos_contacts.schemas import SOSContactCreate, SOSContactUpdate
-from app.features.notifications.service import send_contacts_refresh_push
+from app.features.notifications.service import send_contacts_refresh_push, send_targeted_notification
 
 
 async def list_sos_contacts(db: AsyncSession, user_id: int) -> list[dict]:
@@ -114,6 +114,7 @@ async def add_reciprocal_contact(db: AsyncSession, current_user_id: int, owner_u
     if exists.mappings().first():
         raise HTTPException(status_code=409, detail="Already have this user as a contact")
 
+    # Fetch both users in parallel queries
     owner = await db.execute(
         text("SELECT display_name, phone FROM users WHERE id = :id"),
         {"id": owner_user_id},
@@ -121,6 +122,13 @@ async def add_reciprocal_contact(db: AsyncSession, current_user_id: int, owner_u
     owner_row = owner.mappings().first()
     if not owner_row:
         raise HTTPException(status_code=404, detail="User not found")
+
+    adder = await db.execute(
+        text("SELECT display_name FROM users WHERE id = :id"),
+        {"id": current_user_id},
+    )
+    adder_row = adder.mappings().first()
+    adder_name = (adder_row["display_name"] if adder_row else None) or "Tu contacto"
 
     result = await db.execute(
         text("""
@@ -137,6 +145,19 @@ async def add_reciprocal_contact(db: AsyncSession, current_user_id: int, owner_u
     )
     await db.commit()
     contact = dict(result.mappings().first())
+
+    # Notify the owner (Xiaomi) with a visible banner push + silent UI refresh
+    try:
+        await send_targeted_notification(
+            db,
+            user_id=owner_user_id,
+            title="Nuevo contacto SOS",
+            body=f"{adder_name} te agregó como contacto SOS.",
+            data={"category": "sos_contact_added", "adder_display_name": adder_name},
+            android_channel_id="sos_alerts",
+        )
+    except Exception:
+        pass  # owner may have no tokens; not critical
     await send_contacts_refresh_push(db, [owner_user_id])
     return contact
 

--- a/backend/app/features/sos_invite/service.py
+++ b/backend/app/features/sos_invite/service.py
@@ -245,6 +245,7 @@ async def reject_invite(db: AsyncSession, token: str, caller_user_id: int) -> No
             title="Invitación SOS rechazada",
             body=f"{contact_name} rechazó tu invitación SOS.",
             data={"category": "sos_rejected"},
+            android_channel_id="sos_alerts",
         )
     except Exception:
         pass  # inviter may have no tokens; not critical

--- a/frontend/app/SOSContactsScreen.tsx
+++ b/frontend/app/SOSContactsScreen.tsx
@@ -16,6 +16,7 @@ import { authFetch } from "../utils/api";
 import { API_BASE_URL } from "../utils/config";
 import { colors, fonts } from "../utils/theme";
 import { PENDING_SOS_INVITE_KEY } from "./sos-invite/[token]";
+import { PENDING_SOS_CONTACT_ADDED_KEY } from "./_layout";
 
 interface SOSContact {
   id: number; user_id: number; name: string; phone: string;
@@ -48,6 +49,7 @@ export default function SOSContactsScreen() {
   const [relVal, setRelVal]                 = useState("");
   const [formError, setFormError]           = useState<string | null>(null);
   const [pendingInviteToken, setPendingInviteToken] = useState<string | null>(null);
+  const [pendingContactAdded, setPendingContactAdded] = useState<string | null>(null);
   const [whoHasMe, setWhoHasMe]             = useState<WhoHasMeItem[]>([]);
   const [addingReciprocal, setAddingReciprocal] = useState<number | null>(null);
 
@@ -76,6 +78,10 @@ export default function SOSContactsScreen() {
             console.log('[QA_SOS_INVITE] SOSContactsScreen check pending | token:', token ?? 'none');
             if (live) setPendingInviteToken(token);
           })
+          .catch(() => {});
+
+        AsyncStorage.getItem(PENDING_SOS_CONTACT_ADDED_KEY)
+          .then(name => { if (live) setPendingContactAdded(name); })
           .catch(() => {});
 
         if (isFirst) { setLoading(true); setFetchError(false); }
@@ -121,6 +127,9 @@ export default function SOSContactsScreen() {
         console.log('[QA_SOS_INVITE] AppState active → re-checking pending token');
         AsyncStorage.getItem(PENDING_SOS_INVITE_KEY)
           .then(token => setPendingInviteToken(token))
+          .catch(() => {});
+        AsyncStorage.getItem(PENDING_SOS_CONTACT_ADDED_KEY)
+          .then(name => setPendingContactAdded(name))
           .catch(() => {});
       }
     });
@@ -311,6 +320,26 @@ export default function SOSContactsScreen() {
           </View>
           <MaterialCommunityIcons name="chevron-right" size={20} color="#030810" />
         </TouchableOpacity>
+      )}
+
+      {pendingContactAdded && (
+        <View style={s.inviteBanner}>
+          <MaterialCommunityIcons name="account-check-outline" size={22} color="#030810" />
+          <View style={{ flex: 1, marginLeft: 10 }}>
+            <Text style={s.inviteBannerTitle}>{pendingContactAdded} te agregó como contacto SOS</Text>
+            <Text style={s.inviteBannerSub}>Ya son contactos mutuos</Text>
+          </View>
+          <TouchableOpacity
+            onPress={() => {
+              console.log('[QA_SOS] dismiss contact_added banner');
+              AsyncStorage.removeItem(PENDING_SOS_CONTACT_ADDED_KEY).catch(() => {});
+              setPendingContactAdded(null);
+            }}
+            hitSlop={12}
+          >
+            <MaterialCommunityIcons name="close" size={20} color="#030810" />
+          </TouchableOpacity>
+        </View>
       )}
 
       {contacts.length === 0 ? (

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -25,6 +25,7 @@ import { Toaster, toast } from "sonner-native";
 import { initAnalytics, track, flush } from "../utils/analytics"
 import { flushSOSQueue, shouldConfirmPendingSOS } from "./map/sosQueue"
 import { PENDING_SOS_INVITE_KEY } from "./sos-invite/[token]";
+export const PENDING_SOS_CONTACT_ADDED_KEY = "@BluEye:pending_sos_contact_added";
 import { hasCompletedOnboarding } from "./onboarding/_services/onboardingService"
 import { usePathname } from "expo-router";
 import * as Sentry from '@sentry/react-native';
@@ -73,6 +74,8 @@ interface NotificationData {
   lon?: string
   invite_token?: string
   inviter_display_name?: string
+  adder_display_name?: string
+  type?: string
 }
 
 function resolveNotifPayload(
@@ -85,6 +88,8 @@ function resolveNotifPayload(
   const isSos = data.category === 'sos'
   const isSosInvite = data.category === 'sos_invite'
   const isSosRejected = data.category === 'sos_rejected'
+  const isSosContactAdded = data.category === 'sos_contact_added'
+  const adderDisplayName = data.adder_display_name ?? 'Tu contacto'
   const sosLat = parseFloat(data.lat ?? '')
   const sosLon = parseFloat(data.lon ?? '')
   const sosHasCoords = Number.isFinite(sosLat) && Number.isFinite(sosLon)
@@ -95,6 +100,8 @@ function resolveNotifPayload(
     isSos,
     isSosInvite,
     isSosRejected,
+    isSosContactAdded,
+    adderDisplayName,
     inviteToken: data.invite_token,
     inviterDisplayName: data.inviter_display_name ?? 'Un usuario',
     senderName: data.sender_name ?? 'Un contacto',
@@ -182,8 +189,13 @@ export default Sentry.wrap(function Layout() {
     // Tap en notificación (background → foreground, o foreground tap)
     const tapSub = addNotificationResponseListener(async (rawData, content) => {
       const data = rawData as NotificationData
-      const { id, isFullScreen, isSos, isSosInvite, isSosRejected, inviteToken, inviterDisplayName, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data, content)
-      console.log('[QA_NOTIF] tap | alertId:', id ?? 'none', '| fullScreen:', isFullScreen, '| sos:', isSos, '| sosInvite:', isSosInvite, '| sosRejected:', isSosRejected)
+      const { id, isFullScreen, isSos, isSosInvite, isSosRejected, isSosContactAdded, inviteToken, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data, content)
+      console.log('[QA_NOTIF] tap | alertId:', id ?? 'none', '| fullScreen:', isFullScreen, '| sos:', isSos, '| sosInvite:', isSosInvite, '| sosRejected:', isSosRejected, '| contactAdded:', isSosContactAdded)
+
+      if (data.type === 'contacts_refresh') {
+        console.log('[QA_NOTIF] tap contacts_refresh → skip navigation');
+        return;
+      }
 
       await initAnalytics();
       track("push_open", {
@@ -209,6 +221,11 @@ export default Sentry.wrap(function Layout() {
         router.push('/SOSContactsScreen');
         return;
       }
+      if (isSosContactAdded) {
+        console.log('[QA_NAV] tap → SOSContactsScreen (contact added)')
+        router.push('/SOSContactsScreen');
+        return;
+      }
       if (isFullScreen) {
         console.log('[QA_NAV] tap → AlarmScreen | alertId:', id ?? 'none', '| category:', params.category)
         router.push({ pathname: "AlarmScreen", params });
@@ -225,8 +242,8 @@ export default Sentry.wrap(function Layout() {
     const receivedSub = Notifications.addNotificationReceivedListener((notification) => {
       const rawData = notification.request.content.data as NotificationData
       const content = notification.request.content
-      const { isFullScreen, isSos, isSosInvite, isSosRejected, inviteToken, inviterDisplayName, senderName, params } = resolveNotifPayload(rawData, content)
-      console.log('[QA_NOTIF] received foreground | fullScreen:', isFullScreen, '| sos:', isSos, '| sosInvite:', isSosInvite, '| sosRejected:', isSosRejected, '| category:', params.category)
+      const { isFullScreen, isSos, isSosInvite, isSosRejected, isSosContactAdded, inviteToken, inviterDisplayName, senderName, adderDisplayName, params } = resolveNotifPayload(rawData, content)
+      console.log('[QA_NOTIF] received foreground | fullScreen:', isFullScreen, '| sos:', isSos, '| sosInvite:', isSosInvite, '| sosRejected:', isSosRejected, '| contactAdded:', isSosContactAdded, '| category:', params.category)
       if (isFullScreen && !alarmActiveRef.current) {
         alarmActiveRef.current = true
         console.log('[QA_NAV] received → AlarmScreen | category:', params.category, '| alertId:', params.alertId ?? 'none')
@@ -259,6 +276,19 @@ export default Sentry.wrap(function Layout() {
           description: content.body ?? undefined,
         });
         DeviceEventEmitter.emit('contacts:refresh');
+        return;
+      }
+      if (isSosContactAdded) {
+        console.log('[QA_SOS] foreground received | sos_contact_added | adder:', adderDisplayName)
+        AsyncStorage.setItem(PENDING_SOS_CONTACT_ADDED_KEY, adderDisplayName).catch(() => {});
+        toast(`${adderDisplayName} te agregó como contacto SOS`, {
+          description: 'Ya son contactos mutuos.',
+          action: {
+            label: 'Ver',
+            onClick: () => router.push('/SOSContactsScreen'),
+          },
+        });
+        DeviceEventEmitter.emit('contacts:refresh');
       }
     });
 
@@ -288,9 +318,10 @@ export default Sentry.wrap(function Layout() {
       if (!data) return
       const { title: coldTitle, body: coldBody } = initial.notification.request.content
 
-      const { id, isFullScreen, isSos, isSosInvite, isSosRejected, inviteToken, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data, { title: coldTitle, body: coldBody })
-      console.log('[QA_NAV] cold start | category:', data.category ?? 'none', '| type:', (data as Record<string,unknown>).type ?? 'none', '| isSosInvite:', isSosInvite, '| isSos:', isSos, '| isSosRejected:', isSosRejected, '| id:', id ?? 'none')
-      if (!id && !isFullScreen && !isSos && !isSosInvite && !isSosRejected) return
+      const { id, isFullScreen, isSos, isSosInvite, isSosRejected, isSosContactAdded, adderDisplayName, inviteToken, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data, { title: coldTitle, body: coldBody })
+      console.log('[QA_NAV] cold start | category:', data.category ?? 'none', '| type:', data.type ?? 'none', '| isSosInvite:', isSosInvite, '| isSos:', isSos, '| isSosRejected:', isSosRejected, '| contactAdded:', isSosContactAdded, '| id:', id ?? 'none')
+      if (data.type === 'contacts_refresh') return
+      if (!id && !isFullScreen && !isSos && !isSosInvite && !isSosRejected && !isSosContactAdded) return
 
       await initAnalytics();
       track("push_open", {
@@ -313,6 +344,12 @@ export default Sentry.wrap(function Layout() {
       }
       if (isSosRejected) {
         console.log('[QA_NAV] cold start → SOSContactsScreen (rejected)')
+        router.push('/SOSContactsScreen');
+        return;
+      }
+      if (isSosContactAdded) {
+        console.log('[QA_NAV] cold start → SOSContactsScreen (contact added) | adder:', adderDisplayName)
+        AsyncStorage.setItem(PENDING_SOS_CONTACT_ADDED_KEY, adderDisplayName).catch(() => {});
         router.push('/SOSContactsScreen');
         return;
       }

--- a/frontend/utils/pushNotifications.ts
+++ b/frontend/utils/pushNotifications.ts
@@ -75,6 +75,13 @@ export async function setupNotificationChannels() {
     enableVibrate: true,
     showBadge: true,
   });
+  // Silent channel for background data-refresh pushes — no banner, no sound, hidden in drawer
+  await Notifications.setNotificationChannelAsync("contacts_refresh_silent", {
+    name: "Sincronización de contactos",
+    importance: Notifications.AndroidImportance.MIN,
+    enableVibrate: false,
+    showBadge: false,
+  });
 }
 
 export async function registerForPushNotificationsAsync() {


### PR DESCRIPTION
## Problema

Cuando Samsung agrega a Xiaomi como contacto de vuelta (botón de reciprocidad), Xiaomi recibía un push vacío sin título ni cuerpo, sin banner, y al tocarlo iba a la pantalla de alertas. El usuario no sabía que lo habían agregado.

## Qué cambia

### Backend
- **`send_targeted_notification`**: nuevo parámetro `android_channel_id` para especificar el canal Android por llamada
- **`sos_invite/reject_invite`**: ahora pasa `android_channel_id="sos_alerts"` → el rechazo también muestra banner heads-up
- **`sos_contacts/add_reciprocal_contact`**: obtiene el nombre del que agrega, envía notificación visible ("Soledad te agregó como contacto SOS") en canal `sos_alerts` + `contacts_refresh` para refrescar la UI
- **`notifications/send_contacts_refresh_push`**: ahora usa canal `contacts_refresh_silent` (IMPORTANCE_MIN) para no mostrar notificación vacía cuando la app está cerrada

### Frontend
- **`_layout.tsx`**: maneja `sos_contact_added` en los tres escenarios: foreground (toast con acción "Ver" + guarda en AsyncStorage), tap desde background (→ SOSContactsScreen), cold-start (→ SOSContactsScreen + guarda en AsyncStorage). Guard para `contacts_refresh` en tapSub para evitar navegar a `/alerts`
- **`SOSContactsScreen`**: banner persistente "X te agregó como contacto SOS" que aparece al abrir la pantalla si el usuario no vio la notificación; se descarta con el botón X y limpia AsyncStorage
- **`pushNotifications.ts`**: crea canal `contacts_refresh_silent` con `IMPORTANCE_MIN` en setup

## Flujo completo después del fix

1. Xiaomi invita a Samsung → Samsung recibe banner heads-up ✅ (ya funcionaba)
2. Samsung acepta → ambos quedan linked ✅
3. Samsung toca botón "agregar" → Xiaomi recibe banner heads-up "Soledad te agregó como contacto SOS" ✅
4. Si Xiaomi no ve el banner → abre app → SOSContactsScreen muestra banner persistente ✅
5. Xiaomi descarta el banner → se borra de AsyncStorage ✅