### PR TITLE
fix: skip duplicate toast for sos_contact_added in pushNotifications.ts

### DIFF
--- a/frontend/utils/pushNotifications.ts
+++ b/frontend/utils/pushNotifications.ts
@@ -141,7 +141,7 @@ export function setForegroundNotificationHandler() {
       return;
     }
 
-    if (data?.category === "sos_invite" || data?.category === "sos_rejected") {
+    if (data?.category === "sos_invite" || data?.category === "sos_rejected" || data?.category === "sos_contact_added") {
       console.log('[QA_NOTIF] skip toast for', data.category, '— handled by _layout.tsx');
       return;
     }


### PR DESCRIPTION
pushNotifications.ts ya omitía sos_invite y sos_rejected para evitar toasts duplicados con _layout.tsx. Faltaba agregar sos_contact_added a la misma lista.