### PR TITLE
fix: expo-contacts v15 migration and returning-user onboarding bypass

### DIFF
--- a/frontend/app/SOSContactsScreen.tsx
+++ b/frontend/app/SOSContactsScreen.tsx
@@ -6,7 +6,7 @@ import {
   Alert, ActivityIndicator, StyleSheet, KeyboardAvoidingView, Platform, Pressable, Share,
   AppState, DeviceEventEmitter,
 } from "react-native";
-import { Contact as PhoneContact, ContactField, requestPermissionsAsync as requestContactsPermission } from "expo-contacts";
+import * as ExpoContacts from "expo-contacts";
 import { toast } from "sonner-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
@@ -52,7 +52,7 @@ export default function SOSContactsScreen() {
   const [pendingInviteToken, setPendingInviteToken] = useState<string | null>(null);
   const [pendingContactAdded, setPendingContactAdded] = useState<string | null>(null);
   const [pickerVisible, setPickerVisible] = useState(false);
-  const [phoneContacts, setPhoneContacts] = useState<PhoneContact[]>([]);
+  const [phoneContacts, setPhoneContacts] = useState<ExpoContacts.Contact[]>([]);
   const [contactSearch, setContactSearch] = useState("");
   const [loadingContacts, setLoadingContacts] = useState(false);
   const [whoHasMe, setWhoHasMe]             = useState<WhoHasMeItem[]>([]);
@@ -152,7 +152,7 @@ export default function SOSContactsScreen() {
   function closeModal() { setModalVisible(false); setFormError(null); }
 
   async function pickFromContacts() {
-    const { status } = await requestContactsPermission();
+    const { status } = await ExpoContacts.requestPermissionsAsync();
     if (status !== "granted") {
       Alert.alert(
         "Permiso denegado",
@@ -162,10 +162,11 @@ export default function SOSContactsScreen() {
     }
     setLoadingContacts(true);
     try {
-      const fields = [ContactField.GIVEN_NAME, ContactField.FAMILY_NAME, ContactField.PHONES] as const;
-      const all = await PhoneContact.getAllDetails(fields);
-      const withPhone = all.filter(c => c.phones && c.phones.length > 0);
-      setPhoneContacts(withPhone as unknown as PhoneContact[]);
+      const { data } = await ExpoContacts.getContactsAsync({
+        fields: [ExpoContacts.Fields.PhoneNumbers, ExpoContacts.Fields.Name],
+      });
+      const withPhone = data.filter(c => c.phoneNumbers && c.phoneNumbers.length > 0);
+      setPhoneContacts(withPhone);
       setContactSearch("");
       setPickerVisible(true);
     } catch {
@@ -175,10 +176,9 @@ export default function SOSContactsScreen() {
     }
   }
 
-  function selectPhoneContact(contact: PhoneContact) {
-    const c = contact as unknown as { givenName?: string; familyName?: string; phones?: { number?: string }[] };
-    const fullName = [c.givenName, c.familyName].filter(Boolean).join(" ").trim();
-    const phone = (c.phones?.[0]?.number ?? "").replace(/\s/g, "");
+  function selectPhoneContact(contact: ExpoContacts.Contact) {
+    const fullName = (contact.name ?? "").trim();
+    const phone = (contact.phoneNumbers?.[0]?.number ?? "").replace(/\s/g, "");
     setNameVal(fullName);
     setPhoneVal(phone);
     setPickerVisible(false);
@@ -529,34 +529,29 @@ export default function SOSContactsScreen() {
 
             <FlatList
               data={phoneContacts.filter(c => {
-                const raw = c as unknown as { givenName?: string; familyName?: string; phones?: { number?: string }[] };
-                const fullName = [raw.givenName, raw.familyName].filter(Boolean).join(" ").toLowerCase();
                 const q = contactSearch.toLowerCase();
                 if (!q) return true;
-                return fullName.includes(q) || raw.phones?.some(p => p.number?.includes(q));
+                return (c.name ?? "").toLowerCase().includes(q) ||
+                  c.phoneNumbers?.some(p => p.number?.includes(q));
               })}
               keyExtractor={(_, i) => String(i)}
               keyboardShouldPersistTaps="handled"
               style={{ maxHeight: 400 }}
-              renderItem={({ item }) => {
-                const raw = item as unknown as { givenName?: string; familyName?: string; phones?: { number?: string }[] };
-                const fullName = [raw.givenName, raw.familyName].filter(Boolean).join(" ").trim();
-                return (
-                  <TouchableOpacity
-                    style={s.pickerRow}
-                    onPress={() => selectPhoneContact(item)}
-                    activeOpacity={0.7}
-                  >
-                    <MaterialCommunityIcons name="account-outline" size={22} color={colors.brandCyan} style={{ marginRight: 10 }} />
-                    <View style={{ flex: 1 }}>
-                      <Text style={s.pickerName}>{fullName || "Sin nombre"}</Text>
-                      {raw.phones?.slice(0, 2).map((p, i) => (
-                        <Text key={i} style={s.pickerPhone}>{p.number}</Text>
-                      ))}
-                    </View>
-                  </TouchableOpacity>
-                );
-              }}
+              renderItem={({ item }) => (
+                <TouchableOpacity
+                  style={s.pickerRow}
+                  onPress={() => selectPhoneContact(item)}
+                  activeOpacity={0.7}
+                >
+                  <MaterialCommunityIcons name="account-outline" size={22} color={colors.brandCyan} style={{ marginRight: 10 }} />
+                  <View style={{ flex: 1 }}>
+                    <Text style={s.pickerName}>{item.name || "Sin nombre"}</Text>
+                    {item.phoneNumbers?.slice(0, 2).map((p, i) => (
+                      <Text key={i} style={s.pickerPhone}>{p.number}</Text>
+                    ))}
+                  </View>
+                </TouchableOpacity>
+              )}
               ListEmptyComponent={
                 <Text style={[s.bodyText, { textAlign: "center", marginTop: 20 }]}>
                   {contactSearch ? "Sin resultados" : "No hay contactos con teléfono"}

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -27,6 +27,8 @@ import { flushSOSQueue, shouldConfirmPendingSOS } from "./map/sosQueue"
 import { PENDING_SOS_INVITE_KEY } from "./sos-invite/[token]";
 export const PENDING_SOS_CONTACT_ADDED_KEY = "@BluEye:pending_sos_contact_added";
 import { hasCompletedOnboarding } from "./onboarding/_services/onboardingService"
+import { authFetch } from "../utils/api"
+import { API_BASE_URL } from "../utils/config"
 import { usePathname } from "expo-router";
 import * as Sentry from '@sentry/react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -152,9 +154,21 @@ function AuthGate({ children }) {
         const completed = await hasCompletedOnboarding()
         if (completed) {
           router.replace('/(tabs)/MapScreen')
-        } else {
-          router.replace('/onboarding/step1')
+          return
         }
+        // AsyncStorage vacío (e.g. reinstalación): verificar backend como fuente de verdad
+        try {
+          const res = await authFetch(`${API_BASE_URL}/api/v1/users/me`, { method: 'POST' })
+          if (res.ok) {
+            const profile = await res.json()
+            if (profile?.display_name) {
+              await AsyncStorage.setItem('@blueye_onboarding_completed', 'true')
+              router.replace('/(tabs)/MapScreen')
+              return
+            }
+          }
+        } catch { /* si falla, continúa a onboarding */ }
+        router.replace('/onboarding/step1')
       }
       checkAndRoute()
     }

--- a/frontend/app/index.jsx
+++ b/frontend/app/index.jsx
@@ -2,17 +2,20 @@ import { useEffect, useState } from "react";
 import { useRouter } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { hasCompletedOnboarding } from "./onboarding/_services/onboardingService";
+import { useAuth } from "../features/auth/AuthContext";
 
 // Keep the splash screen visible while we check onboarding status
 SplashScreen.preventAutoHideAsync();
 
 export default function Index() {
   const router = useRouter();
+  const { loading } = useAuth();
   const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
+    if (loading) return;
     checkOnboardingStatus();
-  }, []);
+  }, [loading]);
 
   const checkOnboardingStatus = async () => {
     try {
@@ -20,26 +23,25 @@ export default function Index() {
       console.log('🔍 App startup - Onboarding completed?', completed);
 
       if (completed) {
-        // User has completed onboarding, go to main app
+        // Fast path: flag en AsyncStorage → directo a la app.
+        // _layout.tsx redirigirá a /(auth) si la sesión no está activa.
         console.log('✅ Redirecting to MapScreen');
         router.replace("/(tabs)/MapScreen");
       } else {
-        // First time user, show onboarding
-        console.log('⚠️ Redirecting to Onboarding');
-        router.replace("/onboarding/step1");
+        // Sin flag: ir a /(auth). _layout.tsx + checkAndRoute() decidirá si
+        // hay que mostrar login, onboarding, o ir directo al mapa.
+        console.log('⚠️ Sin flag de onboarding → (auth)');
+        router.replace("/(auth)");
       }
     } catch (error) {
       console.error("❌ Error checking onboarding:", error);
-      // On error, default to onboarding for safety
-      router.replace("/onboarding/step1");
+      router.replace("/(auth)");
     } finally {
-      // Mark as ready and hide splash screen
       setIsReady(true);
       await SplashScreen.hideAsync();
     }
   };
 
-  // Return null while loading (splash screen is visible)
   if (!isReady) {
     return null;
   }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,7 @@
         "expo-build-properties": "~1.0.10",
         "expo-camera": "~17.0.10",
         "expo-constants": "~18.0.13",
-        "expo-contacts": "^56.0.9",
+        "expo-contacts": "~15.0.11",
         "expo-crypto": "~15.0.9",
         "expo-dev-client": "~6.0.20",
         "expo-device": "~8.0.10",
@@ -9030,9 +9030,9 @@
       }
     },
     "node_modules/expo-contacts": {
-      "version": "56.0.9",
-      "resolved": "https://registry.npmjs.org/expo-contacts/-/expo-contacts-56.0.9.tgz",
-      "integrity": "sha512-EFtslaAyyh0ni2GpN7Ie2A1+Nq5IxqW3s3g7piNwXkbYS1AsV33gI2rjAuA0Mryd/E82O2trVSnJqp4gHOJ41A==",
+      "version": "15.0.11",
+      "resolved": "https://registry.npmjs.org/expo-contacts/-/expo-contacts-15.0.11.tgz",
+      "integrity": "sha512-buKkoQuWJgVSEvR1Yloa5SvGC/ud7T2YeYDe0R7Aa0oz8pwQpjk3W7OoL3QrXIfYcuKTrIz6ffqC8lc3peaAyg==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "expo-build-properties": "~1.0.10",
     "expo-camera": "~17.0.10",
     "expo-constants": "~18.0.13",
-    "expo-contacts": "^56.0.9",
+    "expo-contacts": "~15.0.11",
     "expo-crypto": "~15.0.9",
     "expo-dev-client": "~6.0.20",
     "expo-device": "~8.0.10",


### PR DESCRIPTION
## Problema

Dos bugs descubiertos al probar el picker de contactos SOS en Samsung:

**1. Crash en Samsung (NoClassDefFoundError: AnyTypeCache)**
`expo-contacts@56.0.9` requiere `AnyTypeCache` de `expo-modules-kotlin`, clase ausente en `expo-modules-core 3.0.30` (SDK 54). La app crasheaba al arrancar en el Samsung con un `DevLauncherErrorActivity`.

**2. Usuario existente mandado a onboarding tras reinstalar**
Después de `adb uninstall` (o reinstalación limpia), `AsyncStorage` queda vacío. El entry point `index.jsx` tomaba la ausencia de la flag `@blueye_onboarding_completed` como señal de usuario nuevo y mandaba directo a `/onboarding/step1`, ignorando que el usuario ya tenía cuenta en el backend.

## Cambios

### `frontend/package.json`
- `expo-contacts`: `^56.0.9` → `~15.0.11` (versión compatible con SDK 54; confirmado con `npx expo install expo-contacts --check`)

### `frontend/app/SOSContactsScreen.tsx`
- Migración completa a la API de expo-contacts v15:
  - `Contact.getAllDetails(fields)` → `getContactsAsync({ fields: [...] })`
  - `ContactField.PHONES` → `ExpoContacts.Fields.PhoneNumbers`
  - `contact.givenName + contact.familyName` → `contact.name`
  - `contact.phones` → `contact.phoneNumbers`
  - Eliminados todos los `as unknown as` casts que workaroundeaban la API v56

### `frontend/app/index.jsx`
- Agrega `useAuth` para esperar a que Firebase termine de restaurar la sesión antes de hacer routing (`if (loading) return`)
- Cuando no hay flag de onboarding → `/(auth)` (no más `/onboarding/step1` directo)
- `_layout.tsx` es ahora el único responsable de decidir entre onboarding y mapa

### `frontend/app/_layout.tsx`
- `checkAndRoute()` ahora verifica el backend como fuente de verdad cuando `AsyncStorage` está vacío:
  - Llama `POST /api/v1/users/me`
  - Si el perfil tiene `display_name` → usuario existente → guarda flag → `MapScreen`
  - Si no → usuario nuevo → `/onboarding/step1`

## Flujo corregido para usuario existente tras reinstalación

```
index.jsx: sin flag → /(auth)
Usuario inicia sesión con Google
_layout.tsx detecta: user && inAuthGroup → checkAndRoute()
  hasCompletedOnboarding() → false
  POST /api/v1/users/me → { display_name: "Soledad" }
  AsyncStorage.setItem('@blueye_onboarding_completed', 'true')
  router.replace('/(tabs)/MapScreen') ✅
```

## Testing

- Verificado en Samsung Galaxy (ce091719b45f74240d7e) y Xiaomi (tg75kfjrcy49bqwg)
- Samsung: crash eliminado, usuario existente va directo al mapa tras Google login
- Picker de contactos funcional en ambos dispositivos