### PR TITLE
feat: SOS receiver screen, emergency push, and map flow

### DIFF
--- a/backend/app/features/sos_trigger/service.py
+++ b/backend/app/features/sos_trigger/service.py
@@ -95,7 +95,6 @@ async def trigger_sos(
                     priority="high",
                     notification=messaging.AndroidNotification(
                         channel_id="sos_emergency",
-                        priority=messaging.AndroidNotificationPriority.MAX,
                         default_vibrate_timings=False,
                         vibrate_timings_millis=[0, 250, 250, 250],
                     ),

--- a/backend/app/features/sos_trigger/service.py
+++ b/backend/app/features/sos_trigger/service.py
@@ -94,7 +94,7 @@ async def trigger_sos(
                 android=messaging.AndroidConfig(
                     priority="high",
                     notification=messaging.AndroidNotification(
-                        channel_id="sos_alerts",
+                        channel_id="sos_emergency",
                         priority=messaging.AndroidNotificationPriority.MAX,
                         default_vibrate_timings=False,
                         vibrate_timings_millis=[0, 250, 250, 250],

--- a/backend/app/features/sos_trigger/service.py
+++ b/backend/app/features/sos_trigger/service.py
@@ -48,7 +48,14 @@ async def trigger_sos(
             headers={"Retry-After": str(retry_after)},
         )
 
-    # 2. Linked contacts
+    # 2. Sender phone (included in push so receiver can call back)
+    phone_row = await db.execute(
+        text("SELECT phone FROM users WHERE id = :sender_id"),
+        {"sender_id": sender_id},
+    )
+    sender_phone: str = phone_row.scalar() or ""
+
+    # 3. Linked contacts
     contacts_result = await db.execute(
         text("""
             SELECT linked_user_id FROM sos_contacts
@@ -64,12 +71,12 @@ async def trigger_sos(
     skipped_count = 0
 
     if linked_user_ids:
-        # 3. Device tokens
+        # 4. Device tokens
         token_map = await get_tokens_for_users(db, linked_user_ids)
         all_tokens = [t for tokens in token_map.values() for t in tokens]
         skipped_count = len([uid for uid in linked_user_ids if uid not in token_map])
 
-        # 4. Firebase push
+        # 5. Firebase push
         if all_tokens:
             display_name = sender_display_name or "Un usuario de BluEye"
             msg = messaging.MulticastMessage(
@@ -78,11 +85,27 @@ async def trigger_sos(
                     body="Necesita ayuda urgente. Toca para ver su ubicación.",
                 ),
                 data={
-                    "category":    "sos",
-                    "sender_name": display_name,
+                    "category":     "sos",
+                    "sender_name":  display_name,
+                    "sender_phone": sender_phone,
                     "lat":         str(lat) if lat is not None else "",
                     "lon":         str(lon) if lon is not None else "",
                 },
+                android=messaging.AndroidConfig(
+                    priority="high",
+                    notification=messaging.AndroidNotification(
+                        channel_id="sos_alerts",
+                        priority=messaging.AndroidNotificationPriority.MAX,
+                        default_vibrate_timings=False,
+                        vibrate_timings_millis=[0, 250, 250, 250],
+                    ),
+                ),
+                apns=messaging.APNSConfig(
+                    headers={"apns-priority": "10"},
+                    payload=messaging.APNSPayload(
+                        aps=messaging.Aps(sound="default"),
+                    ),
+                ),
                 tokens=all_tokens,
             )
             try:

--- a/frontend/app/(tabs)/MapScreen.tsx
+++ b/frontend/app/(tabs)/MapScreen.tsx
@@ -4,11 +4,12 @@ import { useLocalSearchParams } from "expo-router";
 import Main from "../map";
 
 const MapScreen = () => {
-  const { alertLat, alertLon, alertTitle, alertLevel } = useLocalSearchParams<{
+  const { alertLat, alertLon, alertTitle, alertLevel, alertSosPhone } = useLocalSearchParams<{
     alertLat?: string;
     alertLon?: string;
     alertTitle?: string;
     alertLevel?: string;
+    alertSosPhone?: string;
   }>();
 
   const focusLat = alertLat ? parseFloat(alertLat) : undefined;
@@ -24,6 +25,7 @@ const MapScreen = () => {
         focusLon={focusLon}
         focusTitle={alertTitle}
         focusLevel={alertLevel ? parseInt(alertLevel, 10) : undefined}
+        focusSosPhone={alertSosPhone}
       />
     </>
   );

--- a/frontend/app/SettingsScreen.tsx
+++ b/frontend/app/SettingsScreen.tsx
@@ -1,19 +1,64 @@
 import "../global.css";
 import { clearOnboardingData } from './onboarding/_services/onboardingService';
-import { Alert, Text, ScrollView, ActivityIndicator } from "react-native";
+import { Alert, Text, ScrollView, ActivityIndicator, View, TextInput, StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { useEffect, useState } from "react";
 import { useModel } from "./ai/_context/ModelContext";
 import { MODEL_FAILURE_LABEL } from "./ai/_services/modelTelemetry";
 import { useAuth } from "../features/auth/AuthContext";
 import ScreenHeader from "../components/ScreenHeader";
 import OptionCard from "../components/OptionCard";
+import { authFetch } from "../utils/api";
+import { API_BASE_URL } from "../utils/config";
 
 export default function SettingsScreen() {
   const router = useRouter();
   const { modelStatus, optIn, optOut, retryDownload, downloadProgress, modelFailure } = useModel();
   const { signOut, deleteAccount } = useAuth();
+
+  const [phone, setPhone]             = useState<string>("");
+  const [phoneInput, setPhoneInput]   = useState<string>("");
+  const [editingPhone, setEditingPhone] = useState(false);
+  const [savingPhone, setSavingPhone] = useState(false);
+
+  useEffect(() => {
+    authFetch(`${API_BASE_URL}/api/v1/users/me`)
+      .then(r => r.json())
+      .then(data => {
+        const p: string = data?.phone ?? "";
+        setPhone(p);
+        setPhoneInput(p);
+      })
+      .catch(() => {});
+  }, []);
+
+  async function handleSavePhone() {
+    const trimmed = phoneInput.trim();
+    if (!trimmed) {
+      Alert.alert("Error", "Ingresa un número de teléfono válido.");
+      return;
+    }
+    setSavingPhone(true);
+    try {
+      const res = await authFetch(`${API_BASE_URL}/api/v1/users/me/phone`, {
+        method: "PATCH",
+        body: JSON.stringify({ phone: trimmed }),
+      });
+      if (res.ok) {
+        setPhone(trimmed);
+        setEditingPhone(false);
+        Alert.alert("Listo", "Tu número se guardó. Tus contactos SOS podrán llamarte cuando reciban una alerta.");
+      } else {
+        Alert.alert("Error", "No se pudo guardar el número. Intenta de nuevo.");
+      }
+    } catch {
+      Alert.alert("Error", "Sin conexión. Intenta de nuevo.");
+    } finally {
+      setSavingPhone(false);
+    }
+  }
 
   const handleDeleteAccount = () => {
     Alert.alert(
@@ -102,6 +147,47 @@ export default function SettingsScreen() {
           onPress={() => router.push('/NotificationPreferencesScreen')}
         />
 
+        {/* Phone number for SOS call-back */}
+        <OptionCard
+          icon="phone-outline"
+          title="Mi número de teléfono"
+          subtitle={phone ? phone : "Sin número — tus contactos no podrán llamarte"}
+          onPress={() => {
+            setPhoneInput(phone);
+            setEditingPhone(v => !v);
+          }}
+        />
+        {editingPhone && (
+          <View style={st.phoneRow}>
+            <TextInput
+              style={st.phoneInput}
+              value={phoneInput}
+              onChangeText={setPhoneInput}
+              placeholder="+52 55 1234 5678"
+              placeholderTextColor="rgba(255,255,255,0.3)"
+              keyboardType="phone-pad"
+              autoFocus
+              returnKeyType="done"
+              onSubmitEditing={handleSavePhone}
+            />
+            <View style={st.phoneActions}>
+              <Text
+                style={[st.phoneBtn, st.phoneBtnCancel]}
+                onPress={() => setEditingPhone(false)}
+              >
+                Cancelar
+              </Text>
+              {savingPhone ? (
+                <ActivityIndicator color="white" style={{ marginLeft: 16 }} />
+              ) : (
+                <Text style={[st.phoneBtn, st.phoneBtnSave]} onPress={handleSavePhone}>
+                  Guardar
+                </Text>
+              )}
+            </View>
+          </View>
+        )}
+
         <OptionCard icon="restore" title="Reiniciar Onboarding" onPress={handleResetOnboarding} />
 
         {/* AI offline model — one card per lifecycle status (single source of truth). */}
@@ -180,3 +266,42 @@ export default function SettingsScreen() {
   );
 }
 
+const st = StyleSheet.create({
+  phoneRow: {
+    marginHorizontal: 16,
+    marginTop: -4,
+    marginBottom: 8,
+    backgroundColor: "rgba(255,255,255,0.05)",
+    borderRadius: 12,
+    padding: 14,
+    gap: 12,
+  },
+  phoneInput: {
+    color: "white",
+    fontSize: 16,
+    fontFamily: "Poppins_400Regular",
+    borderBottomWidth: 1,
+    borderBottomColor: "rgba(255,255,255,0.2)",
+    paddingBottom: 6,
+  },
+  phoneActions: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    gap: 4,
+  },
+  phoneBtn: {
+    fontSize: 14,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    overflow: "hidden",
+  },
+  phoneBtnCancel: {
+    color: "rgba(255,255,255,0.45)",
+  },
+  phoneBtnSave: {
+    color: "white",
+    fontFamily: "Poppins_600SemiBold",
+    backgroundColor: "rgba(0, 196, 203, 0.15)",
+  },
+});

--- a/frontend/app/SettingsScreen.tsx
+++ b/frontend/app/SettingsScreen.tsx
@@ -1,64 +1,19 @@
 import "../global.css";
 import { clearOnboardingData } from './onboarding/_services/onboardingService';
-import { Alert, Text, ScrollView, ActivityIndicator, View, TextInput, StyleSheet } from "react-native";
+import { Alert, Text, ScrollView, ActivityIndicator } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
-import { useEffect, useState } from "react";
 import { useModel } from "./ai/_context/ModelContext";
 import { MODEL_FAILURE_LABEL } from "./ai/_services/modelTelemetry";
 import { useAuth } from "../features/auth/AuthContext";
 import ScreenHeader from "../components/ScreenHeader";
 import OptionCard from "../components/OptionCard";
-import { authFetch } from "../utils/api";
-import { API_BASE_URL } from "../utils/config";
 
 export default function SettingsScreen() {
   const router = useRouter();
   const { modelStatus, optIn, optOut, retryDownload, downloadProgress, modelFailure } = useModel();
   const { signOut, deleteAccount } = useAuth();
-
-  const [phone, setPhone]             = useState<string>("");
-  const [phoneInput, setPhoneInput]   = useState<string>("");
-  const [editingPhone, setEditingPhone] = useState(false);
-  const [savingPhone, setSavingPhone] = useState(false);
-
-  useEffect(() => {
-    authFetch(`${API_BASE_URL}/api/v1/users/me`)
-      .then(r => r.json())
-      .then(data => {
-        const p: string = data?.phone ?? "";
-        setPhone(p);
-        setPhoneInput(p);
-      })
-      .catch(() => {});
-  }, []);
-
-  async function handleSavePhone() {
-    const trimmed = phoneInput.trim();
-    if (!trimmed) {
-      Alert.alert("Error", "Ingresa un número de teléfono válido.");
-      return;
-    }
-    setSavingPhone(true);
-    try {
-      const res = await authFetch(`${API_BASE_URL}/api/v1/users/me/phone`, {
-        method: "PATCH",
-        body: JSON.stringify({ phone: trimmed }),
-      });
-      if (res.ok) {
-        setPhone(trimmed);
-        setEditingPhone(false);
-        Alert.alert("Listo", "Tu número se guardó. Tus contactos SOS podrán llamarte cuando reciban una alerta.");
-      } else {
-        Alert.alert("Error", "No se pudo guardar el número. Intenta de nuevo.");
-      }
-    } catch {
-      Alert.alert("Error", "Sin conexión. Intenta de nuevo.");
-    } finally {
-      setSavingPhone(false);
-    }
-  }
 
   const handleDeleteAccount = () => {
     Alert.alert(
@@ -147,47 +102,6 @@ export default function SettingsScreen() {
           onPress={() => router.push('/NotificationPreferencesScreen')}
         />
 
-        {/* Phone number for SOS call-back */}
-        <OptionCard
-          icon="phone-outline"
-          title="Mi número de teléfono"
-          subtitle={phone ? phone : "Sin número — tus contactos no podrán llamarte"}
-          onPress={() => {
-            setPhoneInput(phone);
-            setEditingPhone(v => !v);
-          }}
-        />
-        {editingPhone && (
-          <View style={st.phoneRow}>
-            <TextInput
-              style={st.phoneInput}
-              value={phoneInput}
-              onChangeText={setPhoneInput}
-              placeholder="+52 55 1234 5678"
-              placeholderTextColor="rgba(255,255,255,0.3)"
-              keyboardType="phone-pad"
-              autoFocus
-              returnKeyType="done"
-              onSubmitEditing={handleSavePhone}
-            />
-            <View style={st.phoneActions}>
-              <Text
-                style={[st.phoneBtn, st.phoneBtnCancel]}
-                onPress={() => setEditingPhone(false)}
-              >
-                Cancelar
-              </Text>
-              {savingPhone ? (
-                <ActivityIndicator color="white" style={{ marginLeft: 16 }} />
-              ) : (
-                <Text style={[st.phoneBtn, st.phoneBtnSave]} onPress={handleSavePhone}>
-                  Guardar
-                </Text>
-              )}
-            </View>
-          </View>
-        )}
-
         <OptionCard icon="restore" title="Reiniciar Onboarding" onPress={handleResetOnboarding} />
 
         {/* AI offline model — one card per lifecycle status (single source of truth). */}
@@ -265,43 +179,3 @@ export default function SettingsScreen() {
     </SafeAreaView>
   );
 }
-
-const st = StyleSheet.create({
-  phoneRow: {
-    marginHorizontal: 16,
-    marginTop: -4,
-    marginBottom: 8,
-    backgroundColor: "rgba(255,255,255,0.05)",
-    borderRadius: 12,
-    padding: 14,
-    gap: 12,
-  },
-  phoneInput: {
-    color: "white",
-    fontSize: 16,
-    fontFamily: "Poppins_400Regular",
-    borderBottomWidth: 1,
-    borderBottomColor: "rgba(255,255,255,0.2)",
-    paddingBottom: 6,
-  },
-  phoneActions: {
-    flexDirection: "row",
-    justifyContent: "flex-end",
-    gap: 4,
-  },
-  phoneBtn: {
-    fontSize: 14,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 8,
-    overflow: "hidden",
-  },
-  phoneBtnCancel: {
-    color: "rgba(255,255,255,0.45)",
-  },
-  phoneBtnSave: {
-    color: "white",
-    fontFamily: "Poppins_600SemiBold",
-    backgroundColor: "rgba(0, 196, 203, 0.15)",
-  },
-});

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -72,6 +72,7 @@ interface NotificationData {
   alertMessage?: string
   bulletinUrl?: string
   sender_name?: string
+  sender_phone?: string
   lat?: string
   lon?: string
   invite_token?: string
@@ -95,6 +96,7 @@ function resolveNotifPayload(
   const sosLat = parseFloat(data.lat ?? '')
   const sosLon = parseFloat(data.lon ?? '')
   const sosHasCoords = Number.isFinite(sosLat) && Number.isFinite(sosLon)
+  const senderPhone = data.sender_phone ?? ''
   return {
     id,
     levelNum,
@@ -107,6 +109,7 @@ function resolveNotifPayload(
     inviteToken: data.invite_token,
     inviterDisplayName: data.inviter_display_name ?? 'Un usuario',
     senderName: data.sender_name ?? 'Un contacto',
+    senderPhone,
     sosLat,
     sosLon,
     sosHasCoords,
@@ -203,7 +206,7 @@ export default Sentry.wrap(function Layout() {
     // Tap en notificación (background → foreground, o foreground tap)
     const tapSub = addNotificationResponseListener(async (rawData, content) => {
       const data = rawData as NotificationData
-      const { id, isFullScreen, isSos, isSosInvite, isSosRejected, isSosContactAdded, inviteToken, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data, content)
+      const { id, isFullScreen, isSos, isSosInvite, isSosRejected, isSosContactAdded, inviteToken, senderName, senderPhone, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data, content)
       console.log('[QA_NOTIF] tap | alertId:', id ?? 'none', '| fullScreen:', isFullScreen, '| sos:', isSos, '| sosInvite:', isSosInvite, '| sosRejected:', isSosRejected, '| contactAdded:', isSosContactAdded)
 
       if (data.type === 'contacts_refresh') {
@@ -226,8 +229,16 @@ export default Sentry.wrap(function Layout() {
         return;
       }
       if (isSos) {
-        const coordsText = sosHasCoords ? `\nUbicación: ${sosLat.toFixed(5)}, ${sosLon.toFixed(5)}` : '';
-        Alert.alert('SOS recibido', `${senderName} necesita ayuda urgente.${coordsText}`);
+        console.log('[QA_NAV] tap → sos-receiver | sender:', senderName, '| hasCoords:', sosHasCoords, '| hasPhone:', !!senderPhone)
+        router.push({
+          pathname: '/sos-receiver',
+          params: {
+            senderName,
+            senderPhone,
+            lat: sosHasCoords ? String(sosLat) : '',
+            lon: sosHasCoords ? String(sosLon) : '',
+          },
+        });
         return;
       }
       if (isSosRejected) {
@@ -256,7 +267,7 @@ export default Sentry.wrap(function Layout() {
     const receivedSub = Notifications.addNotificationReceivedListener((notification) => {
       const rawData = notification.request.content.data as NotificationData
       const content = notification.request.content
-      const { isFullScreen, isSos, isSosInvite, isSosRejected, isSosContactAdded, inviteToken, inviterDisplayName, senderName, adderDisplayName, params } = resolveNotifPayload(rawData, content)
+      const { isFullScreen, isSos, isSosInvite, isSosRejected, isSosContactAdded, inviteToken, inviterDisplayName, senderName, senderPhone, adderDisplayName, params } = resolveNotifPayload(rawData, content)
       console.log('[QA_NOTIF] received foreground | fullScreen:', isFullScreen, '| sos:', isSos, '| sosInvite:', isSosInvite, '| sosRejected:', isSosRejected, '| contactAdded:', isSosContactAdded, '| category:', params.category)
       if (isFullScreen && !alarmActiveRef.current) {
         alarmActiveRef.current = true
@@ -279,8 +290,15 @@ export default Sentry.wrap(function Layout() {
         return;
       }
       if (isSos) {
-        toast.error(`SOS — ${senderName}`, {
-          description: 'Necesita ayuda urgente. Revisa tu pantalla.',
+        console.log('[QA_NAV] foreground SOS → sos-receiver | sender:', senderName, '| hasPhone:', !!senderPhone)
+        router.push({
+          pathname: '/sos-receiver',
+          params: {
+            senderName,
+            senderPhone,
+            lat: rawData.lat ?? '',
+            lon: rawData.lon ?? '',
+          },
         });
         return;
       }
@@ -332,7 +350,7 @@ export default Sentry.wrap(function Layout() {
       if (!data) return
       const { title: coldTitle, body: coldBody } = initial.notification.request.content
 
-      const { id, isFullScreen, isSos, isSosInvite, isSosRejected, isSosContactAdded, adderDisplayName, inviteToken, senderName, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data, { title: coldTitle, body: coldBody })
+      const { id, isFullScreen, isSos, isSosInvite, isSosRejected, isSosContactAdded, adderDisplayName, inviteToken, senderName, senderPhone, sosLat, sosLon, sosHasCoords, params } = resolveNotifPayload(data, { title: coldTitle, body: coldBody })
       console.log('[QA_NAV] cold start | category:', data.category ?? 'none', '| type:', data.type ?? 'none', '| isSosInvite:', isSosInvite, '| isSos:', isSos, '| isSosRejected:', isSosRejected, '| contactAdded:', isSosContactAdded, '| id:', id ?? 'none')
       if (data.type === 'contacts_refresh') return
       if (!id && !isFullScreen && !isSos && !isSosInvite && !isSosRejected && !isSosContactAdded) return
@@ -352,8 +370,16 @@ export default Sentry.wrap(function Layout() {
         return;
       }
       if (isSos) {
-        const coordsText = sosHasCoords ? `\nUbicación: ${sosLat.toFixed(5)}, ${sosLon.toFixed(5)}` : '';
-        Alert.alert('SOS recibido', `${senderName} necesita ayuda urgente.${coordsText}`);
+        console.log('[QA_NAV] cold start → sos-receiver | sender:', senderName, '| hasCoords:', sosHasCoords, '| hasPhone:', !!senderPhone)
+        router.push({
+          pathname: '/sos-receiver',
+          params: {
+            senderName,
+            senderPhone,
+            lat: sosHasCoords ? String(sosLat) : '',
+            lon: sosHasCoords ? String(sosLon) : '',
+          },
+        });
         return;
       }
       if (isSosRejected) {

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -258,8 +258,9 @@ export default Sentry.wrap(function Layout() {
         console.log('[QA_NAV] tap → alert detail | alertId:', id)
         router.push({ pathname: "/alerts/[id]", params: { id } });
       } else {
-        console.log('[QA_NAV] tap → alerts list (no alertId)')
-        router.push("/alerts");
+        // No useful payload — MIUI/Android can fire the response listener spuriously
+        // when bringing the app to foreground. Don't navigate anywhere.
+        console.log('[QA_NAV] tap → no useful data, skipping navigation');
       }
     });
 
@@ -300,6 +301,10 @@ export default Sentry.wrap(function Layout() {
             lon: rawData.lon ?? '',
           },
         });
+        // IMPORTANCE_MAX overrides shouldShowAlert:false on Android/MIUI, so the notification
+        // stays visible in the tray even after we handle it in-app. Dismiss it immediately so
+        // the tap listener can't fire again for the same SOS and push a second sos-receiver.
+        Notifications.dismissNotificationAsync(notification.request.identifier).catch(() => {});
         return;
       }
       if (isSosRejected) {

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -481,6 +481,10 @@ export default Sentry.wrap(function Layout() {
                       options={{ headerShown: false }}
                     />
                     <Stack.Screen
+                      name="sos-receiver"
+                      options={{ headerShown: false }}
+                    />
+                    <Stack.Screen
                       name="sos-invite/[token]"
                       options={{ headerShown: false }}
                     />

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -481,7 +481,7 @@ export default Sentry.wrap(function Layout() {
                       options={{ headerShown: false }}
                     />
                     <Stack.Screen
-                      name="sos-receiver"
+                      name="sos-receiver/index"
                       options={{ headerShown: false }}
                     />
                     <Stack.Screen

--- a/frontend/app/map/index.tsx
+++ b/frontend/app/map/index.tsx
@@ -13,6 +13,7 @@ import {
   AppState,
   Image,
   KeyboardAvoidingView,
+  Linking,
   Platform,
 } from "react-native";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
@@ -38,7 +39,7 @@ import { colors, fonts } from "../../utils/theme";
 import { authFetch } from "../../utils/api";
 import { API_BASE_URL } from "../../utils/config";
 import * as Network from "expo-network";
-import { useFocusEffect } from "expo-router";
+import { useFocusEffect, useRouter } from "expo-router";
 import { enqueueSOS, hasPendingSOSItem, getPendingSOSItem, flushSOSQueue, clearSOSQueue } from "./sosQueue";
 import type { Zone, ZoneType } from "./types";
 
@@ -51,6 +52,9 @@ interface MapProps {
   focusLon?: number;
   focusTitle?: string;
   focusLevel?: number;
+  // Present only when navigated from sos-receiver — undefined for hurricane alerts.
+  // Empty string means SOS context but no phone registered.
+  focusSosPhone?: string;
 }
 
 const LEVEL_COLORS: Record<number, string> = {
@@ -108,7 +112,8 @@ const ZoneMarker = React.memo(function ZoneMarker({ zone, onPress }: { zone: Zon
   );
 });
 
-export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, focusLevel }: MapProps = {}) {
+export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, focusLevel, focusSosPhone }: MapProps = {}) {
+  const router = useRouter();
   const [region, setRegion] = useState(DEFAULT_REGION);
   const [showWind, setShowWind] = useState(true);
   const [showPrecip, setShowPrecip] = useState(false);
@@ -651,10 +656,39 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
         )}
       </MapView>
 
-      {/* Layer selector */}
+      {/* SOS context banner — only shown when navigated from sos-receiver */}
+      {focusSosPhone !== undefined && focusTitle != null && (
+        <View style={sosBanner.bar}>
+          <View style={sosBanner.left}>
+            <MaterialCommunityIcons name="alarm-light" size={16} color="#030810" />
+            <Text style={sosBanner.name} numberOfLines={1}>{focusTitle}</Text>
+          </View>
+          <View style={sosBanner.right}>
+            {!!focusSosPhone && (
+              <Pressable
+                style={sosBanner.callBtn}
+                onPress={() => Linking.openURL(`tel:${focusSosPhone!.replace(/\s/g, '')}`).catch(() => {})}
+                android_ripple={{ color: 'rgba(0,0,0,0.15)' }}
+              >
+                <MaterialCommunityIcons name="phone" size={15} color="#030810" />
+                <Text style={sosBanner.callBtnText}>Llamar</Text>
+              </Pressable>
+            )}
+            <Pressable
+              style={sosBanner.backBtn}
+              onPress={() => router.back()}
+              android_ripple={{ color: 'rgba(255,255,255,0.1)' }}
+            >
+              <MaterialCommunityIcons name="arrow-left" size={20} color="white" />
+            </Pressable>
+          </View>
+        </View>
+      )}
+
+      {/* Layer selector — shifted down when SOS banner is visible */}
       <Pressable
         onPress={() => setLayerModalVisible(true)}
-        className="absolute top-12 right-4 p-3 rounded-full"
+        className={`absolute ${focusSosPhone !== undefined ? 'top-20' : 'top-12'} right-4 p-3 rounded-full`}
         style={{ backgroundColor: 'rgba(8, 15, 30, 0.85)' }}
       >
         <MaterialCommunityIcons name="layers-outline" size={24} color="white" />
@@ -1101,5 +1135,56 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
 const styles = StyleSheet.create({
   map: {
     flex: 1,
+  },
+});
+
+const sosBanner = StyleSheet.create({
+  bar: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    backgroundColor: colors.brandRed,
+    zIndex: 200,
+  },
+  left: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    flex: 1,
+    marginRight: 8,
+  },
+  name: {
+    color: '#030810',
+    fontFamily: fonts.poppinsSemiBold,
+    fontSize: 13,
+    flex: 1,
+  },
+  right: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  callBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    backgroundColor: 'rgba(0,0,0,0.15)',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 20,
+  },
+  callBtnText: {
+    color: '#030810',
+    fontFamily: fonts.poppinsSemiBold,
+    fontSize: 13,
+  },
+  backBtn: {
+    padding: 4,
   },
 });

--- a/frontend/app/sos-receiver/index.tsx
+++ b/frontend/app/sos-receiver/index.tsx
@@ -1,0 +1,225 @@
+import "../../global.css";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { View, Text, Pressable, StyleSheet, Linking, Alert } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { colors, fonts } from "../../utils/theme";
+
+export default function SOSReceiverScreen() {
+  const router = useRouter();
+  const { senderName, senderPhone, lat, lon } = useLocalSearchParams<{
+    senderName: string;
+    senderPhone?: string;
+    lat?: string;
+    lon?: string;
+  }>();
+
+  const parsedLat = parseFloat(lat ?? "");
+  const parsedLon = parseFloat(lon ?? "");
+  const hasCoords = Number.isFinite(parsedLat) && Number.isFinite(parsedLon);
+  const hasPhone  = !!senderPhone && senderPhone.trim().length > 0;
+
+  function handleCall() {
+    const tel = `tel:${senderPhone!.replace(/\s/g, "")}`;
+    Linking.canOpenURL(tel).then((can) => {
+      if (can) Linking.openURL(tel);
+      else Alert.alert("Error", "No se puede abrir la marcadora en este dispositivo.");
+    });
+  }
+
+  function handleViewOnMap() {
+    router.replace({
+      pathname: "/(tabs)/MapScreen",
+      params: hasCoords
+        ? { focusLat: String(parsedLat), focusLon: String(parsedLon), focusTitle: senderName }
+        : {},
+    });
+  }
+
+  function handleDismiss() {
+    if (router.canGoBack()) router.back();
+    else router.replace("/(tabs)/MapScreen");
+  }
+
+  return (
+    <SafeAreaView style={s.root} edges={["top", "bottom"]}>
+      {/* Header urgency bar */}
+      <View style={s.urgencyBar}>
+        <MaterialCommunityIcons name="alarm-light" size={20} color="#030810" />
+        <Text style={s.urgencyText}>ALERTA SOS</Text>
+        <MaterialCommunityIcons name="alarm-light" size={20} color="#030810" />
+      </View>
+
+      {/* Main content */}
+      <View style={s.body}>
+        {/* Icon */}
+        <View style={s.iconWrap}>
+          <MaterialCommunityIcons name="alarm-light-outline" size={64} color={colors.brandRed} />
+        </View>
+
+        {/* Sender */}
+        <Text style={s.label}>Tu contacto</Text>
+        <Text style={s.senderName}>{senderName ?? "Un contacto"}</Text>
+        <Text style={s.subtitle}>Necesita ayuda urgente</Text>
+
+        {/* Location */}
+        <View style={s.locationCard}>
+          <MaterialCommunityIcons name="map-marker-outline" size={20} color={colors.brandCyan} />
+          {hasCoords ? (
+            <Text style={s.locationText}>
+              {parsedLat.toFixed(5)}, {parsedLon.toFixed(5)}
+            </Text>
+          ) : (
+            <Text style={[s.locationText, { color: "rgba(255,255,255,0.35)" }]}>
+              Sin ubicación disponible
+            </Text>
+          )}
+        </View>
+
+        {/* Actions */}
+        <View style={s.actions}>
+          {hasPhone && (
+            <Pressable style={s.callBtn} onPress={handleCall} android_ripple={{ color: "rgba(0,0,0,0.15)" }}>
+              <MaterialCommunityIcons name="phone" size={22} color="#030810" />
+              <Text style={s.callBtnText}>Llamar</Text>
+            </Pressable>
+          )}
+
+          {hasCoords && (
+            <Pressable style={s.mapBtn} onPress={handleViewOnMap} android_ripple={{ color: "rgba(255,255,255,0.08)" }}>
+              <MaterialCommunityIcons name="map-search-outline" size={22} color={colors.brandCyan} />
+              <Text style={s.mapBtnText}>Ver en mapa</Text>
+            </Pressable>
+          )}
+        </View>
+      </View>
+
+      {/* Dismiss */}
+      <Pressable style={s.dismissBtn} onPress={handleDismiss} android_ripple={{ color: "rgba(255,255,255,0.06)" }}>
+        <Text style={s.dismissText}>Cerrar</Text>
+      </Pressable>
+    </SafeAreaView>
+  );
+}
+
+const s = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: "#07111E",
+  },
+  urgencyBar: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 10,
+    backgroundColor: colors.brandRed,
+    paddingVertical: 10,
+  },
+  urgencyText: {
+    color: "#030810",
+    fontFamily: fonts.poppinsSemiBold,
+    fontSize: 14,
+    letterSpacing: 2,
+  },
+  body: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 32,
+  },
+  iconWrap: {
+    width: 100,
+    height: 100,
+    borderRadius: 50,
+    backgroundColor: "rgba(226,67,55,0.12)",
+    borderWidth: 1.5,
+    borderColor: "rgba(226,67,55,0.3)",
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 28,
+  },
+  label: {
+    color: "rgba(255,255,255,0.45)",
+    fontFamily: fonts.poppins,
+    fontSize: 12,
+    letterSpacing: 1,
+    textTransform: "uppercase",
+    marginBottom: 6,
+  },
+  senderName: {
+    color: "white",
+    fontFamily: fonts.poppinsSemiBold,
+    fontSize: 26,
+    textAlign: "center",
+    marginBottom: 6,
+  },
+  subtitle: {
+    color: "rgba(255,255,255,0.55)",
+    fontFamily: fonts.poppins,
+    fontSize: 15,
+    marginBottom: 28,
+  },
+  locationCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    backgroundColor: "rgba(255,255,255,0.05)",
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.09)",
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 18,
+    marginBottom: 36,
+    alignSelf: "stretch",
+    justifyContent: "center",
+  },
+  locationText: {
+    color: "rgba(255,255,255,0.75)",
+    fontFamily: fonts.poppins,
+    fontSize: 14,
+  },
+  actions: {
+    alignSelf: "stretch",
+    gap: 12,
+  },
+  callBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 10,
+    backgroundColor: colors.brandRed,
+    borderRadius: 14,
+    paddingVertical: 16,
+  },
+  callBtnText: {
+    color: "#030810",
+    fontFamily: fonts.poppinsSemiBold,
+    fontSize: 17,
+  },
+  mapBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 10,
+    borderWidth: 1,
+    borderColor: colors.brandCyan,
+    borderRadius: 14,
+    paddingVertical: 14,
+  },
+  mapBtnText: {
+    color: colors.brandCyan,
+    fontFamily: fonts.poppinsSemiBold,
+    fontSize: 16,
+  },
+  dismissBtn: {
+    alignItems: "center",
+    paddingVertical: 18,
+    borderTopWidth: 1,
+    borderTopColor: "rgba(255,255,255,0.07)",
+  },
+  dismissText: {
+    color: "rgba(255,255,255,0.4)",
+    fontFamily: fonts.poppins,
+    fontSize: 15,
+  },
+});

--- a/frontend/app/sos-receiver/index.tsx
+++ b/frontend/app/sos-receiver/index.tsx
@@ -19,6 +19,8 @@ export default function SOSReceiverScreen() {
   const hasCoords = Number.isFinite(parsedLat) && Number.isFinite(parsedLon);
   const hasPhone  = !!senderPhone && senderPhone.trim().length > 0;
 
+  console.log('[QA_SOS_RECEIVER] render | sender:', senderName, '| hasCoords:', hasCoords, '| hasPhone:', hasPhone, '| lat:', lat, '| lon:', lon);
+
   function handleCall() {
     const tel = `tel:${senderPhone!.replace(/\s/g, "")}`;
     Linking.canOpenURL(tel).then((can) => {
@@ -28,10 +30,12 @@ export default function SOSReceiverScreen() {
   }
 
   function handleViewOnMap() {
+    console.log('[QA_SOS_RECEIVER] ver en mapa → alertLat:', parsedLat, '| alertLon:', parsedLon);
     router.replace({
       pathname: "/(tabs)/MapScreen",
+      // MapScreen reads alertLat/alertLon — NOT focusLat/focusLon
       params: hasCoords
-        ? { focusLat: String(parsedLat), focusLon: String(parsedLon), focusTitle: senderName }
+        ? { alertLat: String(parsedLat), alertLon: String(parsedLon), alertTitle: senderName }
         : {},
     });
   }
@@ -62,20 +66,6 @@ export default function SOSReceiverScreen() {
         <Text style={s.senderName}>{senderName ?? "Un contacto"}</Text>
         <Text style={s.subtitle}>Necesita ayuda urgente</Text>
 
-        {/* Location */}
-        <View style={s.locationCard}>
-          <MaterialCommunityIcons name="map-marker-outline" size={20} color={colors.brandCyan} />
-          {hasCoords ? (
-            <Text style={s.locationText}>
-              {parsedLat.toFixed(5)}, {parsedLon.toFixed(5)}
-            </Text>
-          ) : (
-            <Text style={[s.locationText, { color: "rgba(255,255,255,0.35)" }]}>
-              Sin ubicación disponible
-            </Text>
-          )}
-        </View>
-
         {/* Actions */}
         <View style={s.actions}>
           {hasPhone && (
@@ -88,8 +78,15 @@ export default function SOSReceiverScreen() {
           {hasCoords && (
             <Pressable style={s.mapBtn} onPress={handleViewOnMap} android_ripple={{ color: "rgba(255,255,255,0.08)" }}>
               <MaterialCommunityIcons name="map-search-outline" size={22} color={colors.brandCyan} />
-              <Text style={s.mapBtnText}>Ver en mapa</Text>
+              <Text style={s.mapBtnText}>Ver ubicación en mapa</Text>
             </Pressable>
+          )}
+
+          {!hasCoords && (
+            <View style={s.noLocationCard}>
+              <MaterialCommunityIcons name="map-marker-off-outline" size={20} color="rgba(255,255,255,0.35)" />
+              <Text style={s.noLocationText}>Sin ubicación disponible</Text>
+            </View>
           )}
         </View>
       </View>
@@ -157,26 +154,7 @@ const s = StyleSheet.create({
     color: "rgba(255,255,255,0.55)",
     fontFamily: fonts.poppins,
     fontSize: 15,
-    marginBottom: 28,
-  },
-  locationCard: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-    backgroundColor: "rgba(255,255,255,0.05)",
-    borderWidth: 1,
-    borderColor: "rgba(255,255,255,0.09)",
-    borderRadius: 12,
-    paddingVertical: 12,
-    paddingHorizontal: 18,
     marginBottom: 36,
-    alignSelf: "stretch",
-    justifyContent: "center",
-  },
-  locationText: {
-    color: "rgba(255,255,255,0.75)",
-    fontFamily: fonts.poppins,
-    fontSize: 14,
   },
   actions: {
     alignSelf: "stretch",
@@ -210,6 +188,18 @@ const s = StyleSheet.create({
     color: colors.brandCyan,
     fontFamily: fonts.poppinsSemiBold,
     fontSize: 16,
+  },
+  noLocationCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    paddingVertical: 14,
+  },
+  noLocationText: {
+    color: "rgba(255,255,255,0.35)",
+    fontFamily: fonts.poppins,
+    fontSize: 14,
   },
   dismissBtn: {
     alignItems: "center",

--- a/frontend/app/sos-receiver/index.tsx
+++ b/frontend/app/sos-receiver/index.tsx
@@ -31,11 +31,10 @@ export default function SOSReceiverScreen() {
 
   function handleViewOnMap() {
     console.log('[QA_SOS_RECEIVER] ver en mapa → alertLat:', parsedLat, '| alertLon:', parsedLon);
-    router.replace({
+    router.push({
       pathname: "/(tabs)/MapScreen",
-      // MapScreen reads alertLat/alertLon — NOT focusLat/focusLon
       params: hasCoords
-        ? { alertLat: String(parsedLat), alertLon: String(parsedLon), alertTitle: senderName }
+        ? { alertLat: String(parsedLat), alertLon: String(parsedLon), alertTitle: senderName, alertSosPhone: senderPhone ?? '' }
         : {},
     });
   }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "expo-device": "~8.0.10",
         "expo-file-system": "~19.0.21",
         "expo-image-picker": "~17.0.10",
+        "expo-intent-launcher": "~13.0.8",
         "expo-linear-gradient": "~15.0.8",
         "expo-linking": "~8.0.11",
         "expo-location": "~19.0.8",
@@ -9182,6 +9183,15 @@
       "dependencies": {
         "expo-image-loader": "~6.0.0"
       },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-intent-launcher": {
+      "version": "13.0.8",
+      "resolved": "https://registry.npmjs.org/expo-intent-launcher/-/expo-intent-launcher-13.0.8.tgz",
+      "integrity": "sha512-sgGFotttKKN6dIatjOEJT8M6Arfakus7vIxgshg5VkxarVhZBGJzOJam7rbUlB1O/gQ8em9G8vhEU9AfjEIe7A==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "expo-device": "~8.0.10",
     "expo-file-system": "~19.0.21",
     "expo-image-picker": "~17.0.10",
+    "expo-intent-launcher": "~13.0.8",
     "expo-linear-gradient": "~15.0.8",
     "expo-linking": "~8.0.11",
     "expo-location": "~19.0.8",

--- a/frontend/utils/pushNotifications.ts
+++ b/frontend/utils/pushNotifications.ts
@@ -10,7 +10,7 @@ import { authFetch } from './api'
 import { API_BASE_URL } from './config'
 
 const BATTERY_OPT_ASKED_KEY  = '@blueeye:battery_opt_asked';
-const HEADS_UP_ASKED_KEY     = '@blueeye:heads_up_asked';
+const HEADS_UP_ASKED_KEY     = '@blueeye:heads_up_asked_v2'; // v2 = sos_emergency channel
 
 export async function requestBatteryOptimizationExemption(): Promise<void> {
   if (Platform.OS !== 'android') return;
@@ -47,7 +47,7 @@ export async function requestBatteryOptimizationExemption(): Promise<void> {
 }
 
 // Show once: ask the user to enable heads-up / floating notifications for the
-// sos_alerts channel. Android lets apps open the exact channel settings screen so
+// sos_emergency channel. Android lets apps open the exact channel settings screen so
 // the user just needs to toggle "Mostrar en pantalla" (MIUI) / "Show as pop-up"
 // (stock Android). Called after battery-opt so both dialogs don't overlap.
 export async function requestHeadsUpPermission(): Promise<void> {
@@ -67,14 +67,14 @@ export async function requestHeadsUpPermission(): Promise<void> {
         text: 'Configurar',
         onPress: async () => {
           try {
-            // Opens the exact sos_alerts channel settings where the user can
+            // Opens the exact sos_emergency channel settings where the user can
             // enable "Floating notifications" / "Show as pop-up" / "Mostrar en pantalla"
             await IntentLauncher.startActivityAsync(
               'android.settings.CHANNEL_NOTIFICATION_SETTINGS',
               {
                 extra: {
                   'android.provider.extra.APP_PACKAGE': 'com.bluai.app',
-                  'android.provider.extra.CHANNEL_ID': 'sos_alerts',
+                  'android.provider.extra.CHANNEL_ID': 'sos_emergency',
                 },
               }
             );
@@ -151,8 +151,9 @@ export async function setupNotificationChannels() {
   // Delete old channel so Android re-creates it at MAX importance.
   // Android never upgrades a channel's importance once created; the only fix is
   // to delete and recreate with the new importance level.
-  await Notifications.deleteNotificationChannelAsync("sos_alerts").catch(() => {});
-  await Notifications.setNotificationChannelAsync("sos_alerts", {
+  // No delete needed — sos_emergency is a new ID that has never existed on any
+  // device, so Android creates it fresh at IMPORTANCE_MAX every time.
+  await Notifications.setNotificationChannelAsync("sos_emergency", {
     name: "Alertas SOS",
     importance: Notifications.AndroidImportance.MAX,
     vibrationPattern: [0, 250, 250, 250],

--- a/frontend/utils/pushNotifications.ts
+++ b/frontend/utils/pushNotifications.ts
@@ -105,12 +105,17 @@ export async function sendTokenToBackend(fcmToken: string): Promise<void> {
 
 export async function setupNotificationChannels() {
   if (Platform.OS !== "android") return;
+  // Delete old channel so Android re-creates it at MAX importance.
+  // Android never upgrades a channel's importance once created; the only fix is
+  // to delete and recreate with the new importance level.
+  await Notifications.deleteNotificationChannelAsync("sos_alerts").catch(() => {});
   await Notifications.setNotificationChannelAsync("sos_alerts", {
     name: "Alertas SOS",
     importance: Notifications.AndroidImportance.MAX,
     vibrationPattern: [0, 250, 250, 250],
     enableVibrate: true,
     showBadge: true,
+    sound: "default",
     lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
     bypassDnd: true,
   });

--- a/frontend/utils/pushNotifications.ts
+++ b/frontend/utils/pushNotifications.ts
@@ -1,12 +1,49 @@
 // frontend/utils/pushNotifications.js
 import * as Notifications from "expo-notifications";
 import * as Device from "expo-device";
+import * as IntentLauncher from "expo-intent-launcher";
 import { Alert, DeviceEventEmitter, Platform } from "react-native";
 import { toast } from "sonner-native";
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { track } from "./analytics";
 import { authFetch } from './api'
 import { API_BASE_URL } from './config'
+
+const BATTERY_OPT_ASKED_KEY = '@blueeye:battery_opt_asked';
+
+export async function requestBatteryOptimizationExemption(): Promise<void> {
+  if (Platform.OS !== 'android') return;
+  try {
+    const alreadyAsked = await AsyncStorage.getItem(BATTERY_OPT_ASKED_KEY);
+    if (alreadyAsked) return;
+    await AsyncStorage.setItem(BATTERY_OPT_ASKED_KEY, 'true');
+  } catch { /* AsyncStorage unavailable — still show the dialog */ }
+
+  Alert.alert(
+    'Alertas de emergencia',
+    'Para que BluEye pueda avisarte aunque el teléfono esté inactivo, necesita permiso para funcionar en segundo plano sin restricciones.',
+    [
+      { text: 'Ahora no', style: 'cancel' },
+      {
+        text: 'Permitir',
+        onPress: async () => {
+          try {
+            await IntentLauncher.startActivityAsync(
+              'android.settings.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS',
+              { data: 'package:com.bluai.app' }
+            );
+          } catch {
+            // Si el intent falla (algunos OEM lo bloquean), abrir ajustes de la app
+            await IntentLauncher.startActivityAsync(
+              IntentLauncher.ActivityAction.APPLICATION_DETAILS_SETTINGS,
+              { data: 'package:com.bluai.app' }
+            );
+          }
+        },
+      },
+    ]
+  );
+}
 
 const _LAST_TOKEN_KEY = 'push_last_registered_token';
 // In-memory guard prevents concurrent calls with the same token from both POSTing
@@ -70,10 +107,12 @@ export async function setupNotificationChannels() {
   if (Platform.OS !== "android") return;
   await Notifications.setNotificationChannelAsync("sos_alerts", {
     name: "Alertas SOS",
-    importance: Notifications.AndroidImportance.HIGH,
+    importance: Notifications.AndroidImportance.MAX,
     vibrationPattern: [0, 250, 250, 250],
     enableVibrate: true,
     showBadge: true,
+    lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+    bypassDnd: true,
   });
   // Silent channel for background data-refresh pushes — no banner, no sound, hidden in drawer
   await Notifications.setNotificationChannelAsync("contacts_refresh_silent", {
@@ -116,6 +155,11 @@ export async function registerForPushNotificationsAsync() {
   console.log("FCM token →", fcmToken);
 
   await sendTokenToBackend(fcmToken);
+
+  // 3) Battery optimization exemption — pide permiso para funcionar sin restricciones
+  //    Solo aparece una vez (guardado en AsyncStorage)
+  requestBatteryOptimizationExemption();
+
   return fcmToken;
 }
 

--- a/frontend/utils/pushNotifications.ts
+++ b/frontend/utils/pushNotifications.ts
@@ -235,7 +235,7 @@ export function setForegroundNotificationHandler() {
       return;
     }
 
-    if (data?.category === "sos_invite" || data?.category === "sos_rejected" || data?.category === "sos_contact_added") {
+    if (data?.category === "sos" || data?.category === "sos_invite" || data?.category === "sos_rejected" || data?.category === "sos_contact_added") {
       console.log('[QA_NOTIF] skip toast for', data.category, '— handled by _layout.tsx');
       return;
     }

--- a/frontend/utils/pushNotifications.ts
+++ b/frontend/utils/pushNotifications.ts
@@ -2,14 +2,15 @@
 import * as Notifications from "expo-notifications";
 import * as Device from "expo-device";
 import * as IntentLauncher from "expo-intent-launcher";
-import { Alert, DeviceEventEmitter, Platform } from "react-native";
+import { Alert, DeviceEventEmitter, Linking, Platform } from "react-native";
 import { toast } from "sonner-native";
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { track } from "./analytics";
 import { authFetch } from './api'
 import { API_BASE_URL } from './config'
 
-const BATTERY_OPT_ASKED_KEY = '@blueeye:battery_opt_asked';
+const BATTERY_OPT_ASKED_KEY  = '@blueeye:battery_opt_asked';
+const HEADS_UP_ASKED_KEY     = '@blueeye:heads_up_asked';
 
 export async function requestBatteryOptimizationExemption(): Promise<void> {
   if (Platform.OS !== 'android') return;
@@ -38,6 +39,48 @@ export async function requestBatteryOptimizationExemption(): Promise<void> {
               IntentLauncher.ActivityAction.APPLICATION_DETAILS_SETTINGS,
               { data: 'package:com.bluai.app' }
             );
+          }
+        },
+      },
+    ]
+  );
+}
+
+// Show once: ask the user to enable heads-up / floating notifications for the
+// sos_alerts channel. Android lets apps open the exact channel settings screen so
+// the user just needs to toggle "Mostrar en pantalla" (MIUI) / "Show as pop-up"
+// (stock Android). Called after battery-opt so both dialogs don't overlap.
+export async function requestHeadsUpPermission(): Promise<void> {
+  if (Platform.OS !== 'android') return;
+  try {
+    const alreadyAsked = await AsyncStorage.getItem(HEADS_UP_ASKED_KEY);
+    if (alreadyAsked) return;
+    await AsyncStorage.setItem(HEADS_UP_ASKED_KEY, 'true');
+  } catch { /* proceed */ }
+
+  Alert.alert(
+    'Notificaciones a pantalla completa',
+    'Para que las alertas SOS aparezcan sobre cualquier pantalla (incluso con el teléfono bloqueado), activa "Mostrar en pantalla" en los ajustes del canal SOS.',
+    [
+      { text: 'Ahora no', style: 'cancel' },
+      {
+        text: 'Configurar',
+        onPress: async () => {
+          try {
+            // Opens the exact sos_alerts channel settings where the user can
+            // enable "Floating notifications" / "Show as pop-up" / "Mostrar en pantalla"
+            await IntentLauncher.startActivityAsync(
+              'android.settings.CHANNEL_NOTIFICATION_SETTINGS',
+              {
+                extra: {
+                  'android.provider.extra.APP_PACKAGE': 'com.bluai.app',
+                  'android.provider.extra.CHANNEL_ID': 'sos_alerts',
+                },
+              }
+            );
+          } catch {
+            // Fallback: open the general app notification settings page
+            await Linking.openSettings();
           }
         },
       },
@@ -161,9 +204,10 @@ export async function registerForPushNotificationsAsync() {
 
   await sendTokenToBackend(fcmToken);
 
-  // 3) Battery optimization exemption — pide permiso para funcionar sin restricciones
-  //    Solo aparece una vez (guardado en AsyncStorage)
+  // 3) Battery optimization exemption — solo aparece una vez
   requestBatteryOptimizationExemption();
+  // 4) Heads-up / floating notifications — mostramos 2 s después para no superponer dialogs
+  setTimeout(() => requestHeadsUpPermission(), 2000);
 
   return fcmToken;
 }


### PR DESCRIPTION
## Qué hace este PR

Implementa el flujo completo de recepción de alertas SOS: pantalla dedicada de receptor, notificaciones de máxima prioridad, y navegación al mapa con contexto del emisor.

## Cambios principales

**Backend**
- Canal FCM `sos_emergency` (`IMPORTANCE_MAX`) — ID nuevo garantiza importancia máxima; Android/MIUI nunca actualiza un canal existente
- `sender_phone` incluido en el payload FCM para que el receptor pueda llamar directamente
- `AndroidConfig(priority="high")` para entrega urgente en doze/idle
- Fix crash `AttributeError: AndroidNotificationPriority` en firebase-admin de Railway

**Frontend — pantalla sos-receiver**
- Pantalla full-screen: nombre del emisor, botón Llamar (si hay teléfono), Ver ubicación en mapa, Cerrar
- `Stack.Screen name="sos-receiver/index"` (nombre correcto del route en expo-router)
- `router.push` (no `replace`) para que el back button regrese al receptor

**Frontend — mapa**
- Banner rojo fijo en la parte superior cuando se llega desde un SOS: nombre del emisor, botón Llamar, botón ← Volver
- `fitToCoordinates` encuadra la ubicación del emisor y del receptor
- `HurricaneMarker` colocado en las coordenadas del emisor

**Frontend — notificaciones**
- Canal `sos_emergency` con `IMPORTANCE_MAX`, `bypassDnd`, `lockscreenVisibility: PUBLIC`
- Dialog de exención de optimización de batería (una sola vez)
- Dialog de permiso de notificaciones flotantes apuntando al canal `sos_emergency`
- Deduplicación de cold-start con `@BluEye:last_cold_start_notif`

**Frontend — bugs corregidos**
- `dismissNotificationAsync` tras manejar SOS en foreground — evita doble navegación al sos-receiver
- Skip toast redundante para `category=sos` en el handler foreground
- Eliminado fallback `router.push("/alerts")` en tap con payload vacío — MIUI dispara el listener espúreamente al traer la app al frente

## Probado en

- Samsung Galaxy (Edgar, receptor) — recepción background y foreground, ver en mapa, banner, Llamar, regresar
- Xiaomi MIUI (Soledad, receptor y emisor) — SOS enviado y recibido correctamente, banner en mapa

## Tests

150 tests backend pasan (`pytest`).