### PR TITLE
feat: SIAT alert level factors in cyclone heading, not just distance

### DIFF
--- a/backend/app/features/siat/direction.py
+++ b/backend/app/features/siat/direction.py
@@ -1,0 +1,59 @@
+"""
+Direction/bearing math for SIAT-CT level adjustment.
+
+Cyclone movement direction arrives in two shapes depending on the source:
+  - NHC feed: numeric degrees from North as a string (e.g. "270").
+  - Fake/injected cyclones: a 16-point compass abbreviation (e.g. "NW").
+
+`parse_movement_direction` normalizes both into a single 0-360 bearing so the
+evaluator can compare "where the cyclone is headed" against "where the user
+is relative to the cyclone" regardless of which source produced the value.
+"""
+
+import math
+
+_COMPASS_POINTS = [
+    "N", "NNE", "NE", "ENE",
+    "E", "ESE", "SE", "SSE",
+    "S", "SSW", "SW", "WSW",
+    "W", "WNW", "NW", "NNW",
+]
+_COMPASS_TO_DEGREES = {point: i * 22.5 for i, point in enumerate(_COMPASS_POINTS)}
+
+
+def parse_movement_direction(value) -> float | None:
+    """Normalize a numeric bearing string or a compass abbreviation to degrees [0, 360)."""
+    if value is None:
+        return None
+
+    text = str(value).strip().upper()
+    if not text:
+        return None
+
+    if text in _COMPASS_TO_DEGREES:
+        return _COMPASS_TO_DEGREES[text]
+
+    try:
+        degrees = float(text)
+    except ValueError:
+        return None
+
+    return degrees % 360
+
+
+def bearing_deg(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Initial great-circle bearing in degrees [0, 360) from point 1 to point 2."""
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dlambda = math.radians(lon2 - lon1)
+
+    x = math.sin(dlambda) * math.cos(phi2)
+    y = math.cos(phi1) * math.sin(phi2) - math.sin(phi1) * math.cos(phi2) * math.cos(dlambda)
+
+    theta = math.atan2(x, y)
+    return math.degrees(theta) % 360
+
+
+def angular_difference(bearing_a: float, bearing_b: float) -> float:
+    """Smallest angular difference between two bearings, in [0, 180]."""
+    diff = abs(bearing_a - bearing_b) % 360
+    return diff if diff <= 180 else 360 - diff

--- a/backend/app/features/siat/evaluator.py
+++ b/backend/app/features/siat/evaluator.py
@@ -8,19 +8,25 @@ Maps cyclone proximity + intensity to the five official SIAT-CT levels:
   4 - NARANJA   (peligro alto, 6–12 h)
   5 - ROJO      (impacto inminente / en curso, < 6 h)
 
-Primary strategy: ETA-based (distance / movement speed).
+Primary strategy: ETA-based (distance / movement speed), adjusted by heading:
+a cyclone heading toward the user keeps the full ETA-based level; one moving
+laterally is stepped down by one level; one moving away is stepped down by
+two levels. The adjusted level is always floored at what plain distance +
+wind intensity alone would justify (see `_level_from_distance`), so a nearby
+"departing" cyclone is never trivialized to AZUL.
 Stationary cyclone fallback: distance + wind intensity with conservative thresholds.
 Out-of-range: cyclones beyond MAX_THREAT_DISTANCE_KM are flagged — the service
 layer skips DB writes and notifications for these to reduce noise.
 
-Known limitation: ETA is straight-line distance / speed and does NOT account for
-the cyclone's bearing or forecast track. A cyclone moving away from the user
-produces the same ETA as one approaching at the same speed. The implementation
-errs on the side of over-alerting (false positives) rather than missing threats.
+Known limitation: heading is a straight-line bearing parsed from the cyclone's
+reported movement direction, not the official NHC forecast cone — a cyclone
+that curves back toward the user after "moving away" isn't accounted for.
 Incorporating NHC forecast cone data would eliminate this in a future version.
 """
 
 import math
+
+from app.features.siat.direction import angular_difference, bearing_deg, parse_movement_direction
 
 SIAT_COLORS: dict[int, str] = {
     1: "AZUL",
@@ -103,6 +109,18 @@ def evaluate_user(user_lat: float, user_lon: float, cyclone: dict) -> dict:
     if speed > 0:
         eta_hours: float | None = distance_km / speed
         level = _level_from_eta(eta_hours)
+
+        floor_level = _level_from_distance(distance_km, cyclone.get("wind_kmh", 0.0))
+        heading_deg = parse_movement_direction(cyclone.get("movement_direction"))
+        if heading_deg is not None:
+            bearing_to_user = bearing_deg(cyclone["lat"], cyclone["lon"], user_lat, user_lon)
+            angular_diff = angular_difference(heading_deg, bearing_to_user)
+            if angular_diff > 120:
+                level -= 2
+            elif angular_diff > 60:
+                level -= 1
+        level = max(level, floor_level, 1)
+
         eta_label = f"ETA estimada: {eta_hours:.1f}h"
     else:
         eta_hours = None

--- a/backend/app/features/siat/tests/test_direction.py
+++ b/backend/app/features/siat/tests/test_direction.py
@@ -1,0 +1,59 @@
+import pytest
+
+from app.features.siat.direction import (
+    angular_difference,
+    bearing_deg,
+    parse_movement_direction,
+)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("270", 270.0),
+        ("0", 0.0),
+        ("360", 0.0),
+        ("45.5", 45.5),
+        ("N", 0.0),
+        ("nw", 315.0),
+        ("ENE", 67.5),
+        ("SSW", 202.5),
+    ],
+)
+def test_parse_movement_direction_valid(value, expected):
+    assert parse_movement_direction(value) == expected
+
+
+@pytest.mark.parametrize("value", [None, "", "  ", "not-a-direction", "XYZ"])
+def test_parse_movement_direction_invalid(value):
+    assert parse_movement_direction(value) is None
+
+
+def test_bearing_deg_due_north():
+    # Point directly north → bearing 0.
+    assert bearing_deg(19.0, -99.0, 20.0, -99.0) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_bearing_deg_due_east():
+    # Near the equator, due east → bearing ~90.
+    assert bearing_deg(0.0, 0.0, 0.0, 1.0) == pytest.approx(90.0, abs=1e-6)
+
+
+def test_bearing_deg_due_south():
+    assert bearing_deg(20.0, -99.0, 19.0, -99.0) == pytest.approx(180.0, abs=1e-6)
+
+
+@pytest.mark.parametrize(
+    "a,b,expected",
+    [
+        (0, 0, 0),
+        (0, 90, 90),
+        (350, 10, 20),
+        (10, 350, 20),
+        (0, 180, 180),
+        (170, 190, 20),
+        (0, 359, 1),
+    ],
+)
+def test_angular_difference(a, b, expected):
+    assert angular_difference(a, b) == pytest.approx(expected, abs=1e-6)

--- a/backend/app/features/siat/tests/test_router.py
+++ b/backend/app/features/siat/tests/test_router.py
@@ -196,6 +196,65 @@ def test_evaluate_user_distant_slow_cyclone_is_azul():
 
 
 # ---------------------------------------------------------------------------
+# evaluate_user() — direction-aware level adjustment
+# ---------------------------------------------------------------------------
+# Cyclone due south of the user (same longitude), so bearing cyclone→user is
+# due north (0°). Distance ~222 km, speed 20 km/h → ETA ~11.1h → baseline
+# level 4 (NARANJA) before any heading adjustment. wind_kmh=50 keeps the
+# distance-only floor at level 2, low enough that the -1/-2 adjustments are
+# visible instead of being clamped back up by the floor.
+
+_DIRECTION_CYCLONE_BASE = {
+    "name": "HEADING-TEST",
+    "status": "HU",
+    "lat": 18.0,
+    "lon": -99.0,
+    "wind_kmh": 50.0,
+    "movement_speed_kmh": 20.0,
+}
+_DIRECTION_USER_LAT, _DIRECTION_USER_LON = 20.0, -99.0
+
+
+def test_evaluate_user_approaching_keeps_eta_level():
+    """Heading ~toward the user (bearing diff <= 60°) → no adjustment."""
+    cyclone = {**_DIRECTION_CYCLONE_BASE, "movement_direction": "N"}
+    result = evaluate_user(_DIRECTION_USER_LAT, _DIRECTION_USER_LON, cyclone)
+    assert result["siat_level"] == 4
+
+
+def test_evaluate_user_lateral_steps_down_one_level():
+    """Heading roughly perpendicular (60° < diff <= 120°) → level - 1."""
+    cyclone = {**_DIRECTION_CYCLONE_BASE, "movement_direction": "E"}
+    result = evaluate_user(_DIRECTION_USER_LAT, _DIRECTION_USER_LON, cyclone)
+    assert result["siat_level"] == 3
+
+
+def test_evaluate_user_departing_steps_down_two_levels():
+    """Heading away from the user (diff > 120°) → level - 2."""
+    cyclone = {**_DIRECTION_CYCLONE_BASE, "movement_direction": "S"}
+    result = evaluate_user(_DIRECTION_USER_LAT, _DIRECTION_USER_LON, cyclone)
+    assert result["siat_level"] == 2
+
+
+def test_evaluate_user_departing_never_drops_below_distance_floor():
+    """A departing cyclone close enough that distance alone floors the level."""
+    cyclone = {
+        **_DIRECTION_CYCLONE_BASE,
+        "wind_kmh": 100.0,  # floor: distance < 300 and wind >= 100 → floor level 4
+        "movement_direction": "S",
+    }
+    result = evaluate_user(_DIRECTION_USER_LAT, _DIRECTION_USER_LON, cyclone)
+    assert result["siat_level"] == 4  # ETA-based (4) - 2 = 2, but floor is 4
+
+
+def test_evaluate_user_missing_direction_keeps_eta_level():
+    """No movement_direction provided → behaves exactly like before (no penalty)."""
+    cyclone = {**_DIRECTION_CYCLONE_BASE}
+    result = evaluate_user(_DIRECTION_USER_LAT, _DIRECTION_USER_LON, cyclone)
+    assert result["siat_level"] == 4
+
+
+# ---------------------------------------------------------------------------
 # GET /api/v1/siat/affected-users
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `direction.py`: parses cyclone `movement_direction` (numeric degrees from NHC, or 16-point compass abbreviation from fake/injected storms) into a uniform 0–360° bearing, plus great-circle bearing + angular-difference helpers.
- `evaluate_user()` in `evaluator.py` now compares the storm's heading against the bearing toward the user: approaching (0–60°) keeps the ETA-derived level, lateral (60–120°) drops it one level, departing (120–180°) drops it two — but never below the pure-distance/wind floor (`_level_from_distance`), which is now always computed as a safety net.
- No behavior change when `movement_direction` is missing (existing tests pass unmodified).

## Why
Per `docs/hurricane-siat-testing-improvements.md` part 1: today "approaching" and "departing" produce identical SIAT levels since only ETA (distance/speed) is used. A storm moving away from a user at the same speed as one bearing down on them should not trigger the same alert level.

## Test plan
- [x] `pytest` — 191 passed, 1 skipped (new `test_direction.py` + new `evaluate_user` heading cases in `test_router.py`, all 6 pre-existing evaluator tests pass unmodified)
- [x] Verified locally on `dev` HEAD before opening