### PR TITLE
feat: show active cyclones on the map with real intensity labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ backend/**/firebase-*.json
 #   Python FastAPI (BACKEND)  #
 ###############################
 backend/venv/
+backend/.venv/
 **/__pycache__/
 **/*.pyc
 backend/.env

--- a/backend/app/features/siat/classification.py
+++ b/backend/app/features/siat/classification.py
@@ -1,0 +1,26 @@
+"""
+Cyclone intensity classification — wind speed -> category code/label.
+
+Deliberately separate from the SIAT level (evaluator.py): classification is
+purely about storm intensity, while the SIAT level is about the risk a
+specific user faces (proximity + heading). A weak depression can still
+carry a high SIAT level if it's bearing down on someone at close range.
+"""
+
+_LABELS = {
+    "HU": "Huracán",
+    "TS": "Tormenta Tropical",
+    "TD": "Depresión Tropical",
+}
+
+
+def classify_wind_kmh(wind_kmh: float) -> str:
+    if wind_kmh >= 119:
+        return "HU"
+    if wind_kmh >= 63:
+        return "TS"
+    return "TD"
+
+
+def classification_label(code: str) -> str:
+    return _LABELS.get(code, code)

--- a/backend/app/features/siat/router.py
+++ b/backend/app/features/siat/router.py
@@ -5,12 +5,12 @@ from app.core.auth import get_current_user
 from app.core.config import settings
 from app.core.database import get_db
 from app.features.siat.schemas import (
-    AffectedUsersResponse, FakeCycloneRequest, InjectCycloneResponse,
+    ActiveCyclonesResponse, AffectedUsersResponse, FakeCycloneRequest, InjectCycloneResponse,
     InjectSMNAlertRequest, InjectSMNAlertResponse, ResetStateResponse,
     RunCycleResponse, UserSiatStatus,
 )
 from app.features.siat.service import (
-    get_affected_users, get_user_siat_status, inject_and_run_cycle,
+    get_active_cyclones, get_affected_users, get_user_siat_status, inject_and_run_cycle,
     inject_smn_test_alert, reset_user_siat_state, run_cycle,
 )
 from app.features.users.service import get_user_by_firebase_uid
@@ -131,3 +131,16 @@ async def siat_user_status(user_id: int, db: AsyncSession = Depends(get_db)):
     if status is None:
         raise HTTPException(status_code=404, detail="No SIAT assessment found for this user")
     return status
+
+
+@router.get("/api/v1/siat/active-cyclones", response_model=ActiveCyclonesResponse)
+async def siat_active_cyclones(
+    db: AsyncSession = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
+):
+    """
+    Cyclones (real + test) recent enough to display on the map, with their
+    intensity category and parsed heading. Any authenticated user can read this.
+    """
+    cyclones = await get_active_cyclones(db)
+    return {"total": len(cyclones), "cyclones": cyclones}

--- a/backend/app/features/siat/schemas.py
+++ b/backend/app/features/siat/schemas.py
@@ -68,3 +68,23 @@ class AffectedUser(BaseModel):
 class AffectedUsersResponse(BaseModel):
     total: int
     users: list[AffectedUser]
+
+
+class ActiveCycloneItem(BaseModel):
+    id: int
+    source: str
+    name: str
+    lat: float
+    lon: float
+    wind_kmh: float | None
+    movement_direction: str | None
+    movement_direction_deg: float | None
+    movement_speed_kmh: float | None
+    category_code: str
+    category_label: str
+    advisory_time: datetime | None
+
+
+class ActiveCyclonesResponse(BaseModel):
+    total: int
+    cyclones: list[ActiveCycloneItem]

--- a/backend/app/features/siat/service.py
+++ b/backend/app/features/siat/service.py
@@ -23,6 +23,8 @@ from firebase_admin import messaging
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from app.features.siat.classification import classify_wind_kmh, classification_label
+from app.features.siat.direction import parse_movement_direction
 from app.features.siat.evaluator import evaluate_user, haversine_km
 from app.features.siat.providers.nhc import fetch_active_cyclones
 from app.features.notifications.service import get_tokens_for_users
@@ -471,7 +473,7 @@ async def inject_and_run_cycle(db: AsyncSession, req) -> dict:
     fake_cyclone: dict = {
         "source": "FAKE",
         "name": req.name,
-        "status": "HU",
+        "status": classify_wind_kmh(req.wind_kmh),
         "lat": req.lat,
         "lon": req.lon,
         "wind_kmh": req.wind_kmh,
@@ -612,3 +614,34 @@ async def get_user_siat_status(db: AsyncSession, user_id: int) -> dict | None:
         {"uid": user_id},
     )
     return result.mappings().first()
+
+
+async def get_active_cyclones(db: AsyncSession, max_age_hours: int = 72) -> list[dict]:
+    """
+    Cyclones (real + fake) recent enough to still be worth showing on the map.
+    Enriches each row with its intensity classification and a parsed heading
+    in degrees, for the map's category label and direction arrow.
+    """
+    result = await db.execute(
+        text("""
+            SELECT id, source, name, lat, lon, wind_kmh,
+                   movement_direction, movement_speed_kmh, advisory_time
+            FROM cyclone_events
+            WHERE advisory_time > NOW() - make_interval(hours => :max_age_hours)
+            ORDER BY advisory_time DESC
+        """),
+        {"max_age_hours": max_age_hours},
+    )
+    rows = result.mappings().all()
+
+    cyclones = []
+    for row in rows:
+        wind_kmh = row["wind_kmh"] or 0.0
+        category_code = classify_wind_kmh(wind_kmh)
+        cyclones.append({
+            **row,
+            "category_code": category_code,
+            "category_label": classification_label(category_code),
+            "movement_direction_deg": parse_movement_direction(row["movement_direction"]),
+        })
+    return cyclones

--- a/backend/app/features/siat/tests/test_classification.py
+++ b/backend/app/features/siat/tests/test_classification.py
@@ -1,0 +1,31 @@
+import pytest
+
+from app.features.siat.classification import classification_label, classify_wind_kmh
+
+
+@pytest.mark.parametrize(
+    "wind_kmh,expected",
+    [
+        (0, "TD"),
+        (62, "TD"),
+        (63, "TS"),
+        (100, "TS"),
+        (118, "TS"),
+        (119, "HU"),
+        (200, "HU"),
+    ],
+)
+def test_classify_wind_kmh_thresholds(wind_kmh, expected):
+    assert classify_wind_kmh(wind_kmh) == expected
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        ("HU", "Huracán"),
+        ("TS", "Tormenta Tropical"),
+        ("TD", "Depresión Tropical"),
+    ],
+)
+def test_classification_label(code, expected):
+    assert classification_label(code) == expected

--- a/backend/app/features/siat/tests/test_router.py
+++ b/backend/app/features/siat/tests/test_router.py
@@ -890,3 +890,85 @@ async def test_smn_level5_overrides_quiet_hours():
 
     assert total == 1
     mock_mark.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# inject_and_run_cycle() derives status from wind — service-level test
+# ---------------------------------------------------------------------------
+
+class _FakeCycloneReq:
+    def __init__(self, wind_kmh: float):
+        self.name = "FALSO-TEST"
+        self.lat = 21.0
+        self.lon = -98.0
+        self.wind_kmh = wind_kmh
+        self.movement_speed_kmh = 10.0
+        self.movement_direction = "N"
+
+
+@pytest.mark.asyncio
+async def test_inject_and_run_cycle_classifies_low_wind_as_td():
+    """Low-wind fake cyclone must be saved as TD, not the old hardcoded 'HU'."""
+    from app.features.siat.service import inject_and_run_cycle
+
+    db = MagicMock()
+    with patch(f"{_SVC}._save_cyclone", new_callable=AsyncMock, return_value=99) as mock_save, \
+         patch(f"{_SVC}.run_cycle", new_callable=AsyncMock, return_value=FAKE_CYCLE_RESULT):
+        await inject_and_run_cycle(db, _FakeCycloneReq(wind_kmh=50.0))
+
+    saved_cyclone = mock_save.call_args.args[1]
+    assert saved_cyclone["status"] == "TD"
+
+
+@pytest.mark.asyncio
+async def test_inject_and_run_cycle_classifies_high_wind_as_hu():
+    """High-wind fake cyclone still resolves to HU."""
+    from app.features.siat.service import inject_and_run_cycle
+
+    db = MagicMock()
+    with patch(f"{_SVC}._save_cyclone", new_callable=AsyncMock, return_value=99) as mock_save, \
+         patch(f"{_SVC}.run_cycle", new_callable=AsyncMock, return_value=FAKE_CYCLE_RESULT):
+        await inject_and_run_cycle(db, _FakeCycloneReq(wind_kmh=200.0))
+
+    saved_cyclone = mock_save.call_args.args[1]
+    assert saved_cyclone["status"] == "HU"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/siat/active-cyclones
+# ---------------------------------------------------------------------------
+
+_FAKE_ACTIVE_CYCLONES = [
+    {
+        "id": 1,
+        "source": "FAKE",
+        "name": "FALSO-1",
+        "lat": 21.0,
+        "lon": -98.0,
+        "wind_kmh": 160.0,
+        "movement_direction": "N",
+        "movement_direction_deg": 0.0,
+        "movement_speed_kmh": 20.0,
+        "category_code": "HU",
+        "category_label": "Huracán",
+        "advisory_time": datetime.now(timezone.utc),
+    },
+]
+
+
+def test_active_cyclones_requires_auth():
+    """No Authorization header → 422 (FastAPI header validation)."""
+    r = client.get("/api/v1/siat/active-cyclones")
+    assert r.status_code == 422
+
+
+def test_active_cyclones_returns_expected_shape():
+    """Any authenticated user (no admin allowlist) gets the enriched cyclone list."""
+    with _mock_auth_email(NON_ADMIN_EMAIL):
+        with patch(f"{_ROUTER}.get_active_cyclones", new_callable=AsyncMock, return_value=_FAKE_ACTIVE_CYCLONES):
+            r = client.get("/api/v1/siat/active-cyclones", headers=AUTH_HEADERS)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 1
+    assert body["cyclones"][0]["category_label"] == "Huracán"
+    assert body["cyclones"][0]["movement_direction_deg"] == 0.0

--- a/frontend/app/map/index.tsx
+++ b/frontend/app/map/index.tsx
@@ -27,11 +27,13 @@ import {
   deleteZone,
   formatRelativeTime,
   generateZoneId,
+  loadActiveCyclones,
   loadZones,
   reverseGeocodeAddress,
   syncCachedZones,
   updateZone,
   voteZone,
+  type ActiveCyclone,
 } from "./service";
 import { darkMapStyle } from "./mapStyle";
 import { DEFAULT_REGION, REPORTING_DISTANCE_METERS, ZONE_TYPES } from "./config";
@@ -57,6 +59,8 @@ interface MapProps {
   focusSosPhone?: string;
 }
 
+// SIAT level (this user's risk) — used only for the focusLat/focusLon marker
+// that comes from a push notification.
 const LEVEL_COLORS: Record<number, string> = {
   1: '#4CAF50',
   2: '#4CAF50',
@@ -65,12 +69,21 @@ const LEVEL_COLORS: Record<number, string> = {
   5: '#F44336',
 }
 
+// Storm intensity classification — deliberately separate from LEVEL_COLORS.
+// A weak depression heading straight at someone can carry a high SIAT level,
+// so mixing the two palettes would misrepresent one or the other.
+const CATEGORY_COLORS: Record<string, string> = {
+  HU: '#F44336',
+  TS: '#FF9800',
+  TD: '#FFC107',
+}
+
 const HurricaneMarker = React.memo(function HurricaneMarker({
-  lat, lon, title, level,
-}: { lat: number; lon: number; title?: string; level?: number }) {
+  lat, lon, title, level, categoryCode, directionDeg,
+}: { lat: number; lon: number; title?: string; level?: number; categoryCode?: string; directionDeg?: number | null }) {
   const [tracksViewChanges, setTracksViewChanges] = useState(true);
   console.log('[QA_MAP] HurricaneMarker render | lat:', lat, '| lon:', lon);
-  const color = LEVEL_COLORS[level ?? 3];
+  const color = categoryCode ? (CATEGORY_COLORS[categoryCode] ?? CATEGORY_COLORS.TD) : LEVEL_COLORS[level ?? 3];
   return (
     <Marker coordinate={{ latitude: lat, longitude: lon }} anchor={{ x: 0.5, y: 0.5 }} tracksViewChanges={tracksViewChanges} title={title}>
       <View
@@ -80,7 +93,9 @@ const HurricaneMarker = React.memo(function HurricaneMarker({
         }}
         style={{ width: 48, height: 48, borderRadius: 24, backgroundColor: color, borderWidth: 2, borderColor: 'white', alignItems: 'center', justifyContent: 'center' }}
       >
-        <MaterialCommunityIcons name="weather-hurricane" size={28} color="white" />
+        <View style={directionDeg != null ? { transform: [{ rotate: `${directionDeg}deg` }] } : undefined}>
+          <MaterialCommunityIcons name={directionDeg != null ? 'navigation' : 'weather-hurricane'} size={28} color="white" />
+        </View>
       </View>
     </Marker>
   );
@@ -138,6 +153,7 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
   const [currentCoords, setCurrentCoords] = useState<{ latitude: number; longitude: number } | null>(null);
   const [hasPendingSOS, setHasPendingSOS] = useState(false);
   const [linkedContactCount, setLinkedContactCount] = useState<number | null>(null);
+  const [activeCyclones, setActiveCyclones] = useState<ActiveCyclone[]>([]);
 
   // Al montar y al volver al foco: verificar cola con control de antigüedad.
   // Items < 30 min → flush automático. Items > 30 min → pedir confirmación al usuario.
@@ -193,6 +209,21 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
           setLinkedContactCount(data.filter(c => c.link_status === 'linked').length);
         } catch {
           // best-effort — badge stays hidden on error
+        }
+      })();
+    }, [])
+  );
+
+  // Al volver al foco: refrescar tormentas activas (reales + de prueba) desde la DB,
+  // así una tormenta inyectada sigue apareciendo después de recargar la app.
+  useFocusEffect(
+    useCallback(() => {
+      (async () => {
+        try {
+          const cyclones = await loadActiveCyclones();
+          setActiveCyclones(cyclones);
+        } catch (error) {
+          console.warn('[Map] Failed to load active cyclones:', error);
         }
       })();
     }, [])
@@ -644,6 +675,17 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
 
         {showEvents && zones.map((zone) => (
           <ZoneMarker key={zone.id} zone={zone} onPress={() => handleCirclePress(zone)} />
+        ))}
+
+        {activeCyclones.map((cyclone) => (
+          <HurricaneMarker
+            key={cyclone.id}
+            lat={cyclone.latitude}
+            lon={cyclone.longitude}
+            title={`${cyclone.name} — ${cyclone.categoryLabel}`}
+            categoryCode={cyclone.categoryCode}
+            directionDeg={cyclone.movementDirectionDeg}
+          />
         ))}
 
         {focusLat != null && focusLon != null && (

--- a/frontend/app/map/service.ts
+++ b/frontend/app/map/service.ts
@@ -295,3 +295,62 @@ export async function syncCachedZones(zones: Zone[]) {
     console.error('[Map] Error saving cached zones:', error)
   }
 }
+
+export type ActiveCyclone = {
+  id: number
+  source: string
+  name: string
+  latitude: number
+  longitude: number
+  windKmh: number | null
+  movementDirection: string | null
+  movementDirectionDeg: number | null
+  movementSpeedKmh: number | null
+  categoryCode: string
+  categoryLabel: string
+  advisoryTime: string | null
+}
+
+type ActiveCycloneResponse = {
+  id: number
+  source: string
+  name: string
+  lat: number
+  lon: number
+  wind_kmh: number | null
+  movement_direction: string | null
+  movement_direction_deg: number | null
+  movement_speed_kmh: number | null
+  category_code: string
+  category_label: string
+  advisory_time: string | null
+}
+
+function normalizeActiveCyclone(item: ActiveCycloneResponse): ActiveCyclone {
+  return {
+    id: item.id,
+    source: item.source,
+    name: item.name,
+    latitude: Number(item.lat),
+    longitude: Number(item.lon),
+    windKmh: item.wind_kmh ?? null,
+    movementDirection: item.movement_direction ?? null,
+    movementDirectionDeg: item.movement_direction_deg ?? null,
+    movementSpeedKmh: item.movement_speed_kmh ?? null,
+    categoryCode: item.category_code,
+    categoryLabel: item.category_label,
+    advisoryTime: item.advisory_time ?? null,
+  }
+}
+
+// Always requires real Firebase auth — unlike mapFetch, there is no dev-auth
+// bypass for this endpoint (see DEV_BYPASS_MAP_AUTH), so it calls authFetch directly.
+export async function loadActiveCyclones(): Promise<ActiveCyclone[]> {
+  const { authFetch } = await import('../../utils/api')
+  const response = await authFetch(`${API_BASE_URL}/api/v1/siat/active-cyclones`)
+  if (!response.ok) {
+    throw new Error(`Failed to load active cyclones: ${response.status}`)
+  }
+  const data: { total: number; cyclones: ActiveCycloneResponse[] } = await response.json()
+  return data.cyclones.map(normalizeActiveCyclone)
+}


### PR DESCRIPTION
## Summary
- **Stacked on #223** (direction-aware level) — its `direction.py` bearing parser is reused here for the map's direction arrow, so this PR's diff only shows what's new on top.
- Adds `classification.py`: derives storm category (`HU`/`TS`/`TD`) from `wind_kmh`, single source of truth for both the category-label fix below and the new map endpoint.
- Fixes `inject_and_run_cycle()` hardcoding `status: "HU"` for every injected fake cyclone regardless of wind — now derived correctly (a 50 km/h test storm now correctly shows as "Depresión Tropical" instead of "Huracán").
- New `GET /api/v1/siat/active-cyclones` (Firebase-authenticated, any user) returns recent (last 72h) rows from `cyclone_events` enriched with category code/label and parsed numeric bearing.
- Frontend: map screen fetches active cyclones on focus and renders one marker per storm — colored by intensity category (separate palette from the existing per-user SIAT-level color, intentionally not conflated), with a rotated direction arrow.
- Also includes a trivial, unrelated `.gitignore` one-liner (ignore `backend/.venv/`) that was already in the working tree before this feature — happy to drop/move it if preferred.

## Why
Per `docs/hurricane-siat-testing-improvements.md` parts 3+4 (explicitly meant to ship together): storms — real or injected — should be visible on the map, not just as a push notification, and labeled by actual intensity instead of a hardcoded "huracán".

## Test plan
- [x] `pytest` — 205 passed, 1 skipped (full suite, on top of #223's branch)
- [x] `tsc --noEmit` / `eslint` — no new errors beyond pre-existing unrelated ones
- [x] Verified live end-to-end on a physical Android device against a local backend (pointed at the staging DB): injected a 50 km/h storm via #224's form, confirmed the map marker rendered yellow with a rotated direction arrow and callout "FALSO-1 — Depresión Tropical", and confirmed it persists after a full app restart (fetched fresh from the DB)