### PR TITLE
fix: SOS invite linking, invite-link auth loss, missing push channel, map SOS-focus

### DIFF
--- a/backend/app/features/sos_invite/service.py
+++ b/backend/app/features/sos_invite/service.py
@@ -11,6 +11,14 @@ from app.features.notifications.service import get_tokens_for_users, _send_multi
 logger = logging.getLogger(__name__)
 
 DEEP_LINK_BASE = "blueye://sos-invite"
+# Known limitation: this is a bare custom scheme, not a universal/app link
+# (app.json has no associatedDomains / autoVerify intent filter). If the invitee
+# doesn't have BluEye installed, tapping a manually-shared share_url does nothing —
+# there's no web fallback to the store and no deferred-deep-link resume after
+# install. They have to install the app on their own, then re-tap the original
+# share message. Fixing this needs a real deferred-deep-link setup (Firebase
+# Dynamic Links, Branch.io, or a first-party https:// landing page + App Links),
+# not a one-line patch.
 
 
 async def create_invite(
@@ -19,11 +27,19 @@ async def create_invite(
     inviter_display_name: str,
     contact_id: int,
 ) -> dict:
+    # Match on the last 10 digits rather than an exact string: the contact's phone
+    # comes verbatim from the device address book (may carry +52, dashes, spaces),
+    # while the invitee's own phone was typed by hand during onboarding — an exact
+    # match almost never survives that formatting gap, so invites silently fell
+    # back to manual share instead of reaching an existing app user.
     contact = await db.execute(
         text("""
             SELECT sc.name, sc.link_status, sc.user_id, sc.phone, u.id AS invitee_user_id
             FROM sos_contacts sc
-            LEFT JOIN users u ON u.phone = sc.phone
+            LEFT JOIN users u ON
+                length(regexp_replace(sc.phone, '[^0-9]', '', 'g')) >= 10
+                AND right(regexp_replace(u.phone, '[^0-9]', '', 'g'), 10)
+                    = right(regexp_replace(sc.phone, '[^0-9]', '', 'g'), 10)
             WHERE sc.id = :id
         """),
         {"id": contact_id},

--- a/frontend/app/(tabs)/MapScreen.tsx
+++ b/frontend/app/(tabs)/MapScreen.tsx
@@ -1,17 +1,36 @@
 import "../../global.css";
+import { useEffect, useState } from "react";
 import { StatusBar } from "expo-status-bar";
 import { useLocalSearchParams } from "expo-router";
 import Main from "../map";
 
-const MapScreen = () => {
-  const { alertLat, alertLon, alertTitle, alertLevel, alertSosPhone } = useLocalSearchParams<{
-    alertLat?: string;
-    alertLon?: string;
-    alertTitle?: string;
-    alertLevel?: string;
-    alertSosPhone?: string;
-  }>();
+type FocusParams = {
+  alertLat?: string;
+  alertLon?: string;
+  alertTitle?: string;
+  alertLevel?: string;
+  alertSosPhone?: string;
+};
 
+const MapScreen = () => {
+  const params = useLocalSearchParams<FocusParams>();
+
+  // Route params get reset to empty a few seconds after arriving here (unrelated
+  // navigation elsewhere touches this same route). Freeze the first non-empty
+  // arrival so the SOS banner / focus marker survive that reset instead of
+  // vanishing right after the user gets here; only a genuinely new focus request
+  // overwrites it, and dismissing the banner clears it explicitly.
+  const [focus, setFocus] = useState<FocusParams>(params);
+  // Deps are intentionally the individual primitives above, not `params` itself
+  // (a new object reference every render, which would defeat the freeze).
+  useEffect(() => {
+    if (params.alertLat || params.alertTitle || params.alertSosPhone !== undefined) {
+      setFocus(params);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [params.alertLat, params.alertLon, params.alertTitle, params.alertLevel, params.alertSosPhone]);
+
+  const { alertLat, alertLon, alertTitle, alertLevel, alertSosPhone } = focus;
   const focusLat = alertLat ? parseFloat(alertLat) : undefined;
   const focusLon = alertLon ? parseFloat(alertLon) : undefined;
 
@@ -26,6 +45,7 @@ const MapScreen = () => {
         focusTitle={alertTitle}
         focusLevel={alertLevel ? parseInt(alertLevel, 10) : undefined}
         focusSosPhone={alertSosPhone}
+        onDismissFocus={() => setFocus({})}
       />
     </>
   );

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -150,7 +150,13 @@ function AuthGate({ children }) {
       return
     }
     const inAuthGroup = segments[0] === '(auth)'
-    if (!user && !inAuthGroup) {
+    // sos-invite previews are public (GET /sos-invitations/preview/{token} needs no
+    // auth) — someone tapping a manually-shared invite link often isn't logged in
+    // yet. Bouncing them to /(auth) here drops the token with nowhere to resume
+    // from, silently losing the invite. Let the screen itself gate the "Aceptar"
+    // action behind login instead.
+    const isSosInviteRoute = segments[0] === 'sos-invite'
+    if (!user && !inAuthGroup && !isSosInviteRoute) {
       router.replace('/(auth)')
     } else if (user && inAuthGroup) {
       const checkAndRoute = async () => {

--- a/frontend/app/map/index.tsx
+++ b/frontend/app/map/index.tsx
@@ -42,6 +42,7 @@ import { authFetch } from "../../utils/api";
 import { API_BASE_URL } from "../../utils/config";
 import * as Network from "expo-network";
 import { useFocusEffect, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { enqueueSOS, hasPendingSOSItem, getPendingSOSItem, flushSOSQueue, clearSOSQueue } from "./sosQueue";
 import type { Zone, ZoneType } from "./types";
 
@@ -57,6 +58,9 @@ interface MapProps {
   // Present only when navigated from sos-receiver — undefined for hurricane alerts.
   // Empty string means SOS context but no phone registered.
   focusSosPhone?: string;
+  // Called when the user dismisses the SOS banner via its back button, so the
+  // parent can clear its frozen focus state instead of it persisting forever.
+  onDismissFocus?: () => void;
 }
 
 // SIAT level (this user's risk) — used only for the focusLat/focusLon marker
@@ -127,8 +131,9 @@ const ZoneMarker = React.memo(function ZoneMarker({ zone, onPress }: { zone: Zon
   );
 });
 
-export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, focusLevel, focusSosPhone }: MapProps = {}) {
+export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, focusLevel, focusSosPhone, onDismissFocus }: MapProps = {}) {
   const router = useRouter();
+  const insets = useSafeAreaInsets();
   const [region, setRegion] = useState(DEFAULT_REGION);
   const [showWind, setShowWind] = useState(true);
   const [showPrecip, setShowPrecip] = useState(false);
@@ -525,6 +530,7 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
       let lon: number | undefined;
       let gpsFailed = false;
       let permDenied = false;
+      let usedFallbackCoords = false;
       const { status } = await Location.requestForegroundPermissionsAsync();
       if (status === "granted") {
         try {
@@ -539,6 +545,15 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
           lon = coords.longitude;
         } catch {
           gpsFailed = true;
+          // Live GPS fix timed out (cold GPS, indoors, etc). Fall back to the
+          // location already resolved when the map screen mounted rather than
+          // sending the SOS with no coordinates at all — it's from this same
+          // session, so it's far more likely to be current than nothing.
+          if (currentCoords) {
+            lat = currentCoords.latitude;
+            lon = currentCoords.longitude;
+            usedFallbackCoords = true;
+          }
         }
       } else {
         permDenied = true;
@@ -559,6 +574,8 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
       // 3. Online: mostrar feedback de GPS si aplica
       if (permDenied) {
         toast.info("Permiso de ubicación denegado", { description: "Se enviará el SOS sin coordenadas." });
+      } else if (usedFallbackCoords) {
+        toast.info("Ubicación aproximada", { description: "No se pudo obtener tu posición exacta a tiempo; se usó tu última ubicación conocida." });
       } else if (gpsFailed) {
         toast.info("Sin ubicación precisa", { description: "Se enviará el SOS sin coordenadas." });
       }
@@ -700,7 +717,7 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
 
       {/* SOS context banner — only shown when navigated from sos-receiver */}
       {focusSosPhone !== undefined && focusTitle != null && (
-        <View style={sosBanner.bar}>
+        <View style={[sosBanner.bar, { paddingTop: insets.top + 10 }]}>
           <View style={sosBanner.left}>
             <MaterialCommunityIcons name="alarm-light" size={16} color="#030810" />
             <Text style={sosBanner.name} numberOfLines={1}>{focusTitle}</Text>
@@ -718,7 +735,10 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
             )}
             <Pressable
               style={sosBanner.backBtn}
-              onPress={() => router.back()}
+              onPress={() => {
+                onDismissFocus?.();
+                router.back();
+              }}
               android_ripple={{ color: 'rgba(255,255,255,0.1)' }}
             >
               <MaterialCommunityIcons name="arrow-left" size={20} color="white" />
@@ -730,8 +750,11 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
       {/* Layer selector — shifted down when SOS banner is visible */}
       <Pressable
         onPress={() => setLayerModalVisible(true)}
-        className={`absolute ${focusSosPhone !== undefined ? 'top-20' : 'top-12'} right-4 p-3 rounded-full`}
-        style={{ backgroundColor: 'rgba(8, 15, 30, 0.85)' }}
+        className="absolute right-4 p-3 rounded-full"
+        style={{
+          top: insets.top + (focusSosPhone !== undefined ? 56 : 12),
+          backgroundColor: 'rgba(8, 15, 30, 0.85)',
+        }}
       >
         <MaterialCommunityIcons name="layers-outline" size={24} color="white" />
       </Pressable>

--- a/frontend/app/sos-invite/[token].tsx
+++ b/frontend/app/sos-invite/[token].tsx
@@ -32,6 +32,11 @@ export default function SosInviteScreen() {
       console.warn('[QA_SOS_INVITE] no token → error stage');
       setStage("error"); setErrorMsg("Enlace inválido."); return;
     }
+    // Persist unconditionally on arrival — not just for the push-notification path
+    // (_layout.tsx). A manually-shared link can land here before the user is
+    // logged in; without this, the token has nowhere else it gets saved and the
+    // invite is lost the moment they navigate away to sign in.
+    AsyncStorage.setItem(PENDING_SOS_INVITE_KEY, token).catch(() => {});
     const url = `${API_BASE_URL}/api/v1/sos-invitations/preview/${token}`;
     console.log('[QA_SOS_INVITE] fetching preview | url:', url);
     fetch(url)

--- a/frontend/utils/pushNotifications.ts
+++ b/frontend/utils/pushNotifications.ts
@@ -163,6 +163,21 @@ export async function setupNotificationChannels() {
     lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
     bypassDnd: true,
   });
+  // Invite / reject / contact-added pushes declare this channel id backend-side
+  // (sos_contacts/service.py, sos_invite/service.py) but it was never created
+  // here — Android silently fell back to its default channel (no heads-up, no
+  // guaranteed sound) for all three, making a successfully-sent invite push
+  // easy to miss entirely. HIGH (not MAX/bypassDnd) — important, but not the
+  // "someone needs help right now" signal that sos_emergency is.
+  await Notifications.setNotificationChannelAsync("sos_alerts", {
+    name: "Contactos SOS",
+    importance: Notifications.AndroidImportance.HIGH,
+    vibrationPattern: [0, 250, 250, 250],
+    enableVibrate: true,
+    showBadge: true,
+    sound: "default",
+    lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+  });
   // Silent channel for background data-refresh pushes — no banner, no sound, hidden in drawer
   await Notifications.setNotificationChannelAsync("contacts_refresh_silent", {
     name: "Sincronización de contactos",


### PR DESCRIPTION
## Summary
Fixes originados en la ronda de pruebas de SOS del equipo:

- **Vinculación de contactos SOS**: el match de teléfono era un string exacto; ahora compara los últimos 10 dígitos, así que el formato del contacto (código de país, guiones, espacios) ya no bloquea la vinculación automática.
- **Invitación perdida sin sesión**: si alguien tocaba un link de invitación compartido por WhatsApp sin tener sesión iniciada, `AuthGate` lo mandaba a login y el token se perdía. Ahora la pantalla de invitación es accesible sin sesión (la preview del backend ya era pública) y el token se guarda al montar, sin importar el estado de auth.
- **Canal de notificación `sos_alerts` faltante**: el backend mandaba invitaciones/rechazos/"te agregaron" declarando este canal, pero nunca se creó en el cliente — Android caía al canal por defecto (sin heads-up, sin sonido garantizado). Ya se registra con importancia HIGH.
- **Banner de SOS en el mapa desaparecía solo**: los parámetros de navegación se reseteaban unos segundos después de llegar (causa externa a esta pantalla); ahora se congelan al llegar y se limpian solo cuando el usuario cierra el banner explícitamente. También se corrigió que el banner quedaba tapado por la barra de estado/notch.
- **Fallback de ubicación al enviar SOS**: si el GPS en vivo no responde en 5s, ahora usa la última ubicación conocida de la sesión en vez de mandar el SOS sin coordenadas.

Documentado como limitación conocida (no arreglada en este PR): si el invitado no tiene la app instalada, el link de invitación no tiene fallback web/deferred-deep-link — requiere infraestructura aparte (Firebase Dynamic Links / Branch.io / App Links).

## Test plan
- [x] 41 tests de backend (`sos_invite`, `sos_contacts`, `sos_trigger`) pasan
- [x] eslint limpio en los archivos de frontend tocados
- [x] Probado en 2 dispositivos físicos (Xiaomi + Motorola) contra staging: banner de SOS ya no desaparece, se ve completo sin recorte
- [ ] Falta re-probar en vivo la vinculación por teléfono normalizado y el canal `sos_alerts` con un build nuevo (pendiente de este PR)