### PR TITLE
SMN cyclone advisories, SIAT-CT bug fixes, and map/dev-tool cleanup

### DIFF
--- a/backend/app/features/alerts/providers/smn_ciclon.py
+++ b/backend/app/features/alerts/providers/smn_ciclon.py
@@ -1,0 +1,174 @@
+"""
+SMN (Servicio Meteorológico Nacional) cyclone advisory provider.
+
+Scrapes the two per-basin "Aviso de Ciclón Tropical" pages. Unlike the general
+forecast bulletin (see smn.py), these pages are a thin Joomla wrapper around an
+embedded Laravel app (loaded via <iframe>) — the actual advisory content lives at:
+  - Pacífico:  https://smn.conagua.gob.mx/tools/GUI/PortalLaravel/public/WebAviso
+  - Atlántico: https://smn.conagua.gob.mx/tools/GUI/PortalLaravel/public/WebAvisoAtlan
+
+Both are server-rendered (no JS execution needed to scrape). When a basin has no
+active system, the page renders a static "Aviso de No Ciclón" image with no data.
+When active, a basin can have MULTIPLE simultaneous systems (e.g. two named storms
+in the Pacific at once) — each is listed as a button with a `data-aviso-id`, and
+only that id's own detail page (`{base}?searchText={id}`) has the full data.
+
+Encoding/robustness notes mirror smn.py: the site has no versioned API, so parsing
+is defensive — any missing field logs and falls back to None instead of raising.
+
+Cached in-memory for 30 minutes, per basin. Returns stale cache on network error.
+"""
+
+import logging
+import re
+from datetime import timedelta, datetime, timezone
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_TOOLS_BASE = "https://smn.conagua.gob.mx/tools/GUI/PortalLaravel/public"
+_OCEAN_URLS = {
+    "atlantico": f"{_TOOLS_BASE}/WebAvisoAtlan",
+    "pacifico": f"{_TOOLS_BASE}/WebAviso",
+}
+_CACHE_TTL = timedelta(minutes=30)
+_cache: dict[str, dict] = {}
+
+
+async def fetch_active_advisories(ocean: str) -> list[dict]:
+    """
+    Returns a list of active cyclone advisories for the given basin
+    ("atlantico" | "pacifico"). Empty list when no system is active.
+    Cached for 30 minutes. Returns stale cache on network error.
+    """
+    if ocean not in _OCEAN_URLS:
+        raise ValueError(f"Unknown ocean: {ocean!r}")
+
+    now = datetime.now(timezone.utc)
+    cached = _cache.get(ocean)
+    if cached and now - cached["fetched_at"] < _CACHE_TTL:
+        return cached["data"]
+
+    base_url = _OCEAN_URLS[ocean]
+    try:
+        async with httpx.AsyncClient(timeout=15.0, verify=False,
+                                      headers={"User-Agent": "BluEye/1.0"}) as client:
+            resp = await client.get(base_url, follow_redirects=True)
+            resp.raise_for_status()
+            html = resp.content.decode("utf-8", errors="replace")
+
+            if "AVISO-DE-NO-CICLON" in html.upper():
+                advisories: list[dict] = []
+            else:
+                aviso_ids = list(dict.fromkeys(re.findall(r'data-aviso-id="(\d+)"', html)))
+                advisories = []
+                for aviso_id in aviso_ids:
+                    detail_resp = await client.get(f"{base_url}?searchText={aviso_id}", follow_redirects=True)
+                    detail_resp.raise_for_status()
+                    detail_html = detail_resp.content.decode("utf-8", errors="replace")
+                    parsed = _parse_advisory(detail_html, ocean=ocean, aviso_id=aviso_id)
+                    if parsed:
+                        advisories.append(parsed)
+    except Exception as exc:
+        logger.warning("SMN cyclone advisory fetch failed (ocean=%s): %s", ocean, exc)
+        return cached["data"] if cached else []
+
+    _cache[ocean] = {"fetched_at": now, "data": advisories}
+    logger.info("SMN cyclone advisories fetched (ocean=%s): %d active", ocean, len(advisories))
+    return advisories
+
+
+def _strip_tags(html: str) -> str:
+    text = re.sub(r"<[^>]+>", " ", html)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _extract_row(label: str, html: str) -> list[str] | None:
+    """
+    Finds a table row whose first <td> matches `label` and returns the text of
+    the remaining <td> cells in that row (e.g. lat/lon or wind sostenidos/rachas
+    are split across two cells).
+    """
+    pattern = rf"<td[^>]*>{re.escape(label)}</td>\s*(.*?)</tr>"
+    m = re.search(pattern, html, re.DOTALL)
+    if not m:
+        return None
+    cells = re.findall(r"<td[^>]*>(.*?)</td>", m.group(1), re.DOTALL)
+    values = [_strip_tags(c) for c in cells]
+    return values or None
+
+
+def _first_number(text: str | None) -> float | None:
+    if not text:
+        return None
+    m = re.search(r"[\d.]+", text)
+    return float(m.group()) if m else None
+
+
+def _parse_advisory(html: str, ocean: str, aviso_id: str) -> dict | None:
+    aviso_num_match = re.search(r"No\.\s*Aviso:\s*(\d+)", html)
+    aviso_num = int(aviso_num_match.group(1)) if aviso_num_match else None
+
+    system_name_match = re.search(r"Sistema ciclónico:\s*([^<]+?)\s*</p>", html)
+    system_name = system_name_match.group(1).strip() if system_name_match else None
+
+    synthesis_match = re.search(r"<h3[^>]*>S[ií]ntesis</h3>\s*<p[^>]*>(.*?)</p>", html, re.DOTALL)
+    synthesis = _strip_tags(synthesis_match.group(1)) if synthesis_match else None
+
+    if not system_name and not synthesis:
+        logger.warning(
+            "SMN cyclone advisory parse failed (ocean=%s, aviso_id=%s): neither "
+            "system name nor synthesis found — page structure may have changed",
+            ocean, aviso_id,
+        )
+        return None
+
+    issued_match = re.search(r"Emisión:\s*([\d-]+\s+\d{1,2}:\d{2})\s*horas", html)
+    issued_at = issued_match.group(1) if issued_match else None
+
+    ubicacion = _extract_row("Ubicación del centro", html)
+    lat = _first_number(ubicacion[0]) if ubicacion and len(ubicacion) > 0 else None
+    lon_raw = _first_number(ubicacion[1]) if ubicacion and len(ubicacion) > 1 else None
+    # Site always reports "Longitud Oeste" for basins SMN tracks (Atlántico/Pacífico
+    # oriental) — west of the prime meridian, so negate to standard signed convention.
+    lon = -lon_raw if lon_raw is not None else None
+
+    location_row = _extract_row("Distancia al lugar más cercano", html)
+    location_text = location_row[0] if location_row else None
+
+    movement_row = _extract_row("Desplazamiento actual", html)
+    movement_text = movement_row[0] if movement_row else None
+
+    wind_row = _extract_row("Vientos máximos [km/h]", html)
+    wind_sustained_kmh = _first_number(wind_row[0]) if wind_row and len(wind_row) > 0 else None
+    wind_gusts_kmh = _first_number(wind_row[1]) if wind_row and len(wind_row) > 1 else None
+
+    pressure_row = _extract_row("Presión mínima central [hpa]", html)
+    pressure_hpa = _first_number(pressure_row[0]) if pressure_row else None
+
+    rain_row = _extract_row("Pronóstico de lluvia", html)
+    rain_forecast = rain_row[0] if rain_row else None
+
+    recommendations_row = _extract_row("Recomendaciones", html)
+    recommendations = recommendations_row[0] if recommendations_row else None
+
+    return {
+        "ocean": ocean,
+        "aviso_id": aviso_id,
+        "aviso_num": aviso_num,
+        "system_name": system_name,
+        "issued_at": issued_at,
+        "synthesis": synthesis,
+        "location_text": location_text,
+        "lat": lat,
+        "lon": lon,
+        "movement_text": movement_text,
+        "wind_sustained_kmh": wind_sustained_kmh,
+        "wind_gusts_kmh": wind_gusts_kmh,
+        "pressure_hpa": pressure_hpa,
+        "rain_forecast": rain_forecast,
+        "recommendations": recommendations,
+        "pdf_url": f"{_TOOLS_BASE}/generatePDF/{aviso_id}",
+        "source": "SMN/CONAGUA",
+    }

--- a/backend/app/features/alerts/router.py
+++ b/backend/app/features/alerts/router.py
@@ -18,8 +18,16 @@ from app.features.alerts.schemas import (
     OneCallAlertsResponse,
     SiatUserState,
     SMNBulletin,
+    SMNCycloneAdvisory,
 )
-from app.features.alerts.service import create_alert, get_alert_by_id, get_alerts, get_user_siat_state
+from app.features.alerts.service import (
+    create_alert,
+    get_alert_by_id,
+    get_alerts,
+    get_general_alerts_for_active,
+    get_smn_cyclone_advisories,
+    get_user_siat_state,
+)
 from app.features.alerts.providers.smn import fetch_latest_bulletin
 from app.features.users.service import get_user_by_firebase_uid
 from app.core.auth import get_current_user
@@ -99,8 +107,9 @@ async def get_active_alerts(
                     short=assessment_reason,
                 ))
 
-    # --- System alerts (admin-created, most recent 5) ---
-    raw_alerts = await get_alerts(db, limit=5, offset=0)
+    # --- System alerts (admin-created, most recent 5) — excludes SMN cyclone
+    # advisories, which get their own dedicated section below ---
+    raw_alerts = await get_general_alerts_for_active(db, limit=5)
     general_alerts = [
         ActiveAlertItem(
             source="SYSTEM",
@@ -122,12 +131,17 @@ async def get_active_alerts(
     except Exception as exc:
         logger.warning("SMN bulletin unavailable, continuing without it: %s", exc)
 
+    # --- SMN cyclone advisories (Atlántico/Pacífico), structured, from DB ---
+    raw_cyclone_advisories = await get_smn_cyclone_advisories(db)
+    smn_cyclone_advisories = [SMNCycloneAdvisory(**a) for a in raw_cyclone_advisories]
+
     return ActiveAlertsResponse(
         generated_at=datetime.now(timezone.utc),
         user_siat=user_siat,
         cyclonic_alerts=cyclonic_alerts,
         general_alerts=general_alerts,
         smn_bulletin=smn_bulletin,
+        smn_cyclone_advisories=smn_cyclone_advisories,
     )
 
 

--- a/backend/app/features/alerts/schemas.py
+++ b/backend/app/features/alerts/schemas.py
@@ -125,9 +125,28 @@ class SMNBulletin(BaseModel):
     source: str
 
 
+class SMNCycloneAdvisory(BaseModel):
+    ocean: str | None          # "atlantico" | "pacifico"
+    system_name: str | None
+    aviso_num: int | None
+    level: int
+    synthesis: str | None
+    location_text: str | None  # e.g. "820 km al sur-suroeste de Zihuatanejo, Gro."
+    lat: float | None
+    lon: float | None
+    movement_text: str | None
+    wind_sustained_kmh: float | None
+    wind_gusts_kmh: float | None
+    pressure_hpa: float | None
+    recommendations: str | None
+    pdf_url: str | None
+    issued_at: datetime
+
+
 class ActiveAlertsResponse(BaseModel):
     generated_at: datetime
     user_siat: SiatUserState | None
     cyclonic_alerts: list[ActiveAlertItem]
     general_alerts: list[ActiveAlertItem]
     smn_bulletin: SMNBulletin | None
+    smn_cyclone_advisories: list[SMNCycloneAdvisory]

--- a/backend/app/features/alerts/service.py
+++ b/backend/app/features/alerts/service.py
@@ -68,14 +68,156 @@ async def persist_smn_bulletin_if_new(db: AsyncSession, bulletin: dict) -> bool:
     return True
 
 
+async def persist_smn_cyclone_advisory_if_new(db: AsyncSession, advisory: dict) -> bool:
+    """
+    Insert an SMN cyclone advisory (Atlántico/Pacífico) into the alerts table
+    if it hasn't been persisted yet. Mirrors persist_smn_bulletin_if_new — same
+    table, same dedup-by-title-within-a-window strategy.
+    """
+    ocean_label = "Atlántico" if advisory.get("ocean") == "atlantico" else "Pacífico"
+    system_name = advisory.get("system_name") or "Sistema ciclónico"
+    aviso_num = advisory.get("aviso_num")
+    title = f"SMN Ciclón {ocean_label}: {system_name}"
+    if aviso_num:
+        title += f" — Aviso #{aviso_num}"
+    title = title[:255]
+
+    existing = await db.execute(
+        text("SELECT id FROM alerts WHERE title = :title AND timestamp > NOW() - INTERVAL '24 hours'"),
+        {"title": title},
+    )
+    existing_row = existing.mappings().first()
+    if existing_row:
+        pdf_url = advisory.get("pdf_url")
+        if pdf_url:
+            await db.execute(
+                text("UPDATE alerts SET pdf_url = :pdf_url WHERE id = :id AND pdf_url IS NULL"),
+                {"pdf_url": pdf_url, "id": existing_row["id"]},
+            )
+            await db.commit()
+        logger.debug("SMN cyclone advisory already persisted: '%s'", title)
+        return False
+
+    level = _smn_headline_to_level(advisory.get("synthesis") or system_name)
+    short = (advisory.get("synthesis") or f"Aviso de ciclón tropical — {system_name}")[:500]
+
+    factors = []
+    if advisory.get("location_text"):
+        factors.append(f"Distancia: {advisory['location_text']}")
+    if advisory.get("wind_sustained_kmh") is not None:
+        factors.append(f"Vientos sostenidos: {advisory['wind_sustained_kmh']:.0f} km/h")
+    if advisory.get("wind_gusts_kmh") is not None:
+        factors.append(f"Rachas: {advisory['wind_gusts_kmh']:.0f} km/h")
+    if advisory.get("pressure_hpa") is not None:
+        factors.append(f"Presión: {advisory['pressure_hpa']:.0f} hPa")
+    if advisory.get("movement_text"):
+        factors.append(f"Desplazamiento: {advisory['movement_text']}")
+
+    recommendations = [advisory["recommendations"]] if advisory.get("recommendations") else []
+
+    # Structured fields with no dedicated column — kept queryable/typed for
+    # get_smn_cyclone_advisories() instead of re-parsing them back out of `factors`.
+    cyclone_meta = {
+        "ocean": advisory.get("ocean"),
+        "system_name": system_name,
+        "aviso_num": aviso_num,
+        "location_text": advisory.get("location_text"),
+        "movement_text": advisory.get("movement_text"),
+        "wind_sustained_kmh": advisory.get("wind_sustained_kmh"),
+        "wind_gusts_kmh": advisory.get("wind_gusts_kmh"),
+        "pressure_hpa": advisory.get("pressure_hpa"),
+    }
+
+    await db.execute(
+        text("""
+            INSERT INTO alerts (level, score, title, short, lat, lon, factors, recommendations,
+                                 pdf_url, cyclone_meta)
+            VALUES (:level, 0, :title, :short, :lat, :lon,
+                    CAST(:factors AS jsonb), CAST(:recommendations AS jsonb), :pdf_url,
+                    CAST(:cyclone_meta AS jsonb))
+        """),
+        {
+            "level": level, "title": title, "short": short,
+            "lat": advisory.get("lat"), "lon": advisory.get("lon"),
+            "factors": json.dumps(factors),
+            "recommendations": json.dumps(recommendations),
+            "pdf_url": advisory.get("pdf_url"),
+            "cyclone_meta": json.dumps(cyclone_meta),
+        },
+    )
+    await db.commit()
+    logger.info("SMN cyclone advisory persisted: level=%d title='%s'", level, title)
+    return True
+
+
 async def get_alerts(db: AsyncSession, limit: int, offset: int):
     result = await db.execute(text("""SELECT id, timestamp, level, score, title, short
        FROM alerts
       ORDER BY timestamp DESC
       LIMIT :limit OFFSET :offset"""),
       {"limit": limit, "offset": offset})
-    
+
     return result.mappings().all()
+
+
+async def get_general_alerts_for_active(db: AsyncSession, limit: int):
+    """
+    System/admin alerts for the /active feed. Excludes SMN cyclone advisories
+    (cyclone_meta IS NOT NULL) — those get their own dedicated section
+    (see get_smn_cyclone_advisories) so they aren't shown twice.
+    """
+    result = await db.execute(
+        text("""
+            SELECT id, timestamp, level, score, title, short
+            FROM alerts
+            WHERE cyclone_meta IS NULL
+            ORDER BY timestamp DESC
+            LIMIT :limit
+        """),
+        {"limit": limit},
+    )
+    return result.mappings().all()
+
+
+async def get_smn_cyclone_advisories(db: AsyncSession) -> list[dict]:
+    """
+    Latest persisted SMN cyclone advisory per (ocean, system), within the last
+    24h — older advisories for the same system are superseded, not "still active".
+    """
+    result = await db.execute(
+        text("""
+            SELECT DISTINCT ON (cyclone_meta->>'ocean', cyclone_meta->>'system_name')
+                id, timestamp, level, title, short, lat, lon, pdf_url, recommendations, cyclone_meta
+            FROM alerts
+            WHERE cyclone_meta IS NOT NULL
+              AND timestamp > NOW() - INTERVAL '24 hours'
+            ORDER BY cyclone_meta->>'ocean', cyclone_meta->>'system_name', timestamp DESC
+        """)
+    )
+    rows = result.mappings().all()
+
+    advisories = []
+    for row in rows:
+        meta = row["cyclone_meta"] or {}
+        recs = row["recommendations"] or []
+        advisories.append({
+            "ocean": meta.get("ocean"),
+            "system_name": meta.get("system_name"),
+            "aviso_num": meta.get("aviso_num"),
+            "level": row["level"],
+            "synthesis": row["short"],
+            "location_text": meta.get("location_text"),
+            "lat": row["lat"],
+            "lon": row["lon"],
+            "movement_text": meta.get("movement_text"),
+            "wind_sustained_kmh": meta.get("wind_sustained_kmh"),
+            "wind_gusts_kmh": meta.get("wind_gusts_kmh"),
+            "pressure_hpa": meta.get("pressure_hpa"),
+            "recommendations": recs[0] if recs else None,
+            "pdf_url": row["pdf_url"],
+            "issued_at": row["timestamp"],
+        })
+    return advisories
 
 async def get_alert_by_id(db: AsyncSession, id):
     result = await db.execute(text("SELECT * FROM alerts WHERE id = :id LIMIT 1"),

--- a/backend/app/features/alerts/tests/test_router.py
+++ b/backend/app/features/alerts/tests/test_router.py
@@ -47,24 +47,27 @@ def test_alerts_active_returns_structure():
     with _mock_auth():
         with patch(f"{_ROUTER}.get_user_by_firebase_uid", new_callable=AsyncMock, return_value=fake_db_user):
             with patch(f"{_ROUTER}.get_user_siat_state", new_callable=AsyncMock, return_value=fake_siat):
-                with patch(f"{_ROUTER}.get_alerts", new_callable=AsyncMock, return_value=[]):
-                    with patch(f"{_ROUTER}.fetch_latest_bulletin", new_callable=AsyncMock, return_value=None):
-                        r = client.get("/api/v1/alerts/active", headers=AUTH_HEADERS)
+                with patch(f"{_ROUTER}.get_general_alerts_for_active", new_callable=AsyncMock, return_value=[]):
+                    with patch(f"{_ROUTER}.get_smn_cyclone_advisories", new_callable=AsyncMock, return_value=[]):
+                        with patch(f"{_ROUTER}.fetch_latest_bulletin", new_callable=AsyncMock, return_value=None):
+                            r = client.get("/api/v1/alerts/active", headers=AUTH_HEADERS)
     assert r.status_code == 200
     body = r.json()
     assert "user_siat" in body
     assert "cyclonic_alerts" in body
     assert "general_alerts" in body
     assert "smn_bulletin" in body
+    assert "smn_cyclone_advisories" in body
 
 
 def test_alerts_active_no_profile_still_returns_200():
     """User without profile should still get a valid (empty) response."""
     with _mock_auth():
         with patch(f"{_ROUTER}.get_user_by_firebase_uid", new_callable=AsyncMock, return_value=None):
-            with patch(f"{_ROUTER}.get_alerts", new_callable=AsyncMock, return_value=[]):
-                with patch(f"{_ROUTER}.fetch_latest_bulletin", new_callable=AsyncMock, return_value=None):
-                    r = client.get("/api/v1/alerts/active", headers=AUTH_HEADERS)
+            with patch(f"{_ROUTER}.get_general_alerts_for_active", new_callable=AsyncMock, return_value=[]):
+                with patch(f"{_ROUTER}.get_smn_cyclone_advisories", new_callable=AsyncMock, return_value=[]):
+                    with patch(f"{_ROUTER}.fetch_latest_bulletin", new_callable=AsyncMock, return_value=None):
+                        r = client.get("/api/v1/alerts/active", headers=AUTH_HEADERS)
     assert r.status_code == 200
     body = r.json()
     assert body["user_siat"] is None
@@ -76,9 +79,10 @@ def test_alerts_active_has_generated_at():
     from datetime import datetime
     with _mock_auth():
         with patch(f"{_ROUTER}.get_user_by_firebase_uid", new_callable=AsyncMock, return_value=None):
-            with patch(f"{_ROUTER}.get_alerts", new_callable=AsyncMock, return_value=[]):
-                with patch(f"{_ROUTER}.fetch_latest_bulletin", new_callable=AsyncMock, return_value=None):
-                    r = client.get("/api/v1/alerts/active", headers=AUTH_HEADERS)
+            with patch(f"{_ROUTER}.get_general_alerts_for_active", new_callable=AsyncMock, return_value=[]):
+                with patch(f"{_ROUTER}.get_smn_cyclone_advisories", new_callable=AsyncMock, return_value=[]):
+                    with patch(f"{_ROUTER}.fetch_latest_bulletin", new_callable=AsyncMock, return_value=None):
+                        r = client.get("/api/v1/alerts/active", headers=AUTH_HEADERS)
     assert r.status_code == 200
     body = r.json()
     assert "generated_at" in body
@@ -91,15 +95,53 @@ def test_alerts_active_smn_failure_does_not_break():
     """SMN raising an exception must not break /active — smn_bulletin is null, status 200."""
     with _mock_auth():
         with patch(f"{_ROUTER}.get_user_by_firebase_uid", new_callable=AsyncMock, return_value=None):
-            with patch(f"{_ROUTER}.get_alerts", new_callable=AsyncMock, return_value=[]):
-                with patch(
-                    f"{_ROUTER}.fetch_latest_bulletin",
-                    new_callable=AsyncMock,
-                    side_effect=Exception("network error"),
-                ):
-                    r = client.get("/api/v1/alerts/active", headers=AUTH_HEADERS)
+            with patch(f"{_ROUTER}.get_general_alerts_for_active", new_callable=AsyncMock, return_value=[]):
+                with patch(f"{_ROUTER}.get_smn_cyclone_advisories", new_callable=AsyncMock, return_value=[]):
+                    with patch(
+                        f"{_ROUTER}.fetch_latest_bulletin",
+                        new_callable=AsyncMock,
+                        side_effect=Exception("network error"),
+                    ):
+                        r = client.get("/api/v1/alerts/active", headers=AUTH_HEADERS)
     assert r.status_code == 200
     assert r.json()["smn_bulletin"] is None
+
+
+def test_alerts_active_includes_cyclone_advisories():
+    """smn_cyclone_advisories surfaces the structured rows from the DB, separate
+    from general_alerts."""
+    fake_advisory = {
+        "ocean": "pacifico",
+        "system_name": "Tormenta Tropical Genevieve",
+        "aviso_num": 5,
+        "level": 3,
+        "synthesis": "TORMENTA TROPICAL GENEVIEVE AL SUR DEL TERRITORIO NACIONAL.",
+        "location_text": "820 km al sur-suroeste de Zihuatanejo, Gro.",
+        "lat": 10.8,
+        "lon": -104.3,
+        "movement_text": "Hacia el oeste-noroeste (300°) a 24 km/h",
+        "wind_sustained_kmh": 95,
+        "wind_gusts_kmh": 110,
+        "pressure_hpa": 997,
+        "recommendations": "No se emiten recomendaciones.",
+        "pdf_url": "https://smn.conagua.gob.mx/tools/GUI/PortalLaravel/public/generatePDF/10635",
+        "issued_at": "2026-07-25T15:00:00+00:00",
+    }
+    with _mock_auth():
+        with patch(f"{_ROUTER}.get_user_by_firebase_uid", new_callable=AsyncMock, return_value=None):
+            with patch(f"{_ROUTER}.get_general_alerts_for_active", new_callable=AsyncMock, return_value=[]):
+                with patch(
+                    f"{_ROUTER}.get_smn_cyclone_advisories",
+                    new_callable=AsyncMock,
+                    return_value=[fake_advisory],
+                ):
+                    with patch(f"{_ROUTER}.fetch_latest_bulletin", new_callable=AsyncMock, return_value=None):
+                        r = client.get("/api/v1/alerts/active", headers=AUTH_HEADERS)
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["smn_cyclone_advisories"]) == 1
+    assert body["smn_cyclone_advisories"][0]["system_name"] == "Tormenta Tropical Genevieve"
+    assert body["smn_cyclone_advisories"][0]["wind_sustained_kmh"] == 95
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/features/alerts/tests/test_smn_ciclon.py
+++ b/backend/app/features/alerts/tests/test_smn_ciclon.py
@@ -1,0 +1,246 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from app.features.alerts.providers.smn_ciclon import _parse_advisory
+from app.features.alerts.service import get_smn_cyclone_advisories, persist_smn_cyclone_advisory_if_new
+
+# Trimmed but structurally faithful copy of the real WebAviso(Atlan) detail page
+# (fetched 2026-07-25) — keeps only the tags the parser's regexes target.
+_ACTIVE_ADVISORY_HTML = """
+<html><body>
+<header>
+  <p class="mb-0 small">
+    Océano Pacífico
+    - No. Aviso: 5
+  </p>
+  <p class="mb-0 small">Emisión: 2026-07-25 09:00 horas (15:00 horas GMT)</p>
+</header>
+<div class="alert-banner">
+  <p class="mb-0">Sistema ciclónico: Tormenta Tropical Genevieve</p>
+</div>
+<div class="sintesis-box">
+  <h3 class="h5">Síntesis</h3>
+  <p class="lead mb-0">TORMENTA TROPICAL GENEVIEVE AL SUR DEL TERRITORIO NACIONAL.</p>
+</div>
+<table>
+  <tbody>
+    <tr><td>Ubicación del centro</td><td>Latitud Norte: 10.8</td><td>Longitud Oeste: 104.3</td></tr>
+    <tr><td>Distancia al lugar más cercano</td><td colspan="2">820 km al sur-suroeste de Zihuatanejo, Gro.</td></tr>
+    <tr><td>Desplazamiento actual</td><td colspan="2">Hacia el oeste-noroeste (300°) a 24 km/h</td></tr>
+    <tr><td>Vientos máximos [km/h]</td><td>Sostenidos: 95</td><td>Rachas: 110</td></tr>
+    <tr><td>Presión mínima central [hpa]</td><td colspan="2">997</td></tr>
+    <tr><td>Pronóstico de lluvia</td><td colspan="2">Lluvias fuertes en el occidente del país.</td></tr>
+    <tr><td>Recomendaciones</td><td colspan="2">Debido a su distancia y trayectoria no se emiten recomendaciones.</td></tr>
+  </tbody>
+</table>
+</body></html>
+"""
+
+_NO_CICLON_HTML = """
+<html><body>
+<div class="aviso-container">
+    <img class="aviso-img" src="https://smn.conagua.gob.mx/tools/GUI/PortalLaravel/public/./Img/AVISO-DE-NO-CICLON.jpg">
+</div>
+</body></html>
+"""
+
+
+# ---------------------------------------------------------------------------
+# _parse_advisory
+# ---------------------------------------------------------------------------
+
+def test_parse_advisory_extracts_all_fields():
+    result = _parse_advisory(_ACTIVE_ADVISORY_HTML, ocean="pacifico", aviso_id="10635")
+
+    assert result is not None
+    assert result["aviso_num"] == 5
+    assert result["system_name"] == "Tormenta Tropical Genevieve"
+    assert result["synthesis"] == "TORMENTA TROPICAL GENEVIEVE AL SUR DEL TERRITORIO NACIONAL."
+    assert result["lat"] == 10.8
+    assert result["lon"] == -104.3  # "Longitud Oeste" negated to standard convention
+    assert result["location_text"] == "820 km al sur-suroeste de Zihuatanejo, Gro."
+    assert result["movement_text"] == "Hacia el oeste-noroeste (300°) a 24 km/h"
+    assert result["wind_sustained_kmh"] == 95
+    assert result["wind_gusts_kmh"] == 110
+    assert result["pressure_hpa"] == 997
+    assert result["recommendations"] == "Debido a su distancia y trayectoria no se emiten recomendaciones."
+    assert result["pdf_url"] == (
+        "https://smn.conagua.gob.mx/tools/GUI/PortalLaravel/public/generatePDF/10635"
+    )
+
+
+def test_parse_advisory_returns_none_when_structure_unrecognized():
+    result = _parse_advisory("<html><body>unexpected content</body></html>", ocean="pacifico", aviso_id="1")
+    assert result is None
+
+
+def test_parse_advisory_missing_optional_row_does_not_crash():
+    html_without_pressure = _ACTIVE_ADVISORY_HTML.replace(
+        '<tr><td>Presión mínima central [hpa]</td><td colspan="2">997</td></tr>', ""
+    )
+    result = _parse_advisory(html_without_pressure, ocean="pacifico", aviso_id="10635")
+    assert result is not None
+    assert result["pressure_hpa"] is None
+
+
+# ---------------------------------------------------------------------------
+# persist_smn_cyclone_advisory_if_new — service-level tests (no HTTP)
+# ---------------------------------------------------------------------------
+
+def _make_advisory(**overrides):
+    base = {
+        "ocean": "pacifico",
+        "aviso_id": "10635",
+        "aviso_num": 5,
+        "system_name": "Tormenta Tropical Genevieve",
+        "synthesis": "TORMENTA TROPICAL GENEVIEVE AL SUR DEL TERRITORIO NACIONAL.",
+        "location_text": "820 km al sur-suroeste de Zihuatanejo, Gro.",
+        "lat": 10.8,
+        "lon": -104.3,
+        "movement_text": "Hacia el oeste-noroeste (300°) a 24 km/h",
+        "wind_sustained_kmh": 95,
+        "wind_gusts_kmh": 110,
+        "pressure_hpa": 997,
+        "recommendations": "No se emiten recomendaciones.",
+        "pdf_url": "https://smn.conagua.gob.mx/tools/GUI/PortalLaravel/public/generatePDF/10635",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_persist_new_cyclone_advisory_returns_true():
+    db = MagicMock()
+    db.commit = AsyncMock()
+    db.execute = AsyncMock(side_effect=[
+        MagicMock(**{"mappings.return_value.first.return_value": None}),  # dedup miss
+        MagicMock(),  # INSERT
+    ])
+
+    result = await persist_smn_cyclone_advisory_if_new(db, _make_advisory())
+
+    assert result is True
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_persist_existing_cyclone_advisory_returns_false():
+    """Already-persisted advisory with no pdf_url to backfill → no write at all."""
+    db = MagicMock()
+    db.commit = AsyncMock()
+    db.execute = AsyncMock(return_value=MagicMock(
+        **{"mappings.return_value.first.return_value": {"id": "existing-uuid"}}
+    ))
+
+    result = await persist_smn_cyclone_advisory_if_new(db, _make_advisory(pdf_url=None))
+
+    assert result is False
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_persist_existing_cyclone_advisory_backfills_pdf_url():
+    """Already-persisted advisory whose row is missing pdf_url gets it backfilled."""
+    db = MagicMock()
+    db.commit = AsyncMock()
+    db.execute = AsyncMock(return_value=MagicMock(
+        **{"mappings.return_value.first.return_value": {"id": "existing-uuid"}}
+    ))
+
+    result = await persist_smn_cyclone_advisory_if_new(db, _make_advisory())
+
+    assert result is False
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_persist_cyclone_advisory_title_includes_ocean_and_system():
+    db = MagicMock()
+    db.commit = AsyncMock()
+    captured = {}
+
+    async def _execute(stmt, params=None):
+        if params and "title" in params and "id" not in params:
+            captured["title"] = params["title"]
+        return MagicMock(**{"mappings.return_value.first.return_value": None})
+
+    db.execute = AsyncMock(side_effect=_execute)
+
+    await persist_smn_cyclone_advisory_if_new(db, _make_advisory(ocean="atlantico", system_name="Huracán Fausto"))
+
+    assert captured["title"] == "SMN Ciclón Atlántico: Huracán Fausto — Aviso #5"
+
+
+@pytest.mark.asyncio
+async def test_persist_cyclone_advisory_level_from_synthesis_keywords():
+    """Reuses _smn_headline_to_level — a hurricane synthesis maps to a higher level."""
+    db = MagicMock()
+    db.commit = AsyncMock()
+    captured = {}
+
+    async def _execute(stmt, params=None):
+        if params and "level" in params:
+            captured["level"] = params["level"]
+        return MagicMock(**{"mappings.return_value.first.return_value": None})
+
+    db.execute = AsyncMock(side_effect=_execute)
+
+    await persist_smn_cyclone_advisory_if_new(
+        db, _make_advisory(synthesis="HURACÁN FAUSTO CATEGORÍA 4 EN EL PACÍFICO.")
+    )
+
+    assert captured["level"] == 5  # "CATEGORÍA 4" keyword
+
+
+# ---------------------------------------------------------------------------
+# get_smn_cyclone_advisories — maps DB rows (incl. cyclone_meta JSON) to dicts
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_smn_cyclone_advisories_maps_row_fields():
+    fake_row = {
+        "id": "uuid-1",
+        "timestamp": "2026-07-25T15:00:00+00:00",
+        "level": 3,
+        "title": "SMN Ciclón Pacífico: Tormenta Tropical Genevieve — Aviso #5",
+        "short": "TORMENTA TROPICAL GENEVIEVE AL SUR DEL TERRITORIO NACIONAL.",
+        "lat": 10.8,
+        "lon": -104.3,
+        "pdf_url": "https://smn.conagua.gob.mx/tools/GUI/PortalLaravel/public/generatePDF/10635",
+        "recommendations": ["No se emiten recomendaciones."],
+        "cyclone_meta": {
+            "ocean": "pacifico",
+            "system_name": "Tormenta Tropical Genevieve",
+            "aviso_num": 5,
+            "location_text": "820 km al sur-suroeste de Zihuatanejo, Gro.",
+            "movement_text": "Hacia el oeste-noroeste (300°) a 24 km/h",
+            "wind_sustained_kmh": 95,
+            "wind_gusts_kmh": 110,
+            "pressure_hpa": 997,
+        },
+    }
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=MagicMock(**{"mappings.return_value.all.return_value": [fake_row]}))
+
+    result = await get_smn_cyclone_advisories(db)
+
+    assert len(result) == 1
+    advisory = result[0]
+    assert advisory["ocean"] == "pacifico"
+    assert advisory["system_name"] == "Tormenta Tropical Genevieve"
+    assert advisory["aviso_num"] == 5
+    assert advisory["level"] == 3
+    assert advisory["synthesis"] == fake_row["short"]
+    assert advisory["wind_sustained_kmh"] == 95
+    assert advisory["recommendations"] == "No se emiten recomendaciones."
+    assert advisory["pdf_url"] == fake_row["pdf_url"]
+
+
+@pytest.mark.asyncio
+async def test_get_smn_cyclone_advisories_empty_when_none_active():
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=MagicMock(**{"mappings.return_value.all.return_value": []}))
+
+    result = await get_smn_cyclone_advisories(db)
+
+    assert result == []

--- a/backend/app/features/siat/providers/nhc.py
+++ b/backend/app/features/siat/providers/nhc.py
@@ -2,11 +2,19 @@
 NHC (National Hurricane Center) provider.
 Fetches active tropical cyclones from the public NHC JSON feed — no auth required.
 
-Official field reference:
+Official field reference (PDF):
   https://www.nhc.noaa.gov/productexamples/NHC_Tropical_Cyclone_Status_JSON_File_Reference.pdf
 
-Key field notes from the official PDF:
-  - latitude_numeric / longitude_numeric  (decimal degrees, numeric)
+The PDF documents `latitude_numeric` / `longitude_numeric` (snake_case), but the
+LIVE feed actually serves `latitudeNumeric` / `longitudeNumeric` (camelCase) —
+verified directly against https://www.nhc.noaa.gov/CurrentStorms.json. Using the
+PDF's snake_case names here silently defaulted lat/lon to 0.0 for every real
+storm (dict.get with a default never raises), which made every cyclone appear
+~10,000 km away and skip SIAT-CT's proximity evaluation entirely. Trust the live
+feed's actual keys over the PDF for lat/lon.
+
+Key field notes:
+  - latitudeNumeric / longitudeNumeric  (decimal degrees, numeric — LIVE feed casing)
   - intensity       wind speed in KNOTS
   - pressure        mean sea level pressure in millibars
   - movementDir     degrees from North (numeric)
@@ -61,13 +69,27 @@ async def fetch_active_cyclones() -> list[dict]:
 
 
 def _normalize(storm: dict) -> dict:
+    # No default on the dict lookups: a missing lat/lon must raise KeyError and
+    # get skipped+logged by the caller, not silently default to 0.0 (which is
+    # how the original bug went undetected — every real storm looked like it
+    # was sitting in the Gulf of Guinea, ~10,000 km from any Mexican user).
+    lat = float(storm["latitudeNumeric"])
+    lon = float(storm["longitudeNumeric"])
+    if lat == 0.0 and lon == 0.0:
+        # The field can be *present* but transiently zeroed — observed live
+        # against the real feed, presumably a race on NHC's end while their
+        # file regenerates. (0, 0) is not a plausible position for any storm
+        # this feed tracks, so treat it exactly like a missing field: raise
+        # and let the caller skip+log this entry instead of saving garbage
+        # that would make the storm look ~10,000 km away from everyone.
+        raise ValueError(f"Implausible (0, 0) position for storm {storm.get('name', '?')!r} — likely a transient feed glitch")
+
     return {
         "source": "NHC",
         "name": storm.get("name", "Unknown"),
         "status": storm.get("classification", "Unknown"),
-        # Official field names use snake_case with underscore
-        "lat": float(storm.get("latitude_numeric", 0)),
-        "lon": float(storm.get("longitude_numeric", 0)),
+        "lat": lat,
+        "lon": lon,
         # intensity is in knots → convert to km/h
         "wind_kmh": float(storm.get("intensity", 0) or 0) * _KNOTS_TO_KMH,
         # pressure field is named exactly "pressure" in the official schema

--- a/backend/app/features/siat/service.py
+++ b/backend/app/features/siat/service.py
@@ -247,7 +247,17 @@ async def _mark_notified(db: AsyncSession, user_id: int, level: int) -> None:
 async def _upsert_cyclone_alert(
     db: AsyncSession, cyclone: dict, assessment: dict
 ) -> str:
-    """Create an alerts record for a SIAT cyclone escalation. Returns the alert UUID."""
+    """
+    Create an alerts record for a SIAT cyclone escalation. Returns the alert UUID.
+
+    notified_at is set to NOW() here (not left NULL) because this escalation
+    already gets its own targeted push via _push_per_user, right after this
+    call, in run_cycle. Leaving it NULL made _get_pending_smn_alerts() pick up
+    this same brand-new row later in the SAME cycle and fire a SECOND push for
+    it through the generic SMN/geofenced path (_notify_smn_alerts) — a real
+    duplicate notification for one escalation, observed live. That path is for
+    national bulletins / admin-created alerts, not SIAT cyclone escalations.
+    """
     level = assessment["siat_level"]
     color = assessment["siat_color"]
     label = _COLOR_LABELS.get(color, color)
@@ -255,8 +265,8 @@ async def _upsert_cyclone_alert(
     short = (assessment.get("reason") or f"Ciclón a {assessment.get('distance_km', '?'):.0f} km")[:500]
     result = await db.execute(
         text("""
-            INSERT INTO alerts (level, score, title, short, lat, lon, factors, recommendations)
-            VALUES (:level, 0, :title, :short, :lat, :lon, '[]', '[]')
+            INSERT INTO alerts (level, score, title, short, lat, lon, factors, recommendations, notified_at)
+            VALUES (:level, 0, :title, :short, :lat, :lon, '[]', '[]', NOW())
             RETURNING id
         """),
         {
@@ -499,7 +509,8 @@ async def run_cycle(db: AsyncSession, extra_cyclones: list[dict] | None = None) 
     logger.info("SIAT run-cycle: %d cyclone(s), %d user(s) with location", len(cyclones), len(users))
 
     all_assessments: list[dict] = []
-    escalations: dict[int, dict] = {}  # user_id → highest assessment this cycle
+    escalations: dict[int, dict] = {}  # user_id → highest assessment this cycle (for the push decision)
+    best_assessment: dict[int, dict] = {}  # user_id → highest-LEVEL assessment this cycle (for persisted state)
     cyclone_map: dict[int, dict] = {}  # cyclone_id → cyclone data (for alert creation)
 
     for cyclone in (cyclones if users else []):
@@ -522,6 +533,9 @@ async def run_cycle(db: AsyncSession, extra_cyclones: list[dict] | None = None) 
                     )
                     continue
 
+                # Reads the state from BEFORE this cycle started — user_alert_states
+                # is only written once per user, after every cyclone has been
+                # evaluated (see below), so this stays stable across the whole loop.
                 old_state = await _get_user_state(db, user["id"])
                 old_level = old_state["current_level"] if old_state else None
                 new_level = assessment["siat_level"]
@@ -535,7 +549,14 @@ async def run_cycle(db: AsyncSession, extra_cyclones: list[dict] | None = None) 
                 )
 
                 await _save_assessment(db, user["id"], cyclone_id, assessment)
-                await _upsert_user_state(db, user["id"], new_level, assessment["siat_color"], cyclone_id)
+
+                # Track the worst active threat per user across ALL cyclones this
+                # cycle. Persisting per-cyclone here (instead of after the loop)
+                # would make current_level reflect whichever cyclone happened to
+                # be evaluated last, not the most dangerous one.
+                prev_best = best_assessment.get(user["id"])
+                if prev_best is None or new_level > prev_best["siat_level"]:
+                    best_assessment[user["id"]] = {**assessment, "cyclone_id": cyclone_id}
 
                 if new_level >= _NOTIFY_MIN_LEVEL and (old_level is None or new_level > old_level):
                     prefs = await get_preferences(db, user["id"])
@@ -567,6 +588,13 @@ async def run_cycle(db: AsyncSession, extra_cyclones: list[dict] | None = None) 
                     user["id"], cyclone.get("name"), exc, exc_info=True,
                 )
                 continue
+
+    # Persist current_level ONCE per user, using the worst threat found this
+    # cycle across every active cyclone — not per-cyclone inside the loop above.
+    for user_id, assessment in best_assessment.items():
+        await _upsert_user_state(
+            db, user_id, assessment["siat_level"], assessment["siat_color"], assessment["cyclone_id"]
+        )
 
     notifications_sent = 0
     if escalations:
@@ -621,6 +649,13 @@ async def get_active_cyclones(db: AsyncSession, max_age_hours: int = 72) -> list
     Cyclones (real + fake) recent enough to still be worth showing on the map.
     Enriches each row with its intensity classification and a parsed heading
     in degrees, for the map's category label and direction arrow.
+
+    Excludes (0, 0): a storm that's no longer in NHC's live feed (dissipated,
+    or the feed dropped it) stops getting fresh saves, so a row from before a
+    transient feed glitch — or from before the nhc.py provider fix — can sit
+    at (0, 0) for the entire max_age_hours window with no further write to
+    correct it. (0, 0) is never a plausible position for a storm this feed
+    tracks, so it's filtered here rather than trusted blindly.
     """
     result = await db.execute(
         text("""
@@ -628,6 +663,7 @@ async def get_active_cyclones(db: AsyncSession, max_age_hours: int = 72) -> list
                    movement_direction, movement_speed_kmh, advisory_time
             FROM cyclone_events
             WHERE advisory_time > NOW() - make_interval(hours => :max_age_hours)
+              AND NOT (lat = 0 AND lon = 0)
             ORDER BY advisory_time DESC
         """),
         {"max_age_hours": max_age_hours},

--- a/backend/app/features/siat/tests/test_nhc.py
+++ b/backend/app/features/siat/tests/test_nhc.py
@@ -1,0 +1,99 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from app.features.siat.providers.nhc import _normalize, fetch_active_cyclones
+
+# Shape of a real entry from https://www.nhc.noaa.gov/CurrentStorms.json
+# (verified live 2026-07-25) — the live feed uses camelCase for lat/lon,
+# NOT the snake_case latitude_numeric/longitude_numeric the official PDF
+# documents. This regression-tests the bug where the mismatch silently
+# defaulted every real storm's position to (0.0, 0.0).
+_REAL_STORM_PAYLOAD = {
+    "id": "ep062026",
+    "name": "Fausto",
+    "classification": "HU",
+    "intensity": "85",
+    "pressure": "971",
+    "latitude": "19.1N",
+    "longitude": "136.5W",
+    "latitudeNumeric": 19.1,
+    "longitudeNumeric": -136.5,
+    "movementDir": 280,
+    "movementSpeed": 14,
+}
+
+
+def test_normalize_parses_live_feed_camel_case_lat_lon():
+    result = _normalize(_REAL_STORM_PAYLOAD)
+
+    assert result["lat"] == 19.1
+    assert result["lon"] == -136.5
+    assert result["name"] == "Fausto"
+    assert result["status"] == "HU"
+
+
+def test_normalize_wind_and_movement_conversions():
+    result = _normalize(_REAL_STORM_PAYLOAD)
+
+    assert result["wind_kmh"] == pytest.approx(85 * 1.852)
+    assert result["movement_speed_kmh"] == pytest.approx(14 * 1.60934)
+    assert result["pressure"] == 971
+
+
+def test_normalize_missing_lat_lon_raises_keyerror():
+    """A storm entry with no lat/lon must fail loudly (KeyError), not silently
+    default to (0.0, 0.0) — the caller (fetch_active_cyclones) catches this
+    and skips+logs the entry instead of feeding bogus data into SIAT-CT."""
+    broken_payload = {k: v for k, v in _REAL_STORM_PAYLOAD.items() if "atitude" not in k.lower()}
+    with pytest.raises(KeyError):
+        _normalize(broken_payload)
+
+
+def test_normalize_zero_zero_position_raises_valueerror():
+    """
+    Regression test: observed live against the real NHC feed on 2026-07-26 —
+    a storm's latitudeNumeric/longitudeNumeric fields were BOTH PRESENT but
+    transiently 0 (presumably a race on NHC's end while their file
+    regenerates), which the KeyError guard alone doesn't catch since the keys
+    exist. (0, 0) is not a plausible position for any storm this feed tracks,
+    so it must be rejected the same way a missing field is — not saved as if
+    it were real, which would make the storm look ~10,000 km from everyone.
+    """
+    zeroed_payload = {**_REAL_STORM_PAYLOAD, "latitudeNumeric": 0.0, "longitudeNumeric": 0.0}
+    with pytest.raises(ValueError):
+        _normalize(zeroed_payload)
+
+
+@pytest.mark.asyncio
+async def test_fetch_active_cyclones_skips_malformed_entry_without_crashing():
+    """One malformed entry (missing lat/lon) must not take down the whole feed —
+    the other, well-formed entry still comes through."""
+    good_payload = dict(_REAL_STORM_PAYLOAD)
+    malformed_payload = {"name": "Broken", "classification": "TD"}  # no lat/lon at all
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value.raise_for_status = lambda: None
+        mock_get.return_value.json = lambda: {"activeStorms": [good_payload, malformed_payload]}
+
+        cyclones = await fetch_active_cyclones()
+
+    assert len(cyclones) == 1
+    assert cyclones[0]["name"] == "Fausto"
+    assert cyclones[0]["lat"] == 19.1
+
+
+@pytest.mark.asyncio
+async def test_fetch_active_cyclones_skips_zeroed_entry_without_crashing():
+    """A (0, 0) entry (transient NHC feed glitch) must be skipped, not saved as
+    the storm's real position — the other, well-formed entry still comes through."""
+    good_payload = dict(_REAL_STORM_PAYLOAD)
+    zeroed_payload = {**_REAL_STORM_PAYLOAD, "name": "Glitched", "latitudeNumeric": 0.0, "longitudeNumeric": 0.0}
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value.raise_for_status = lambda: None
+        mock_get.return_value.json = lambda: {"activeStorms": [good_payload, zeroed_payload]}
+
+        cyclones = await fetch_active_cyclones()
+
+    assert len(cyclones) == 1
+    assert cyclones[0]["name"] == "Fausto"

--- a/backend/app/features/siat/tests/test_router.py
+++ b/backend/app/features/siat/tests/test_router.py
@@ -419,6 +419,34 @@ async def test_run_cycle_sends_push_when_prefs_allow():
 
 
 # ---------------------------------------------------------------------------
+# _upsert_cyclone_alert — must not be double-notified via the SMN geofenced path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_upsert_cyclone_alert_marks_notified_at_immediately():
+    """
+    Regression test: a cyclone escalation alert must be created with
+    notified_at already set. It gets its own targeted push via _push_per_user
+    right after this call, inside run_cycle — leaving notified_at NULL let
+    _get_pending_smn_alerts() pick up this same brand-new row later in the
+    SAME cycle and fire a SECOND push for it through the generic SMN/
+    geofenced path (observed live: two distinct pushes for one escalation).
+    """
+    from app.features.siat.service import _upsert_cyclone_alert
+
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=MagicMock(
+        **{"mappings.return_value.first.return_value": {"id": "test-uuid"}}
+    ))
+
+    await _upsert_cyclone_alert(db, _FAKE_CYCLONE, _ASSESSMENT_LEVEL_3)
+
+    sql_text = str(db.execute.call_args.args[0])
+    assert "notified_at" in sql_text
+    assert "NOW()" in sql_text
+
+
+# ---------------------------------------------------------------------------
 # SMN/CONAGUA alerts → geocercado push — service-level tests
 # ---------------------------------------------------------------------------
 
@@ -820,6 +848,61 @@ async def test_run_cycle_with_extra_cyclones():
     assert result["cyclones_found"] == 1   # NHC=0, extra=1
     assert len(result["assessments"]) == 1
     assert result["notifications_sent"] == 1
+
+
+# ---------------------------------------------------------------------------
+# run_cycle() persists the WORST threat per cycle, not the last-evaluated one
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_run_cycle_persists_highest_level_regardless_of_evaluation_order():
+    """
+    Regression test: with two simultaneously active cyclones, user_alert_states
+    must end up reflecting the MOST severe assessment of the cycle — even when
+    the weaker cyclone happens to be evaluated last in the loop. Previously,
+    _upsert_user_state was called unconditionally per (cyclone, user) pair, so
+    whichever cyclone was last in the list silently overwrote a more dangerous
+    one evaluated earlier in the same cycle.
+    """
+    from app.features.siat.service import run_cycle
+
+    strong_cyclone = {"name": "STRONG", "status": "HU", "lat": 19.0, "lon": -99.0,
+                       "wind_kmh": 200.0, "movement_speed_kmh": 20.0}
+    weak_cyclone = {"name": "WEAK", "status": "TS", "lat": 10.0, "lon": -104.0,
+                     "wind_kmh": 80.0, "movement_speed_kmh": 15.0}
+
+    def _evaluate_side_effect(user_lat, user_lon, cyclone):
+        return _ASSESSMENT_LEVEL_5 if cyclone["name"] == "STRONG" else _ASSESSMENT_LEVEL_2
+
+    prefs = {"siat_enabled": True, "min_siat_level": 2, "map_events_enabled": True}
+    db = MagicMock()
+    db.commit = AsyncMock()
+    upsert_calls = []
+
+    async def _record_upsert(db, user_id, level, color, cyclone_id):
+        upsert_calls.append({"user_id": user_id, "level": level, "color": color})
+
+    with patch(f"{_SVC}.fetch_active_cyclones", new_callable=AsyncMock,
+               return_value=[strong_cyclone, weak_cyclone]), \
+         patch(f"{_SVC}._get_users_with_location", new_callable=AsyncMock, return_value=[_FAKE_USER]), \
+         patch(f"{_SVC}._save_cyclone", new_callable=AsyncMock, side_effect=[101, 102]), \
+         patch(f"{_SVC}.evaluate_user", side_effect=_evaluate_side_effect), \
+         patch(f"{_SVC}._get_user_state", new_callable=AsyncMock, return_value={"current_level": 1}), \
+         patch(f"{_SVC}._save_assessment", new_callable=AsyncMock), \
+         patch(f"{_SVC}._upsert_user_state", side_effect=_record_upsert), \
+         patch(f"{_SVC}.get_preferences", new_callable=AsyncMock, return_value=prefs), \
+         patch(f"{_SVC}.get_tokens_for_users", new_callable=AsyncMock, return_value={1: ["token-abc"]}), \
+         patch(f"{_SVC}._push_per_user", new_callable=AsyncMock, return_value=1), \
+         patch(f"{_SVC}._mark_notified", new_callable=AsyncMock), \
+         patch(f"{_SVC}._notify_smn_alerts", new_callable=AsyncMock, return_value=0), \
+         patch(f"{_SVC}._upsert_cyclone_alert", new_callable=AsyncMock, return_value="test-alert-uuid"):
+        await run_cycle(db)
+
+    # user_alert_states must be written exactly once for this user, with the
+    # STRONG cyclone's level (5) — never overwritten down to WEAK's level (2)
+    # even though WEAK was evaluated last.
+    assert len(upsert_calls) == 1
+    assert upsert_calls[0] == {"user_id": 1, "level": 5, "color": "ROJO"}
 
 
 @pytest.mark.asyncio

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,7 +16,8 @@ from app.features.sos_invite.router import router as sos_invite_router
 from app.features.sos_trigger.router import router as sos_trigger_router
 from app.features.siat.service import ensure_siat_tables, run_cycle
 from app.features.alerts.providers.smn import fetch_latest_bulletin
-from app.features.alerts.service import persist_smn_bulletin_if_new
+from app.features.alerts.providers.smn_ciclon import fetch_active_advisories
+from app.features.alerts.service import persist_smn_bulletin_if_new, persist_smn_cyclone_advisory_if_new
 import app.core.firebase
 import asyncio
 import logging
@@ -68,6 +69,9 @@ async def ensure_core_tables(engine: AsyncEngine) -> None:
         """))
         await conn.execute(text(
             "ALTER TABLE alerts ADD COLUMN IF NOT EXISTS pdf_url TEXT"
+        ))
+        await conn.execute(text(
+            "ALTER TABLE alerts ADD COLUMN IF NOT EXISTS cyclone_meta JSONB"
         ))
         await conn.execute(text(
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS phone VARCHAR(30)"
@@ -208,6 +212,20 @@ async def _siat_background_loop():
                             "SMN: new bulletin persisted — '%s'",
                             (bulletin.get("headline") or "")[:60],
                         )
+
+                for ocean in ("atlantico", "pacifico"):
+                    try:
+                        advisories = await fetch_active_advisories(ocean)
+                        for advisory in advisories:
+                            inserted = await persist_smn_cyclone_advisory_if_new(db, advisory)
+                            if inserted:
+                                logger.info(
+                                    "SMN: new cyclone advisory persisted — ocean=%s system=%s",
+                                    ocean, advisory.get("system_name"),
+                                )
+                    except Exception:
+                        logger.exception("SMN cyclone advisory cycle failed (ocean=%s)", ocean)
+
                 result = await run_cycle(db)
                 logger.info(
                     "SIAT background cycle: cyclones=%d users=%d notif=%d",

--- a/frontend/app/AlarmScreen.jsx
+++ b/frontend/app/AlarmScreen.jsx
@@ -49,7 +49,7 @@ export default function AlarmScreen() {
               style={{ backgroundColor: categoryBadgeColor }}
             >
               <Text className="text-white font-bold text-sm">
-                Categoría {alertData.category}
+                Nivel {alertData.category}
               </Text>
             </View>
           </View>

--- a/frontend/app/NotificationTestScreen.tsx
+++ b/frontend/app/NotificationTestScreen.tsx
@@ -1,94 +1,84 @@
-import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, ActivityIndicator, ScrollView, Switch, Alert, TextInput } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { MaterialCommunityIcons } from '@expo/vector-icons';
-import MapView, { Marker } from 'react-native-maps';
-import * as Location from 'expo-location';
-import { toast } from 'sonner-native';
-import { colors } from '../utils/theme';
-import { authFetch } from '../utils/api';
-import { API_BASE_URL } from '../utils/config';
-import { darkMapStyle } from './map/mapStyle';
-import { DEFAULT_REGION } from './map/config';
-
-type MCIName = React.ComponentProps<typeof MaterialCommunityIcons>['name'];
-
-type NotificationTestType = 'hurricane_l2' | 'hurricane_l3' | 'hurricane_l4' | 'sos_test' | 'generic';
-
-type TestButton = {
-  label: string;
-  icon: MCIName;
-  color: string;
-  type: NotificationTestType;
-};
-
-const BUTTONS: TestButton[] = [
-  { label: 'Huracán Nivel 2 — Verde',               icon: 'weather-hurricane',  color: colors.brandGreen,   type: 'hurricane_l2' },
-  { label: 'Huracán Nivel 3 — Amarillo',             icon: 'weather-hurricane',  color: colors.brandYellow,  type: 'hurricane_l3' },
-  { label: 'Huracán Nivel 4 — Naranja (fullscreen)', icon: 'alert-octagram',     color: colors.brandOrange,  type: 'hurricane_l4' },
-  { label: 'SOS de prueba',                         icon: 'alarm-light-outline', color: colors.brandRed,     type: 'sos_test' },
-  { label: 'Push genérico',                         icon: 'bell-outline',        color: colors.brandBlue,    type: 'generic' },
-];
+import React, { useState } from "react";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  ActivityIndicator,
+  ScrollView,
+  TextInput,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import MapView, { Marker } from "react-native-maps";
+import * as Location from "expo-location";
+import { toast } from "sonner-native";
+import { colors } from "../utils/theme";
+import { authFetch } from "../utils/api";
+import { API_BASE_URL } from "../utils/config";
+import { darkMapStyle } from "./map/mapStyle";
+import { DEFAULT_REGION } from "./map/config";
 
 // Same 16-point compass abbreviations the backend's direction.py parses —
 // collapsed to 8 for a simpler chip row (backend also accepts the numeric bearing NHC sends).
-const COMPASS_DIRECTIONS = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'] as const;
-type CompassDirection = typeof COMPASS_DIRECTIONS[number];
+const COMPASS_DIRECTIONS = [
+  "N",
+  "NE",
+  "E",
+  "SE",
+  "S",
+  "SW",
+  "W",
+  "NW",
+] as const;
+type CompassDirection = (typeof COMPASS_DIRECTIONS)[number];
 
 // Same defaults FakeCycloneRequest uses in backend/app/features/siat/schemas.py
-const DEFAULT_CYCLONE_NAME = 'FALSO-1';
-const DEFAULT_WIND_KMH = '120';
-const DEFAULT_SPEED_KMH = '20';
-const DEFAULT_DIRECTION: CompassDirection = 'NW';
+const DEFAULT_CYCLONE_NAME = "FALSO-1";
+const DEFAULT_WIND_KMH = "120";
+const DEFAULT_SPEED_KMH = "20";
+const DEFAULT_DIRECTION: CompassDirection = "NW";
 const DEFAULT_LAT = 21.0;
 const DEFAULT_LON = -98.0;
 
 export default function NotificationTestScreen() {
-  const [loadingIndex, setLoadingIndex] = useState<number | null>(null);
-  const [onlyMe, setOnlyMe] = useState(true);
   const [cycloneLoading, setCycloneLoading] = useState(false);
-
   const [resetLoading, setResetLoading] = useState(false);
-  const [smnLoading, setSmnLoading] = useState(false);
 
   const [cycloneName, setCycloneName] = useState(DEFAULT_CYCLONE_NAME);
   const [cycloneLat, setCycloneLat] = useState(String(DEFAULT_LAT));
   const [cycloneLon, setCycloneLon] = useState(String(DEFAULT_LON));
   const [windKmh, setWindKmh] = useState(DEFAULT_WIND_KMH);
   const [speedKmh, setSpeedKmh] = useState(DEFAULT_SPEED_KMH);
-  const [direction, setDirection] = useState<CompassDirection>(DEFAULT_DIRECTION);
+  const [direction, setDirection] =
+    useState<CompassDirection>(DEFAULT_DIRECTION);
   const [locatingSelf, setLocatingSelf] = useState(false);
 
   const markerLat = Number(cycloneLat);
   const markerLon = Number(cycloneLon);
-  const hasValidMarker = Number.isFinite(markerLat) && Number.isFinite(markerLon);
-
-  const confirmBroadcast = (): Promise<boolean> =>
-    new Promise(resolve =>
-      Alert.alert(
-        '¿Enviar a todos?',
-        'Esto mandará la notificación a TODOS los dispositivos registrados en esta base de datos.',
-        [
-          { text: 'Cancelar', style: 'cancel', onPress: () => resolve(false) },
-          { text: 'Enviar', style: 'destructive', onPress: () => resolve(true) },
-        ],
-      ),
-    );
+  const hasValidMarker =
+    Number.isFinite(markerLat) && Number.isFinite(markerLon);
 
   const useMyLocation = async () => {
     if (locatingSelf) return;
     setLocatingSelf(true);
     try {
       const { status } = await Location.requestForegroundPermissionsAsync();
-      if (status !== 'granted') {
-        toast.error('Permiso denegado', { description: 'Activa el permiso de ubicación para usar tu posición actual.' });
+      if (status !== "granted") {
+        toast.error("Permiso denegado", {
+          description:
+            "Activa el permiso de ubicación para usar tu posición actual.",
+        });
         return;
       }
-      const { coords } = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
+      const { coords } = await Location.getCurrentPositionAsync({
+        accuracy: Location.Accuracy.Balanced,
+      });
       setCycloneLat(coords.latitude.toFixed(5));
       setCycloneLon(coords.longitude.toFixed(5));
     } catch (e) {
-      toast.error('No se pudo obtener tu ubicación', { description: String(e) });
+      toast.error("No se pudo obtener tu ubicación", {
+        description: String(e),
+      });
     } finally {
       setLocatingSelf(false);
     }
@@ -103,23 +93,33 @@ export default function NotificationTestScreen() {
     const speed = Number(speedKmh);
 
     if (!cycloneName.trim()) {
-      toast.error('Nombre requerido', { description: 'Escribe un nombre para el ciclón de prueba.' });
+      toast.error("Nombre requerido", {
+        description: "Escribe un nombre para el ciclón de prueba.",
+      });
       return;
     }
     if (!Number.isFinite(lat) || lat < -90 || lat > 90) {
-      toast.error('Latitud inválida', { description: 'Debe ser un número entre -90 y 90.' });
+      toast.error("Latitud inválida", {
+        description: "Debe ser un número entre -90 y 90.",
+      });
       return;
     }
     if (!Number.isFinite(lon) || lon < -180 || lon > 180) {
-      toast.error('Longitud inválida', { description: 'Debe ser un número entre -180 y 180.' });
+      toast.error("Longitud inválida", {
+        description: "Debe ser un número entre -180 y 180.",
+      });
       return;
     }
     if (!Number.isFinite(wind) || wind <= 0) {
-      toast.error('Viento inválido', { description: 'Debe ser un número mayor a 0.' });
+      toast.error("Viento inválido", {
+        description: "Debe ser un número mayor a 0.",
+      });
       return;
     }
     if (!Number.isFinite(speed) || speed < 0) {
-      toast.error('Velocidad inválida', { description: 'Debe ser un número mayor o igual a 0.' });
+      toast.error("Velocidad inválida", {
+        description: "Debe ser un número mayor o igual a 0.",
+      });
       return;
     }
 
@@ -134,37 +134,57 @@ export default function NotificationTestScreen() {
 
     setCycloneLoading(true);
     try {
-      console.log('[SIAT] inject-cyclone →', body.name, body);
-      const res = await authFetch(`${API_BASE_URL}/api/v1/siat/inject-cyclone`, {
-        method: 'POST',
-        body: JSON.stringify(body),
-      });
-      console.log('[SIAT] inject-cyclone status:', res.status);
+      console.log("[SIAT] inject-cyclone →", body.name, body);
+      const res = await authFetch(
+        `${API_BASE_URL}/api/v1/siat/inject-cyclone`,
+        {
+          method: "POST",
+          body: JSON.stringify(body),
+        },
+      );
+      console.log("[SIAT] inject-cyclone status:", res.status);
       if (res.status === 403) {
-        console.warn('[SIAT] inject-cyclone 403 — sin acceso');
-        toast.error('Sin acceso', { description: 'Pide que agreguen tu email a NOTIFICATION_TEST_ADMIN_EMAILS en backend/.env' });
+        console.warn("[SIAT] inject-cyclone 403 — sin acceso");
+        toast.error("Sin acceso", {
+          description:
+            "Pide que agreguen tu email a NOTIFICATION_TEST_ADMIN_EMAILS en backend/.env",
+        });
         return;
       }
       if (res.status === 422) {
         const err = await res.json().catch(() => ({}));
-        console.warn('[SIAT] inject-cyclone 422 — sin ubicación:', err.detail);
-        toast.error('Sin ubicación registrada', { description: err.detail || 'Configura tu ubicación en el perfil antes de inyectar.' });
+        console.warn("[SIAT] inject-cyclone 422 — sin ubicación:", err.detail);
+        toast.error("Sin ubicación registrada", {
+          description:
+            err.detail ||
+            "Configura tu ubicación en el perfil antes de inyectar.",
+        });
         return;
       }
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
-      console.log('[SIAT] inject-cyclone OK — users_evaluated:', data.users_evaluated, 'notifications_sent:', data.notifications_sent, 'assessments:', data.assessments);
+      console.log(
+        "[SIAT] inject-cyclone OK — users_evaluated:",
+        data.users_evaluated,
+        "notifications_sent:",
+        data.notifications_sent,
+        "assessments:",
+        data.assessments,
+      );
       const firstAssessment = data.assessments?.[0];
       const detail = firstAssessment
         ? `${data.users_evaluated} eval. · Nivel ${firstAssessment.siat_level} ${firstAssessment.siat_color} · ${firstAssessment.distance_km?.toFixed(0)} km`
         : `${data.users_evaluated} evaluado(s)`;
-      const notifDesc = data.notifications_sent > 0
-        ? `Push enviado · ${detail}`
-        : `Sin push · ${detail} · (revisa quiet hours o nivel mínimo)`;
-      toast.success(`Ciclón inyectado · ${body.name}`, { description: notifDesc });
+      const notifDesc =
+        data.notifications_sent > 0
+          ? `Push enviado · ${detail}`
+          : `Sin push · ${detail} · (revisa quiet hours o nivel mínimo)`;
+      toast.success(`Ciclón inyectado · ${body.name}`, {
+        description: notifDesc,
+      });
     } catch (e) {
-      console.error('[SIAT] inject-cyclone error:', e);
-      toast.error('Error al inyectar ciclón', { description: String(e) });
+      console.error("[SIAT] inject-cyclone error:", e);
+      toast.error("Error al inyectar ciclón", { description: String(e) });
     } finally {
       setCycloneLoading(false);
     }
@@ -174,83 +194,33 @@ export default function NotificationTestScreen() {
     if (resetLoading) return;
     setResetLoading(true);
     try {
-      console.log('[SIAT] reset-state →');
-      const res = await authFetch(`${API_BASE_URL}/api/v1/siat/reset-state`, { method: 'POST' });
-      console.log('[SIAT] reset-state status:', res.status);
+      console.log("[SIAT] reset-state →");
+      const res = await authFetch(`${API_BASE_URL}/api/v1/siat/reset-state`, {
+        method: "POST",
+      });
+      console.log("[SIAT] reset-state status:", res.status);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      console.log('[SIAT] reset-state OK');
-      toast.success('Estado SIAT reiniciado', { description: 'La siguiente inyección evaluará desde nivel 0.' });
+      console.log("[SIAT] reset-state OK");
+      toast.success("Estado SIAT reiniciado", {
+        description: "La siguiente inyección evaluará desde nivel 0.",
+      });
     } catch (e) {
-      console.error('[SIAT] reset-state error:', e);
-      toast.error('Error al reiniciar', { description: String(e) });
+      console.error("[SIAT] reset-state error:", e);
+      toast.error("Error al reiniciar", { description: String(e) });
     } finally {
       setResetLoading(false);
     }
   };
 
-  const injectSmnAlert = async () => {
-    if (smnLoading) return;
-    setSmnLoading(true);
-    try {
-      console.log('[SMN] inject-smn-alert → level 3');
-      const res = await authFetch(`${API_BASE_URL}/api/v1/siat/inject-smn-alert`, {
-        method: 'POST',
-        body: JSON.stringify({ level: 3, title: 'SMN: Alerta Meteorológica de Prueba [TEST]', short: 'Prueba de alerta nacional SMN/CONAGUA generada por el equipo BluEye.' }),
-      });
-      console.log('[SMN] inject-smn-alert status:', res.status);
-      if (res.status === 403) {
-        console.warn('[SMN] inject-smn-alert 403 — sin acceso');
-        toast.error('Sin acceso', { description: 'Pide que agreguen tu email a NOTIFICATION_TEST_ADMIN_EMAILS en backend/.env' });
-        return;
-      }
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
-      console.log('[SMN] inject-smn-alert OK — notifications_sent:', data.notifications_sent, 'users_evaluated:', data.users_evaluated);
-      const desc = data.notifications_sent > 0
-        ? `Push enviado a ${data.notifications_sent} dispositivo(s) · ${data.users_evaluated} usuario(s) evaluados`
-        : `${data.users_evaluated} usuario(s) evaluados · sin push (revisa prefs)`;
-      toast.success('Alerta SMN inyectada', { description: desc });
-    } catch (e) {
-      console.error('[SMN] inject-smn-alert error:', e);
-      toast.error('Error al inyectar alerta SMN', { description: String(e) });
-    } finally {
-      setSmnLoading(false);
-    }
-  };
-
-  const sendTest = async (index: number) => {
-    if (loadingIndex !== null) return;
-    if (!onlyMe && !(await confirmBroadcast())) return;
-    setLoadingIndex(index);
-    const btn = BUTTONS[index];
-    console.log('[NotifTest] sendTest →', btn.type, '| only_me:', onlyMe);
-    try {
-      const res = await authFetch(`${API_BASE_URL}/api/v1/notifications/test`, {
-        method: 'POST',
-        body: JSON.stringify({ type: btn.type, only_me: onlyMe }),
-      });
-      console.log('[NotifTest] sendTest status:', res.status);
-      if (res.status === 403) {
-        console.warn('[NotifTest] sendTest 403 — sin acceso');
-        toast.error('Sin acceso', { description: 'Pide que agreguen tu email a NOTIFICATION_TEST_ADMIN_EMAILS en backend/.env' });
-        return;
-      }
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
-      console.log('[NotifTest] sendTest OK — success_count:', data.success_count, 'failure_count:', data.failure_count);
-      const desc = onlyMe ? 'Solo tu dispositivo' : `${data.success_count} dispositivo(s)`;
-      toast.success('Enviado', { description: desc });
-    } catch (e) {
-      console.error('[NotifTest] sendTest error:', e);
-      toast.error('Error al enviar', { description: String(e) });
-    } finally {
-      setLoadingIndex(null);
-    }
-  };
-
   return (
-    <SafeAreaView edges={['top', 'left', 'right', 'bottom']} className="flex-1 bg-transparent">
-      <ScrollView className="flex-1 px-6 pt-6" showsVerticalScrollIndicator={false}>
+    <SafeAreaView
+      edges={["top", "left", "right", "bottom"]}
+      className="flex-1 bg-transparent"
+    >
+      <ScrollView
+        className="flex-1 px-6 pt-6"
+        showsVerticalScrollIndicator={false}
+      >
         <Text className="text-xl font-poppins-semibold text-white mb-1">
           Dev: Notificaciones
         </Text>
@@ -258,64 +228,18 @@ export default function NotificationTestScreen() {
           Herramienta interna — solo visible en staging/dev
         </Text>
 
-        {/* Destino de la notificación */}
-        <View
-          className="flex-row items-center justify-between mb-6 rounded-2xl px-5 py-4"
-          style={{ backgroundColor: 'rgba(255,255,255,0.06)', borderWidth: 1, borderColor: 'rgba(255,255,255,0.12)' }}
-        >
-          <View className="flex-1 mr-4">
-            <Text className="text-sm font-poppins-semibold text-white">Solo mi dispositivo</Text>
-            <Text className="text-xs font-poppins text-white/50 mt-0.5">
-              {onlyMe ? 'Push solo a tus tokens registrados' : 'Broadcast a TODOS los dispositivos'}
-            </Text>
-          </View>
-          <Switch
-            value={onlyMe}
-            onValueChange={setOnlyMe}
-            trackColor={{ false: 'rgba(255,255,255,0.15)', true: colors.brandBlue }}
-            thumbColor="white"
-          />
-        </View>
-
-        {BUTTONS.map((btn, index) => (
-          <TouchableOpacity
-            key={btn.type}
-            onPress={() => sendTest(index)}
-            disabled={loadingIndex !== null}
-            className="flex-row items-center mb-4 rounded-2xl px-5 py-4"
-            style={{
-              backgroundColor: `${btn.color}22`,
-              borderWidth: 1,
-              borderColor: btn.color,
-              opacity: loadingIndex !== null && loadingIndex !== index ? 0.5 : 1,
-            }}
-          >
-            {loadingIndex === index ? (
-              <ActivityIndicator size="small" color={btn.color} style={{ marginRight: 12 }} />
-            ) : (
-              <MaterialCommunityIcons name={btn.icon} size={22} color={btn.color} style={{ marginRight: 12 }} />
-            )}
-            <Text className="flex-1 font-poppins-semibold text-sm" style={{ color: 'white' }}>
-              {btn.label}
-            </Text>
-            {loadingIndex !== null && loadingIndex !== index && (
-              <Text className="text-xs font-poppins text-white/30">espera...</Text>
-            )}
-          </TouchableOpacity>
-        ))}
-
         {/* Sección: inyección de ciclón falso */}
         <Text className="text-base font-poppins-semibold text-white mt-4 mb-1">
           Motor SIAT — Ciclón Falso
         </Text>
         <Text className="text-xs font-poppins text-white/50 mb-4">
-          Crea un ciclón de prueba con los parámetros que quieras y corre el ciclo SIAT
-          completo end-to-end.
+          Crea un ciclón de prueba con los parámetros que quieras y corre el
+          ciclo SIAT completo end-to-end.
         </Text>
 
         <View
           className="mb-4 rounded-2xl overflow-hidden"
-          style={{ borderWidth: 1, borderColor: 'rgba(255,255,255,0.12)' }}
+          style={{ borderWidth: 1, borderColor: "rgba(255,255,255,0.12)" }}
         >
           <MapView
             style={{ height: 180 }}
@@ -332,7 +256,11 @@ export default function NotificationTestScreen() {
                 coordinate={{ latitude: markerLat, longitude: markerLon }}
                 anchor={{ x: 0.5, y: 0.5 }}
               >
-                <MaterialCommunityIcons name="weather-hurricane" size={28} color={colors.brandRed} />
+                <MaterialCommunityIcons
+                  name="weather-hurricane"
+                  size={28}
+                  color={colors.brandRed}
+                />
               </Marker>
             )}
           </MapView>
@@ -340,36 +268,53 @@ export default function NotificationTestScreen() {
             onPress={useMyLocation}
             disabled={locatingSelf}
             className="flex-row items-center justify-center py-2.5"
-            style={{ backgroundColor: 'rgba(255,255,255,0.06)' }}
+            style={{ backgroundColor: "rgba(255,255,255,0.06)" }}
           >
-            {locatingSelf
-              ? <ActivityIndicator size="small" color="white" style={{ marginRight: 8 }} />
-              : <MaterialCommunityIcons name="crosshairs-gps" size={16} color="white" style={{ marginRight: 8 }} />}
-            <Text className="font-poppins text-xs text-white/70">Usar mi ubicación actual</Text>
+            {locatingSelf ? (
+              <ActivityIndicator
+                size="small"
+                color="white"
+                style={{ marginRight: 8 }}
+              />
+            ) : (
+              <MaterialCommunityIcons
+                name="crosshairs-gps"
+                size={16}
+                color="white"
+                style={{ marginRight: 8 }}
+              />
+            )}
+            <Text className="font-poppins text-xs text-white/70">
+              Usar mi ubicación actual
+            </Text>
           </TouchableOpacity>
         </View>
 
         <View className="flex-row gap-3 mb-3">
           <View className="flex-1">
-            <Text className="font-poppins text-xs text-white/50 mb-1">Latitud</Text>
+            <Text className="font-poppins text-xs text-white/50 mb-1">
+              Latitud
+            </Text>
             <TextInput
               value={cycloneLat}
               onChangeText={setCycloneLat}
               keyboardType="numbers-and-punctuation"
               placeholderTextColor="rgba(255,255,255,0.3)"
               className="rounded-lg px-3 py-2 font-poppins text-white"
-              style={{ borderWidth: 1, borderColor: 'rgba(255,255,255,0.2)' }}
+              style={{ borderWidth: 1, borderColor: "rgba(255,255,255,0.2)" }}
             />
           </View>
           <View className="flex-1">
-            <Text className="font-poppins text-xs text-white/50 mb-1">Longitud</Text>
+            <Text className="font-poppins text-xs text-white/50 mb-1">
+              Longitud
+            </Text>
             <TextInput
               value={cycloneLon}
               onChangeText={setCycloneLon}
               keyboardType="numbers-and-punctuation"
               placeholderTextColor="rgba(255,255,255,0.3)"
               className="rounded-lg px-3 py-2 font-poppins text-white"
-              style={{ borderWidth: 1, borderColor: 'rgba(255,255,255,0.2)' }}
+              style={{ borderWidth: 1, borderColor: "rgba(255,255,255,0.2)" }}
             />
           </View>
         </View>
@@ -380,30 +325,34 @@ export default function NotificationTestScreen() {
           onChangeText={setCycloneName}
           placeholderTextColor="rgba(255,255,255,0.3)"
           className="rounded-lg px-3 py-2 mb-3 font-poppins text-white"
-          style={{ borderWidth: 1, borderColor: 'rgba(255,255,255,0.2)' }}
+          style={{ borderWidth: 1, borderColor: "rgba(255,255,255,0.2)" }}
         />
 
         <View className="flex-row gap-3 mb-3">
           <View className="flex-1">
-            <Text className="font-poppins text-xs text-white/50 mb-1">Viento (km/h)</Text>
+            <Text className="font-poppins text-xs text-white/50 mb-1">
+              Viento (km/h)
+            </Text>
             <TextInput
               value={windKmh}
               onChangeText={setWindKmh}
               keyboardType="numeric"
               placeholderTextColor="rgba(255,255,255,0.3)"
               className="rounded-lg px-3 py-2 font-poppins text-white"
-              style={{ borderWidth: 1, borderColor: 'rgba(255,255,255,0.2)' }}
+              style={{ borderWidth: 1, borderColor: "rgba(255,255,255,0.2)" }}
             />
           </View>
           <View className="flex-1">
-            <Text className="font-poppins text-xs text-white/50 mb-1">Velocidad (km/h)</Text>
+            <Text className="font-poppins text-xs text-white/50 mb-1">
+              Velocidad (km/h)
+            </Text>
             <TextInput
               value={speedKmh}
               onChangeText={setSpeedKmh}
               keyboardType="numeric"
               placeholderTextColor="rgba(255,255,255,0.3)"
               className="rounded-lg px-3 py-2 font-poppins text-white"
-              style={{ borderWidth: 1, borderColor: 'rgba(255,255,255,0.2)' }}
+              style={{ borderWidth: 1, borderColor: "rgba(255,255,255,0.2)" }}
             />
           </View>
         </View>
@@ -416,12 +365,20 @@ export default function NotificationTestScreen() {
               onPress={() => setDirection(dir)}
               className="rounded-full px-4 py-2"
               style={{
-                backgroundColor: direction === dir ? colors.brandBlue : 'rgba(255,255,255,0.06)',
+                backgroundColor:
+                  direction === dir
+                    ? colors.brandBlue
+                    : "rgba(255,255,255,0.06)",
                 borderWidth: 1,
-                borderColor: direction === dir ? colors.brandBlue : 'rgba(255,255,255,0.2)',
+                borderColor:
+                  direction === dir
+                    ? colors.brandBlue
+                    : "rgba(255,255,255,0.2)",
               }}
             >
-              <Text className="font-poppins-semibold text-xs text-white">{dir}</Text>
+              <Text className="font-poppins-semibold text-xs text-white">
+                {dir}
+              </Text>
             </TouchableOpacity>
           ))}
         </View>
@@ -437,49 +394,57 @@ export default function NotificationTestScreen() {
             opacity: cycloneLoading ? 0.6 : 1,
           }}
         >
-          {cycloneLoading
-            ? <ActivityIndicator size="small" color={colors.brandRed} style={{ marginRight: 12 }} />
-            : <MaterialCommunityIcons name="weather-hurricane" size={22} color={colors.brandRed} style={{ marginRight: 12 }} />}
-          <Text className="font-poppins-semibold text-sm text-white">Inyectar ciclón</Text>
+          {cycloneLoading ? (
+            <ActivityIndicator
+              size="small"
+              color={colors.brandRed}
+              style={{ marginRight: 12 }}
+            />
+          ) : (
+            <MaterialCommunityIcons
+              name="weather-hurricane"
+              size={22}
+              color={colors.brandRed}
+              style={{ marginRight: 12 }}
+            />
+          )}
+          <Text className="font-poppins-semibold text-sm text-white">
+            Inyectar ciclón
+          </Text>
         </TouchableOpacity>
 
         {/* Reset estado SIAT */}
         <TouchableOpacity
           onPress={resetSiatState}
           disabled={resetLoading}
-          className="flex-row items-center mb-4 rounded-2xl px-5 py-4"
-          style={{ backgroundColor: 'rgba(255,255,255,0.06)', borderWidth: 1, borderColor: 'rgba(255,255,255,0.2)' }}
-        >
-          {resetLoading
-            ? <ActivityIndicator size="small" color="white" style={{ marginRight: 12 }} />
-            : <MaterialCommunityIcons name="refresh" size={22} color="white" style={{ marginRight: 12 }} />}
-          <View className="flex-1">
-            <Text className="font-poppins-semibold text-sm text-white">Limpiar estado SIAT</Text>
-            <Text className="font-poppins text-xs text-white/50">Permite volver a disparar escalación desde el mismo nivel</Text>
-          </View>
-        </TouchableOpacity>
-
-        {/* Sección: alerta SMN nacional */}
-        <Text className="text-base font-poppins-semibold text-white mt-4 mb-1">
-          Ruta SMN/CONAGUA
-        </Text>
-        <Text className="text-xs font-poppins text-white/50 mb-4">
-          Inyecta una alerta nacional (sin coords) y la procesa vía geocercado.{'\n'}
-          Nivel 3 — AMARILLO por defecto. Llega a todos los usuarios elegibles.
-        </Text>
-
-        <TouchableOpacity
-          onPress={injectSmnAlert}
-          disabled={smnLoading}
           className="flex-row items-center mb-8 rounded-2xl px-5 py-4"
-          style={{ backgroundColor: `${colors.brandYellow}22`, borderWidth: 1, borderColor: colors.brandYellow }}
+          style={{
+            backgroundColor: "rgba(255,255,255,0.06)",
+            borderWidth: 1,
+            borderColor: "rgba(255,255,255,0.2)",
+          }}
         >
-          {smnLoading
-            ? <ActivityIndicator size="small" color={colors.brandYellow} style={{ marginRight: 12 }} />
-            : <MaterialCommunityIcons name="weather-cloudy-alert" size={22} color={colors.brandYellow} style={{ marginRight: 12 }} />}
+          {resetLoading ? (
+            <ActivityIndicator
+              size="small"
+              color="white"
+              style={{ marginRight: 12 }}
+            />
+          ) : (
+            <MaterialCommunityIcons
+              name="refresh"
+              size={22}
+              color="white"
+              style={{ marginRight: 12 }}
+            />
+          )}
           <View className="flex-1">
-            <Text className="font-poppins-semibold text-sm text-white">Alerta SMN Nacional — Amarillo</Text>
-            <Text className="font-poppins text-xs text-white/50">Nivel 3 · Sin geocoordenadas · Todos los usuarios</Text>
+            <Text className="font-poppins-semibold text-sm text-white">
+              Limpiar estado SIAT
+            </Text>
+            <Text className="font-poppins text-xs text-white/50">
+              Permite volver a disparar escalación desde el mismo nivel
+            </Text>
           </View>
         </TouchableOpacity>
       </ScrollView>

--- a/frontend/app/alerts/[id].tsx
+++ b/frontend/app/alerts/[id].tsx
@@ -197,7 +197,7 @@ export default function AlertDetailsScreen() {
               {impactLabel.toUpperCase()}
             </Text>
             <Text style={{ color: 'white', fontFamily: fonts.poppinsSemiBold, fontSize: 15 }}>
-              Categoría {alert.level}
+              Nivel {alert.level}
             </Text>
           </LinearGradient>
 

--- a/frontend/app/alerts/_components/CycloneAdvisoryCard.tsx
+++ b/frontend/app/alerts/_components/CycloneAdvisoryCard.tsx
@@ -1,0 +1,231 @@
+import { View, Text, TouchableOpacity, Linking } from "react-native";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { track } from "../../../utils/analytics";
+import { fonts } from "../../../utils/theme";
+import { colorForLevel, labelForLevel } from "./AlertCard";
+import type { SMNCycloneAdvisory } from "../_types";
+
+const OCEAN_LABEL: Record<string, string> = {
+  atlantico: "Océano Atlántico",
+  pacifico: "Océano Pacífico",
+};
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={{ marginRight: 20, marginBottom: 8 }}>
+      <Text
+        style={{
+          color: "rgba(255,255,255,0.5)",
+          fontFamily: fonts.poppins,
+          fontSize: 11,
+          textTransform: "uppercase",
+        }}
+      >
+        {label}
+      </Text>
+      <Text
+        style={{
+          color: "white",
+          fontFamily: fonts.poppinsSemiBold,
+          fontSize: 15,
+        }}
+      >
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+export default function CycloneAdvisoryCard({
+  advisory,
+}: {
+  advisory: SMNCycloneAdvisory;
+}) {
+  const baseColor = colorForLevel(advisory.level);
+  const oceanLabel = advisory.ocean
+    ? (OCEAN_LABEL[advisory.ocean] ?? advisory.ocean)
+    : "SMN";
+
+  const handleOpenPdf = async () => {
+    if (!advisory.pdf_url) return;
+    track("cyclone_advisory_pdf_tap", {
+      system: advisory.system_name ?? "unknown",
+      ocean: advisory.ocean ?? "unknown",
+    });
+    try {
+      const canOpen = await Linking.canOpenURL(advisory.pdf_url);
+      if (canOpen) await Linking.openURL(advisory.pdf_url);
+    } catch (err) {
+      console.error("[CycloneAdvisoryCard] openURL error:", err);
+    }
+  };
+
+  return (
+    <View
+      style={{
+        backgroundColor: "rgba(10, 28, 50, 0.6)",
+        borderRadius: 16,
+        borderWidth: 1,
+        borderColor: `${baseColor}55`,
+        padding: 16,
+        marginBottom: 12,
+      }}
+    >
+      {/* Header */}
+      <View className="flex-row items-center justify-between mb-2">
+        <View className="flex-row items-center flex-1">
+          <MaterialCommunityIcons
+            name="weather-hurricane"
+            size={28}
+            color={baseColor}
+          />
+          <View style={{ marginLeft: 10, flex: 1 }}>
+            <Text
+              style={{
+                color: "rgba(255,255,255,0.5)",
+                fontFamily: fonts.poppins,
+                fontSize: 11,
+                letterSpacing: 1,
+                textTransform: "uppercase",
+              }}
+            >
+              {oceanLabel}
+              {advisory.aviso_num ? ` · Aviso #${advisory.aviso_num}` : ""}
+            </Text>
+            <Text
+              style={{
+                color: "white",
+                fontFamily: fonts.poppinsSemiBold,
+                fontSize: 17,
+              }}
+            >
+              {advisory.system_name ?? "Sistema ciclónico"}
+            </Text>
+          </View>
+        </View>
+        <View
+          style={{
+            backgroundColor: baseColor,
+            borderRadius: 999,
+            paddingHorizontal: 10,
+            paddingVertical: 4,
+          }}
+        >
+          <Text
+            style={{
+              color: "white",
+              fontFamily: fonts.poppinsSemiBold,
+              fontSize: 11,
+            }}
+          >
+            {labelForLevel(advisory.level)}
+          </Text>
+        </View>
+      </View>
+
+      {/* Síntesis oficial */}
+      {advisory.synthesis && (
+        <Text
+          style={{
+            color: "rgba(255,255,255,0.85)",
+            fontFamily: fonts.poppins,
+            fontSize: 14,
+            lineHeight: 20,
+            marginBottom: 10,
+          }}
+        >
+          {advisory.synthesis}
+        </Text>
+      )}
+
+      {/* Stats */}
+      <View className="flex-row flex-wrap">
+        {advisory.location_text && (
+          <Stat label="Distancia" value={advisory.location_text} />
+        )}
+        {advisory.wind_sustained_kmh != null && (
+          <Stat
+            label="Viento sostenido"
+            value={`${advisory.wind_sustained_kmh} km/h`}
+          />
+        )}
+        {advisory.wind_gusts_kmh != null && (
+          <Stat label="Rachas" value={`${advisory.wind_gusts_kmh} km/h`} />
+        )}
+        {advisory.pressure_hpa != null && (
+          <Stat label="Presión" value={`${advisory.pressure_hpa} hPa`} />
+        )}
+      </View>
+      {advisory.movement_text && (
+        <Text
+          style={{
+            color: "rgba(255,255,255,0.6)",
+            fontFamily: fonts.poppins,
+            fontSize: 13,
+            marginBottom: 10,
+          }}
+        >
+          Desplazamiento: {advisory.movement_text}
+        </Text>
+      )}
+
+      {/* Recomendaciones oficiales */}
+      {advisory.recommendations && (
+        <View
+          style={{
+            backgroundColor: "rgba(255,255,255,0.06)",
+            borderRadius: 10,
+            padding: 10,
+            marginBottom: advisory.pdf_url ? 10 : 0,
+          }}
+        >
+          <Text
+            style={{
+              color: "rgba(255,255,255,0.5)",
+              fontFamily: fonts.poppins,
+              fontSize: 11,
+              textTransform: "uppercase",
+              marginBottom: 4,
+            }}
+          >
+            Recomendaciones oficiales
+          </Text>
+          <Text
+            style={{
+              color: "white",
+              fontFamily: fonts.poppins,
+              fontSize: 13,
+              lineHeight: 19,
+            }}
+          >
+            {advisory.recommendations}
+          </Text>
+        </View>
+      )}
+
+      {advisory.pdf_url && (
+        <TouchableOpacity
+          onPress={handleOpenPdf}
+          activeOpacity={0.7}
+          className="flex-row items-center"
+        >
+          <MaterialCommunityIcons
+            name="file-pdf-box"
+            size={18}
+            color={baseColor}
+          />
+          <Text
+            style={{
+              color: baseColor,
+              fontFamily: fonts.poppinsSemiBold,
+              fontSize: 13,
+              marginLeft: 6,
+            }}
+          >
+            Ver aviso oficial (PDF)
+          </Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}

--- a/frontend/app/alerts/_hooks/useCycloneAdvisories.ts
+++ b/frontend/app/alerts/_hooks/useCycloneAdvisories.ts
@@ -1,0 +1,35 @@
+import useSWR from "swr";
+import { authFetch } from "../../../utils/api";
+import { useAuth } from "../../../features/auth/AuthContext";
+import { API_BASE_URL } from "../../../utils/config";
+import type { SMNCycloneAdvisory } from "../_types";
+
+const fetcher = async (): Promise<SMNCycloneAdvisory[]> => {
+  const url = `${API_BASE_URL}/api/v1/alerts/active`;
+  const res = await authFetch(url);
+  if (!res.ok) {
+    const body = await res.text();
+    console.error(
+      `[CycloneAdvisories] HTTP ${res.status} | url: ${url} | body: ${body}`,
+    );
+    throw new Error(`HTTP ${res.status}`);
+  }
+  const data = await res.json();
+  return data.smn_cyclone_advisories ?? [];
+};
+
+/**
+ * Structured SMN cyclone advisories (Atlántico/Pacífico) from /alerts/active.
+ * Separate from useAlerts (which lists the flat /alerts history) — this is
+ * specifically the dedicated section for official SMN cyclone data.
+ */
+export default function useCycloneAdvisories() {
+  const { user } = useAuth();
+  const { data, error, isLoading } = useSWR<SMNCycloneAdvisory[]>(
+    user ? "cyclone-advisories" : null,
+    fetcher,
+    { refreshInterval: 60000 },
+  );
+
+  return { data, error, isLoading };
+}

--- a/frontend/app/alerts/_types.ts
+++ b/frontend/app/alerts/_types.ts
@@ -16,3 +16,21 @@ export interface Alert {
 export interface AlertsByYear {
   [year: number]: Alert[];
 }
+
+export interface SMNCycloneAdvisory {
+  ocean: "atlantico" | "pacifico" | null;
+  system_name: string | null;
+  aviso_num: number | null;
+  level: number;
+  synthesis: string | null;
+  location_text: string | null;
+  lat: number | null;
+  lon: number | null;
+  movement_text: string | null;
+  wind_sustained_kmh: number | null;
+  wind_gusts_kmh: number | null;
+  pressure_hpa: number | null;
+  recommendations: string | null;
+  pdf_url: string | null;
+  issued_at: string;
+}

--- a/frontend/app/alerts/index.tsx
+++ b/frontend/app/alerts/index.tsx
@@ -1,15 +1,23 @@
-import { View, Text, FlatList, ActivityIndicator, Pressable } from "react-native";
+import {
+  View,
+  Text,
+  FlatList,
+  ActivityIndicator,
+  Pressable,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import useAlerts from "./_hooks/useAlerts";
+import useCycloneAdvisories from "./_hooks/useCycloneAdvisories";
 import AlertCard from "./_components/AlertCard";
-import { colors } from '../../utils/theme';
-
+import CycloneAdvisoryCard from "./_components/CycloneAdvisoryCard";
+import { colors } from "../../utils/theme";
 
 export default function AlertsListScreen() {
   const router = useRouter();
   const { data, error, isLoading } = useAlerts();
+  const { data: cycloneAdvisories } = useCycloneAdvisories();
 
   if (isLoading) {
     return (
@@ -22,12 +30,17 @@ export default function AlertsListScreen() {
   if (error) {
     return (
       <View className="flex-1 justify-center items-center bg-transparent">
-        <Text className="text-red-500">Error al cargar alertas, verifica tu conexión a internet</Text>
+        <Text className="text-red-500">
+          Error al cargar alertas, verifica tu conexión a internet
+        </Text>
       </View>
     );
   }
 
-  if (!data || data.length === 0) {
+  const hasCycloneAdvisories =
+    !!cycloneAdvisories && cycloneAdvisories.length > 0;
+
+  if ((!data || data.length === 0) && !hasCycloneAdvisories) {
     return (
       <View className="flex-1 justify-center items-center bg-transparent">
         <Text className="text-white">No hay alertas</Text>
@@ -53,19 +66,54 @@ export default function AlertsListScreen() {
             size={20}
             color="#ffff"
           />
-          <Text className="ml-2 text-sm font-poppins-semibold text-white">Por año</Text>
+          <Text className="ml-2 text-sm font-poppins-semibold text-white">
+            Por año
+          </Text>
         </Pressable>
       </View>
 
       <FlatList
         contentContainerStyle={{ padding: 12 }}
-        data={data}
+        data={data ?? []}
         keyExtractor={(item) => item.id.toString()}
+        ListHeaderComponent={
+          hasCycloneAdvisories ? (
+            <View style={{ marginBottom: 8 }}>
+              <Text
+                className="text-xs font-poppins-semibold text-white/60 mb-2"
+                style={{ letterSpacing: 1, textTransform: "uppercase" }}
+              >
+                Avisos de ciclón tropical · SMN
+              </Text>
+              {cycloneAdvisories!.map((advisory, i) => (
+                <CycloneAdvisoryCard
+                  key={`${advisory.ocean}-${advisory.system_name}-${i}`}
+                  advisory={advisory}
+                />
+              ))}
+              {data && data.length > 0 && (
+                <Text
+                  className="text-xs font-poppins-semibold text-white/60 mt-2 mb-2"
+                  style={{ letterSpacing: 1, textTransform: "uppercase" }}
+                >
+                  Historial
+                </Text>
+              )}
+            </View>
+          ) : null
+        }
         renderItem={({ item }) => (
           <AlertCard
             alert={item}
             onPress={() => {
-              console.log('[QA_ALERTS] list tap | id:', item.id, '| level:', item.level, '| title:', item.title);
+              console.log(
+                "[QA_ALERTS] list tap | id:",
+                item.id,
+                "| level:",
+                item.level,
+                "| title:",
+                item.title,
+              );
               router.push({
                 pathname: "/alerts/[id]",
                 params: { id: item.id },

--- a/frontend/app/map/index.tsx
+++ b/frontend/app/map/index.tsx
@@ -219,18 +219,30 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
     }, [])
   );
 
-  // Al volver al foco: refrescar tormentas activas (reales + de prueba) desde la DB,
-  // así una tormenta inyectada sigue apareciendo después de recargar la app.
+  // Refresca tormentas activas (reales + de prueba) al llegar al foco, y luego
+  // cada 60s mientras la pantalla siga enfocada — sin esto, un ciclón que se
+  // actualiza (o se corrige tras un glitch del feed del NHC) no se refleja
+  // hasta que el usuario cierre y reabra la app.
   useFocusEffect(
     useCallback(() => {
-      (async () => {
+      let isActive = true;
+
+      const fetchCyclones = async () => {
         try {
           const cyclones = await loadActiveCyclones();
-          setActiveCyclones(cyclones);
+          if (isActive) setActiveCyclones(cyclones);
         } catch (error) {
           console.warn('[Map] Failed to load active cyclones:', error);
         }
-      })();
+      };
+
+      fetchCyclones();
+      const interval = setInterval(fetchCyclones, 60000);
+
+      return () => {
+        isActive = false;
+        clearInterval(interval);
+      };
     }, [])
   );
 
@@ -255,6 +267,22 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
       longitudeDelta: 3,
     }, 800);
   }, [focusLat, focusLon]);
+
+  // Active cyclones are real ocean-going storms — usually far outside the
+  // tight zoom the map defaults to around the user's own location, so without
+  // this they're effectively invisible even though they're plotted correctly.
+  const focusActiveCyclones = () => {
+    if (activeCyclones.length === 0) {
+      toast('Sin ciclones activos', { description: 'No hay huracanes o tormentas tropicales activos en este momento.' });
+      return;
+    }
+    const coordinates = activeCyclones.map(c => ({ latitude: c.latitude, longitude: c.longitude }));
+    if (userLocation) coordinates.push(userLocation);
+    mapRef.current?.fitToCoordinates(coordinates, {
+      edgePadding: { top: 80, right: 60, bottom: 120, left: 60 },
+      animated: true,
+    });
+  };
 
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout>;
@@ -837,6 +865,36 @@ export default function WeatherMapNativewind({ focusLat, focusLon, focusTitle, f
         }}
       >
         <MaterialCommunityIcons name="navigation-variant" size={24} color="#FFFFFF" />
+      </Pressable>
+
+      {/* Ver ciclones activos — reales (Fausto/Genevieve, etc.) suelen estar muy
+          mar adentro, fuera del zoom por default; esto centra la cámara en ellos. */}
+      <Pressable
+        onPress={focusActiveCyclones}
+        style={{
+          position: 'absolute',
+          bottom: 168,
+          right: 16,
+          width: 48,
+          height: 48,
+          borderRadius: 14,
+          backgroundColor: 'rgba(8, 15, 30, 0.85)',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <MaterialCommunityIcons name="weather-hurricane" size={24} color="#FFFFFF" />
+        {activeCyclones.length > 0 && (
+          <View style={{
+            position: 'absolute', top: -6, right: -6, minWidth: 18, height: 18, borderRadius: 9,
+            backgroundColor: colors.brandRed, alignItems: 'center', justifyContent: 'center',
+            paddingHorizontal: 4, borderWidth: 1.5, borderColor: '#fff',
+          }}>
+            <Text style={{ color: '#fff', fontSize: 10, fontFamily: fonts.poppinsSemiBold }}>
+              {activeCyclones.length}
+            </Text>
+          </View>
+        )}
       </Pressable>
 
       {/* SOS FAB */}


### PR DESCRIPTION
## Summary
- **feat(alerts):** scrapes the SMN "Aviso de Ciclón Tropical" pages (Atlántico/Pacífico) and surfaces them as a dedicated, structured section on `/api/v1/alerts/active` and in the Alertas screen, alongside the existing SIAT-CT / SMN bulletin sources.
- **fix(siat):** the NHC feed's `latitudeNumeric`/`longitudeNumeric` use camelCase (not the PDF's documented snake_case), which silently defaulted every real cyclone's position to (0, 0) — making it look ~10,000 km from any Mexican user and never getting evaluated for risk. Also guards against the field being present-but-transiently-zeroed (observed live).
- **fix(siat):** `run_cycle` persisted `current_level` per-cyclone inside the evaluation loop, so a user's stored risk level reflected whichever cyclone was evaluated *last* that cycle instead of the most severe one. Now the max-level assessment is tracked and persisted once per user.
- **fix(siat):** a cyclone escalation alert was left un-notified in the DB, so the generic SMN/geofenced push path picked it up again in the same cycle and fired a duplicate notification for one escalation.
- **fix(alerts):** the alert detail screen and full-screen alarm both mislabeled the SIAT risk level (1-5, Azul→Rojo) as a hurricane "Categoría", conflating it with the unrelated Saffir-Simpson wind scale.
- **feat(map):** new button centers the map on all active cyclones (previously plotted correctly but invisible — off the default tight zoom around the user's own location); the active-cyclone list now also auto-refreshes every 60s.
- **chore:** trimmed `Dev: Notificaciones` down to just the cyclone injector + state reset, removing the generic test-push buttons the team wasn't using.

## Test plan
- [x] `pytest` — 225/225 passing
- [x] Verified live against the real NHC + SMN feeds during development (not just mocks)
- [x] Verified on 2 physical Android devices: SMN cyclone cards render, map button centers correctly, multi-user push (inject from one device → both receive it), "Nivel N" label fix, trimmed dev-tools screen